### PR TITLE
fix(wal): make archive command idempotent

### DIFF
--- a/src/managers/docker.test.ts
+++ b/src/managers/docker.test.ts
@@ -1,5 +1,36 @@
-import { describe, expect, test } from 'bun:test';
-import { getPostgresHostIp } from './docker';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildPostgresArchiveCommand, getPostgresHostIp } from './docker';
+
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'velo-wal-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function commandFor(command: string, sourcePath: string, fileName: string): string {
+  return command.replaceAll('%p', sourcePath).replaceAll('%f', fileName);
+}
+
+async function runArchiveCommand(command: string): Promise<number> {
+  const proc = Bun.spawn(['sh', '-c', command], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  await proc.exited;
+  return proc.exitCode ?? 1;
+}
+
+afterEach(async function cleanup() {
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
 describe('DockerManager PostgreSQL host binding', function () {
   test('binds PostgreSQL to localhost by default', function () {
@@ -8,5 +39,60 @@ describe('DockerManager PostgreSQL host binding', function () {
 
   test('binds PostgreSQL to all interfaces when public access is explicit', function () {
     expect(getPostgresHostIp({ publicAccess: true })).toBe('0.0.0.0');
+  });
+});
+
+describe('buildPostgresArchiveCommand', function () {
+  test('archives a WAL file the first time', async function () {
+    const dir = await createTempDir();
+    const sourcePath = join(dir, 'pg-wal');
+    const archiveDir = join(dir, 'archive');
+    const fileName = '000000010000000000000001';
+    await writeFile(sourcePath, 'wal-data');
+    await Bun.$`mkdir ${archiveDir}`.quiet();
+
+    const command = commandFor(
+      buildPostgresArchiveCommand(archiveDir),
+      sourcePath,
+      fileName
+    );
+
+    expect(await runArchiveCommand(command)).toBe(0);
+    expect(await Bun.file(join(archiveDir, fileName)).text()).toBe('wal-data');
+  });
+
+  test('treats duplicate identical WAL files as success', async function () {
+    const dir = await createTempDir();
+    const sourcePath = join(dir, 'pg-wal');
+    const archiveDir = join(dir, 'archive');
+    const fileName = '000000010000000000000001';
+    await Bun.$`mkdir ${archiveDir}`.quiet();
+    await writeFile(sourcePath, 'wal-data');
+    await writeFile(join(archiveDir, fileName), 'wal-data');
+
+    const command = commandFor(
+      buildPostgresArchiveCommand(archiveDir),
+      sourcePath,
+      fileName
+    );
+
+    expect(await runArchiveCommand(command)).toBe(0);
+  });
+
+  test('fails when the WAL file cannot be copied', async function () {
+    const dir = await createTempDir();
+    const sourcePath = join(dir, 'pg-wal');
+    const archivePath = join(dir, 'archive-file');
+    const fileName = '000000010000000000000001';
+    await writeFile(sourcePath, 'wal-data');
+    await writeFile(archivePath, 'not-a-directory');
+
+    const command = commandFor(
+      buildPostgresArchiveCommand(archivePath),
+      sourcePath,
+      fileName
+    );
+
+    expect(await runArchiveCommand(command)).not.toBe(0);
   });
 });

--- a/src/managers/docker.ts
+++ b/src/managers/docker.ts
@@ -27,6 +27,10 @@ export interface DockerManagerOptions {
   socketPath?: string;
 }
 
+export function buildPostgresArchiveCommand(archivePath: string): string {
+  return `if [ ! -f ${archivePath}/%f ]; then cp %p ${archivePath}/%f; else cmp -s %p ${archivePath}/%f; fi`;
+}
+
 export class DockerManager {
   private docker: Dockerode;
 
@@ -51,7 +55,7 @@ export class DockerManager {
         'postgres',
         '-c', 'wal_level=replica',
         '-c', 'archive_mode=on',
-        '-c', "archive_command=test ! -f /wal-archive/%f && cp %p /wal-archive/%f",
+        '-c', `archive_command=${buildPostgresArchiveCommand('/wal-archive')}`,
         '-c', 'max_wal_senders=3',
         '-c', 'wal_keep_size=1GB',
         '-c', 'restore_command=cp /wal-archive/%f %p',


### PR DESCRIPTION
## Summary
- make PostgreSQL archive_command copy on first archive and compare existing WAL files on retry
- add tests for first archive, duplicate identical archive, and copy failure

Fixes #40

## Tests
- bun test src/managers/docker.test.ts
- bun test src/**/*.test.ts
- bun run typecheck
- bun run build

Note: full local ./scripts/test.sh needs sudo password in this environment, so CI will run it.