### PR TITLE
fix(network): bind postgres to localhost by default

### DIFF
--- a/src/commands/branch/create.ts
+++ b/src/commands/branch/create.ts
@@ -5,7 +5,7 @@ import { parseNamespace, getMainBranch } from '../../utils/namespace';
 import { parseRecoveryTime, formatDate } from '../../utils/time';
 import { UserError } from '../../errors';
 import { getBranchContainerName, getContainerName, getDatasetName, getDatasetPathFromName } from '../../utils/naming';
-import { getPublicIP, formatConnectionString } from '../../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../../utils/network';
 import { initializeServices, getBranchWithProject } from '../../utils/service-factory';
 import { selectSnapshotForPITR } from '../../services/pitr-service';
 import { createApplicationConsistentSnapshot } from '../../services/snapshot-service';
@@ -14,6 +14,7 @@ import { OperationRunner } from '../../utils/operation-runner';
 export interface BranchCreateOptions {
   parent?: string;
   pitr?: string;  // Point-in-time recovery target
+  public?: boolean;
 }
 
 export async function branchCreateCommand(targetName: string, options: BranchCreateOptions = {}) {
@@ -75,6 +76,7 @@ export async function branchCreateCommand(targetName: string, options: BranchCre
   let mountpoint: string;
   let port = 0;
   let containerID: string | undefined;
+  let branch: Branch | null = null;
 
   await operation.run(async function runOperation() {
     if (options.pitr && recoveryTarget) {
@@ -157,6 +159,7 @@ export async function branchCreateCommand(targetName: string, options: BranchCre
         password: sourceProject.credentials.password,
         username: sourceProject.credentials.username,
         database: sourceProject.credentials.database,
+        publicAccess: options.public === true,
       });
 
       operation.addRollback(async function rollbackContainer() {
@@ -174,7 +177,7 @@ export async function branchCreateCommand(targetName: string, options: BranchCre
 
     const sizeBytes = await zfs.getUsedSpace(targetDatasetName);
 
-    const branch: Branch = {
+    branch = {
       id: generateUUID(),
       name: target.full,
       projectName: target.project,
@@ -187,13 +190,17 @@ export async function branchCreateCommand(targetName: string, options: BranchCre
       createdAt: new Date().toISOString(),
       sizeBytes,
       status: 'running',
+      publicAccess: options.public === true,
     };
 
     await state.branches.add(sourceProject.id, branch);
   });
 
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  if (!branch) {
+    throw new UserError('Branch state was not created');
+  }
+
+  const publicIP = await getPublicIPForBranch(branch);
 
   console.log();
   console.log(chalk.bold(`Branch '${target.full}' created`));

--- a/src/commands/branch/get.ts
+++ b/src/commands/branch/get.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { formatBytes } from '../../utils/helpers';
 import { parseNamespace } from '../../utils/namespace';
 import { UserError } from '../../errors';
-import { getPublicIP, formatConnectionString } from '../../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../../utils/network';
 import { CLI_NAME } from '../../config/constants';
 import { initializeServices } from '../../utils/service-factory';
 import { getBranchHealth } from '../../services/branch-health-service';
@@ -51,8 +51,7 @@ export async function branchGetCommand(name: string) {
     const snapshotShortName = branch.snapshotName.split('@')[1];
     console.log(chalk.dim('  Snapshot     '), snapshotShortName);
   }
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  const publicIP = await getPublicIPForBranch(branch);
 
   console.log();
   console.log(chalk.bold('Connection:'));

--- a/src/commands/branch/password.ts
+++ b/src/commands/branch/password.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { parseNamespace } from '../../utils/namespace';
 import { UserError } from '../../errors';
-import { getPublicIP, formatConnectionString } from '../../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../../utils/network';
 import { CLI_NAME } from '../../config/constants';
 import { initializeServices } from '../../utils/service-factory';
 
@@ -20,8 +20,7 @@ export async function branchPasswordCommand(name: string) {
 
   const { branch, project } = result;
 
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  const publicIP = await getPublicIPForBranch(branch);
 
   console.log();
   console.log(chalk.bold(`Connection details for ${name}`));

--- a/src/commands/branch/reset.ts
+++ b/src/commands/branch/reset.ts
@@ -3,7 +3,7 @@ import { createApplicationConsistentSnapshot } from '../../services/snapshot-ser
 import { getBranchContainerName, getDatasetPathFromName } from '../../utils/naming';
 import { UserError } from '../../errors';
 import { withProgress } from '../../utils/progress';
-import { getPublicIP, formatConnectionString } from '../../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../../utils/network';
 import { CLI_NAME } from '../../config/constants';
 import { initializeServices, getBranchWithProject } from '../../utils/service-factory';
 import { OperationRunner } from '../../utils/operation-runner';
@@ -113,6 +113,7 @@ export async function branchResetCommand(name: string, options: { force?: boolea
         password: project.credentials.password,
         username: project.credentials.username,
         database: project.credentials.database,
+        publicAccess: originalBranch.publicAccess === true,
       });
 
       await docker.startContainer(id);
@@ -163,6 +164,7 @@ export async function branchResetCommand(name: string, options: { force?: boolea
         password: project.credentials.password,
         username: project.credentials.username,
         database: project.credentials.database,
+        publicAccess: branch.publicAccess === true,
       });
 
       operation.addRollback(async function rollbackNewContainer() {
@@ -202,8 +204,7 @@ export async function branchResetCommand(name: string, options: { force?: boolea
     await resources.destroyDataset(backupDatasetName).catch(function ignoreError() {});
   });
 
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  const publicIP = await getPublicIPForBranch(branch);
 
   console.log();
   console.log(chalk.bold('Branch reset'));

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -16,7 +16,7 @@ import { UserError } from '../../errors';
 import { withProgress } from '../../utils/progress';
 import * as fs from 'fs/promises';
 import { getContainerName, getDatasetName } from '../../utils/naming';
-import { getPublicIP, formatConnectionString } from '../../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../../utils/network';
 import { ResourceService } from '../../services/resource-service';
 import { OperationRunner } from '../../utils/operation-runner';
 
@@ -24,6 +24,7 @@ interface CreateOptions {
   pool?: string;
   version?: string;
   image?: string;
+  public?: boolean;
 }
 
 export async function projectCreateCommand(name: string, options: CreateOptions = {}) {
@@ -118,6 +119,7 @@ export async function projectCreateCommand(name: string, options: CreateOptions 
   let certPaths: { certDir: string };
   let containerID: string;
   let sizeBytes: number;
+  let mainBranch: Branch | null = null;
 
   await operation.run(async function runOperation() {
     await operation.step(`Create dataset ${mainBranchName}`, async function createDataset() {
@@ -174,6 +176,7 @@ export async function projectCreateCommand(name: string, options: CreateOptions 
         password,
         username: 'postgres',
         database: 'postgres',
+        publicAccess: options.public === true,
       });
 
       operation.addRollback(async function rollbackContainer() {
@@ -193,7 +196,7 @@ export async function projectCreateCommand(name: string, options: CreateOptions 
     sizeBytes = await zfs.getUsedSpace(mainDatasetName);
 
     // Create main branch
-    const mainBranch: Branch = {
+    mainBranch = {
       id: generateUUID(),
       name: mainBranchName,
       projectName: name,
@@ -206,6 +209,7 @@ export async function projectCreateCommand(name: string, options: CreateOptions 
       createdAt: new Date().toISOString(),
       sizeBytes,
       status: 'running',
+      publicAccess: options.public === true,
     };
 
     // Create project record with main branch
@@ -226,8 +230,11 @@ export async function projectCreateCommand(name: string, options: CreateOptions 
     await state.projects.add(project);
   });
 
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  if (!mainBranch) {
+    throw new UserError('Project branch state was not created');
+  }
+
+  const publicIP = await getPublicIPForBranch(mainBranch);
 
   console.log();
   console.log(chalk.bold(`Project '${name}' created`));

--- a/src/commands/restart.ts
+++ b/src/commands/restart.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { getBranchContainerName } from '../utils/naming';
 import { UserError } from '../errors';
 import { withProgress } from '../utils/progress';
-import { getPublicIP, formatConnectionString } from '../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../utils/network';
 import { CLI_NAME } from '../config/constants';
 import { initializeServices } from '../utils/service-factory';
 
@@ -50,8 +50,7 @@ export async function restartCommand(name: string) {
   }
   await state.branches.update(project.id, branch);
 
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  const publicIP = await getPublicIPForBranch(branch);
 
   console.log();
   console.log(chalk.bold('Branch restarted'));

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { getBranchContainerName } from '../utils/naming';
 import { UserError } from '../errors';
 import { withProgress } from '../utils/progress';
-import { getPublicIP, formatConnectionString } from '../utils/network';
+import { getPublicIPForBranch, formatConnectionString } from '../utils/network';
 import { CLI_NAME } from '../config/constants';
 import { initializeServices } from '../utils/service-factory';
 
@@ -58,8 +58,7 @@ export async function startCommand(name: string) {
   }
   await state.branches.update(project.id, branch);
 
-  // Get public IP for remote connection info
-  const publicIP = await getPublicIP();
+  const publicIP = await getPublicIPForBranch(branch);
 
   console.log();
   console.log(chalk.bold('Branch started'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,11 @@ projectCommand
   .option('--pool <name>', 'ZFS pool to use (auto-detected if not specified)')
   .option('--pg-version <version>', 'PostgreSQL version (e.g., 17, 16)')
   .option('--image <image>', 'Custom Docker image (e.g., ankane/pgvector:17)')
-  .action(wrapCommand(async (name: string, options: { pool?: string; pgVersion?: string; image?: string }) => {
+  .option('--public', 'bind PostgreSQL to all host interfaces')
+  .action(wrapCommand(async function createProjectAction(
+    name: string,
+    options: { pool?: string; pgVersion?: string; image?: string; public?: boolean }
+  ) {
     // Map pgVersion to version for backwards compat
     const opts = { ...options, version: options.pgVersion };
     await projectCreateCommand(name, opts);
@@ -113,7 +117,11 @@ branchCommand
   .argument('<name>', 'branch name in format: <project>/<branch>')
   .option('--parent <parent>', 'parent branch (defaults to <project>/main)')
   .option('--pitr <time>', 'recover to point in time (e.g., "2025-10-07T14:30:00Z", "2 hours ago")')
-  .action(wrapCommand(async (name: string, options: { parent?: string; pitr?: string }) => {
+  .option('--public', 'bind PostgreSQL to all host interfaces')
+  .action(wrapCommand(async function createBranchAction(
+    name: string,
+    options: { parent?: string; pitr?: string; public?: boolean }
+  ) {
     await branchCreateCommand(name, options);
   }));
 

--- a/src/managers/docker.test.ts
+++ b/src/managers/docker.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import { getPostgresHostIp } from './docker';
+
+describe('DockerManager PostgreSQL host binding', function () {
+  test('binds PostgreSQL to localhost by default', function () {
+    expect(getPostgresHostIp({})).toBe('127.0.0.1');
+  });
+
+  test('binds PostgreSQL to all interfaces when public access is explicit', function () {
+    expect(getPostgresHostIp({ publicAccess: true })).toBe('0.0.0.0');
+  });
+});

--- a/src/managers/docker.ts
+++ b/src/managers/docker.ts
@@ -12,6 +12,7 @@ export interface PostgresConfig {
   password: string;
   username: string;
   database: string;
+  publicAccess?: boolean;
 }
 
 export interface ContainerStatus {
@@ -63,10 +64,9 @@ export class DockerManager {
       },
       HostConfig: {
         PortBindings: {
-          // Bind to all interfaces (0.0.0.0) to make databases publicly accessible
           // Use port 0 to let Docker assign an available port, or use specific port if provided
           '5432/tcp': [{
-            HostIp: '0.0.0.0',
+            HostIp: getPostgresHostIp(config),
             HostPort: config.port === 0 ? '' : config.port.toString()
           }],
         },
@@ -305,4 +305,12 @@ export class DockerManager {
       throw error;
     }
   }
+}
+
+export function getPostgresHostIp(config: Pick<PostgresConfig, 'publicAccess'>): string {
+  if (config.publicAccess === true) {
+    return '0.0.0.0';
+  }
+
+  return '127.0.0.1';
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -31,6 +31,7 @@ export interface Branch {
   port: number;
   createdAt: string;
   status: 'running' | 'stopped' | 'created';
+  publicAccess?: boolean;                    // true binds PostgreSQL to all host interfaces
   sizeBytes?: number;                        // Dataset size in bytes (optional, populated on create/reset)
   idleStop?: IdleStopPolicy;
   snapshotPolicy?: SnapshotPolicy;

--- a/src/utils/network.test.ts
+++ b/src/utils/network.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { formatConnectionString } from './network';
+
+describe('connection string formatting', function () {
+  test('does not show a remote URL without public IP', function () {
+    const output = formatConnectionString('postgres', 'secret', 5432, 'postgres', null);
+
+    expect(output).toContain('localhost');
+    expect(output).not.toContain('Remote:');
+  });
+
+  test('shows a remote URL when public IP is provided', function () {
+    const output = formatConnectionString('postgres', 'secret', 5432, 'postgres', '203.0.113.10');
+
+    expect(output).toContain('Local:');
+    expect(output).toContain('Remote:');
+    expect(output).toContain('203.0.113.10');
+  });
+});

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,4 +1,4 @@
-import { $ } from 'bun';
+import type { Branch } from '../types/state';
 
 // Cache public IP for the session to avoid repeated network lookups
 let cachedPublicIP: string | null | undefined = undefined;
@@ -52,6 +52,14 @@ export async function getPublicIP(): Promise<string | null> {
     cachedPublicIP = null;
     return null;
   }
+}
+
+export async function getPublicIPForBranch(branch: Branch): Promise<string | null> {
+  if (branch.publicAccess !== true) {
+    return null;
+  }
+
+  return await getPublicIP();
 }
 
 /**


### PR DESCRIPTION
## Summary
- bind PostgreSQL containers to 127.0.0.1 by default
- add explicit --public mode for project and branch creation
- suppress public-IP URLs unless branch public access is enabled
- add tests for default and explicit public HostIp behavior

Closes #45

## Checks
- bun test src
- bun run typecheck
- bun run build
- git diff --check