### PR TITLE
fix(setup): align setup docs and root handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ A **project** is a logical grouping of branches (like a Git repo), and each **br
 **Global commands**:
 - `status` - Show status of all projects and branches
 - `doctor` - Run comprehensive health checks and diagnostics
-- `setup` - One-time setup: grant ZFS permissions and configure Docker (requires sudo)
+- `setup` - One-time setup: grant ZFS permissions and configure Docker (uses sudo internally)
 
 ### Manager Classes
 

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ zpool list  # Check existing pools
 # For testing: sudo truncate -s 10G /tmp/zfs-pool.img && sudo zpool create tank /tmp/zfs-pool.img
 # For production: sudo zpool create tank /dev/sdb
 
-# 2. Run velo setup (grants permissions, configures Docker)
-sudo velo setup
+# 2. Run velo setup (uses sudo internally)
+velo setup
 
 # 3. Log out and log back in (required for group membership to take effect)
 
@@ -253,6 +253,7 @@ velo project create myapp
 **What `velo setup` does:**
 - Auto-detects ZFS pool (or prompts if multiple exist)
 - Grants ZFS delegation permissions (90% of operations run without sudo)
+- Uses sudo internally for setup tasks that need elevated permissions
 - Adds user to docker group
 - Creates `velo` group and adds current user
 - Installs minimal sudoers config for mount/unmount operations only
@@ -270,15 +271,16 @@ velo project create myapp
 
 **Permission setup** (one-time, required before first use):
 ```bash
-sudo velo setup
+velo setup
 ```
 
 The setup command:
 1. Auto-detects ZFS pool (or prompts if multiple exist)
 2. Grants ZFS delegation permissions (90% of operations run without sudo)
-3. Adds user to docker group
-4. Creates `velo` group and adds current user
-5. Installs minimal sudoers config for mount/unmount operations only
+3. Uses sudo internally for setup tasks that need elevated permissions
+4. Adds user to docker group
+5. Creates `velo` group and adds current user
+6. Installs minimal sudoers config for mount/unmount operations only
 
 **Security model:**
 - 90% of ZFS operations use delegation (no sudo)

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { getSetupUser } from './setup';
+
+describe('setup user detection', function () {
+  test('uses regular user', function () {
+    const user = getSetupUser({ USER: 'alice' }, function () {
+      return 1000;
+    });
+
+    expect(user).toBe('alice');
+  });
+
+  test('rejects root user', function () {
+    const user = getSetupUser({ USER: 'root' }, function () {
+      return 0;
+    });
+
+    expect(user).toBeNull();
+  });
+
+  test('rejects sudo even when USER is preserved', function () {
+    const user = getSetupUser({ USER: 'alice', SUDO_USER: 'alice' }, function () {
+      return 0;
+    });
+
+    expect(user).toBeNull();
+  });
+
+  test('rejects missing user', function () {
+    const user = getSetupUser({}, function () {
+      return 1000;
+    });
+
+    expect(user).toBeNull();
+  });
+});

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -8,16 +8,31 @@ import { DEFAULTS } from '../config/defaults';
  * Setup command - grants ZFS permissions and configures Docker access
  * This command runs as a normal user and uses sudo internally for operations that need elevated privileges
  */
-export async function setupCommand() {
-  // Get the current user
-  const actualUser = process.env.USER;
+export function getSetupUser(
+  env: Record<string, string | undefined> = process.env,
+  getuid: (() => number) | undefined = process.getuid,
+) {
+  const effectiveUid = getuid?.();
+  const user = env.USER;
 
-  if (!actualUser || actualUser === 'root') {
+  if (effectiveUid === 0 || !user || user === 'root') {
+    return null;
+  }
+
+  return user;
+}
+
+export async function setupCommand() {
+  const actualUser = getSetupUser();
+
+  if (!actualUser) {
     console.log();
     console.log('✗ Please run this command as a regular user, not as root');
     console.log();
-    console.log('Usage:');
+    console.log('Run:');
     console.log(`  ${CLI_NAME} setup`);
+    console.log();
+    console.log('Setup uses sudo internally when needed.');
     console.log();
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,8 +370,8 @@ program
 
 program
   .command('setup')
-  .description('One-time setup: grant ZFS permissions and configure Docker (requires sudo)')
-  .action(wrapCommand(async () => {
+  .description('One-time setup: grant ZFS permissions and configure Docker (uses sudo internally)')
+  .action(wrapCommand(async function () {
     await setupCommand();
   }));
 


### PR DESCRIPTION
## What changed
- Document `velo setup` without `sudo`.
- Make setup reject effective root, including sudo-preserved `USER`.
- Add unit coverage for regular, root, sudo, and missing-user setup detection.

## Why
README told users to run `sudo velo setup`, but setup is intended to run as a regular user and use sudo internally.

Fixes #41

## Checks
- `bun test src/commands/setup.test.ts`
- `bun run typecheck`
- `bun test src`
