### PR TITLE
fix(state): serialize mutating operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ projectCommand
     // Map pgVersion to version for backwards compat
     const opts = { ...options, version: options.pgVersion };
     await projectCreateCommand(name, opts);
-  }));
+  }, { operationLock: true }));
 
 projectCommand
   .command('list')
@@ -100,7 +100,7 @@ projectCommand
   .option('-f, --force', 'force delete even if branches exist')
   .action(wrapCommand(async (name: string, options: { force?: boolean }) => {
     await projectDeleteCommand(name, options);
-  }));
+  }, { operationLock: true }));
 
 
 // ============================================================================
@@ -123,7 +123,7 @@ branchCommand
     options: { parent?: string; pitr?: string; public?: boolean }
   ) {
     await branchCreateCommand(name, options);
-  }));
+  }, { operationLock: true }));
 
 branchCommand
   .command('list')
@@ -148,7 +148,7 @@ branchCommand
   .option('-f, --force', 'delete branch and all child branches')
   .action(wrapCommand(async (name: string, options: { force?: boolean }) => {
     await branchDeleteCommand(name, options);
-  }));
+  }, { operationLock: true }));
 
 branchCommand
   .command('reset')
@@ -157,7 +157,7 @@ branchCommand
   .option('-f, --force', 'force reset even if dependent branches exist (will destroy them)')
   .action(wrapCommand(async (name: string, options: { force?: boolean }) => {
     await branchResetCommand(name, options);
-  }));
+  }, { operationLock: true }));
 
 branchCommand
   .command('password')
@@ -173,7 +173,7 @@ branchCommand
   .argument('<name>', 'branch name in format: <project>/<branch>')
   .action(wrapCommand(async (name: string) => {
     await startCommand(name);
-  }));
+  }, { operationLock: true }));
 
 branchCommand
   .command('stop')
@@ -181,7 +181,7 @@ branchCommand
   .argument('<name>', 'branch name in format: <project>/<branch>')
   .action(wrapCommand(async (name: string) => {
     await stopCommand(name);
-  }));
+  }, { operationLock: true }));
 
 branchCommand
   .command('restart')
@@ -189,7 +189,7 @@ branchCommand
   .argument('<name>', 'branch name in format: <project>/<branch>')
   .action(wrapCommand(async (name: string) => {
     await restartCommand(name);
-  }));
+  }, { operationLock: true }));
 
 // ============================================================================
 // WAL commands
@@ -218,7 +218,7 @@ walCommand
       days: options.days ? parseInt(options.days, 10) : 7,
       dryRun: options.dryRun,
     });
-  }));
+  }, { operationLock: true }));
 
 // ============================================================================
 // Snapshot commands
@@ -235,7 +235,7 @@ snapshotCommand
   .option('--label <label>', 'optional label for the snapshot')
   .action(wrapCommand(async (branch: string, options: { label?: string }) => {
     await snapshotCreateCommand(branch, options);
-  }));
+  }, { operationLock: true }));
 
 snapshotCommand
   .command('list')
@@ -251,7 +251,7 @@ snapshotCommand
   .argument('<snapshot-id>', 'snapshot ID')
   .action(wrapCommand(async (snapshotId: string) => {
     await snapshotDeleteCommand(snapshotId);
-  }));
+  }, { operationLock: true }));
 
 snapshotCommand
   .command('cleanup')
@@ -266,7 +266,7 @@ snapshotCommand
       dryRun: options.dryRun,
       all: options.all,
     });
-  }));
+  }, { operationLock: true }));
 
 const snapshotScheduleCommand = snapshotCommand
   .command('schedule')
@@ -285,7 +285,7 @@ snapshotScheduleCommand
       retentionDays: parseInt(options.retentionDays, 10),
       walRetentionDays: parseInt(options.walRetentionDays, 10),
     });
-  }));
+  }, { operationLock: true }));
 
 snapshotScheduleCommand
   .command('disable')
@@ -293,7 +293,7 @@ snapshotScheduleCommand
   .argument('<branch>', 'branch name in format: <project>/<branch>')
   .action(wrapCommand(async function (branch: string) {
     await snapshotScheduleDisableCommand(branch);
-  }));
+  }, { operationLock: true }));
 
 snapshotScheduleCommand
   .command('list')
@@ -309,7 +309,7 @@ snapshotScheduleCommand
   .option('--dry-run', 'show what would happen without creating or deleting files')
   .action(wrapCommand(async function (branch: string | undefined, options: { dryRun?: boolean }) {
     await snapshotScheduleRunCommand(branch, options);
-  }));
+  }, { operationLock: true }));
 
 const snapshotScheduleCronCommand = snapshotScheduleCommand
   .command('cron')
@@ -366,7 +366,7 @@ program
   .option('-f, --force', 'skip confirmation prompt')
   .action(wrapCommand(async (options: { dryRun?: boolean; force?: boolean }) => {
     await cleanupCommand(options);
-  }));
+  }, { operationLock: true }));
 
 program
   .command('setup')
@@ -392,7 +392,7 @@ idleStopCommand
     await idleStopEnableCommand(branch, {
       minutes: parseInt(options.minutes, 10),
     });
-  }));
+  }, { operationLock: true }));
 
 idleStopCommand
   .command('disable')
@@ -400,7 +400,7 @@ idleStopCommand
   .argument('<branch>', 'branch name in format: <project>/<branch>')
   .action(wrapCommand(async (branch: string) => {
     await idleStopDisableCommand(branch);
-  }));
+  }, { operationLock: true }));
 
 idleStopCommand
   .command('list')
@@ -416,7 +416,7 @@ idleStopCommand
   .option('--dry-run', 'show what would happen without stopping branches')
   .action(wrapCommand(async (branch: string | undefined, options: { dryRun?: boolean }) => {
     await idleStopRunCommand(branch, options);
-  }));
+  }, { operationLock: true }));
 
 // ============================================================================
 // State commands
@@ -438,6 +438,6 @@ stateCommand
   .description('Restore state from backup')
   .action(wrapCommand(async () => {
     await stateRestoreCommand();
-  }));
+  }, { operationLock: true }));
 
 program.parse();

--- a/src/managers/state.test.ts
+++ b/src/managers/state.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { StateManager } from './state';
+import type { Branch, Project } from '../types/state';
+
+describe('StateManager operation lock', function () {
+  const testDir = '/tmp/velo-operation-lock-test';
+  const stateFile = path.join(testDir, 'state.json');
+  const operationLockFile = `${stateFile}.operation.lock`;
+
+  beforeEach(async function () {
+    await fs.rm(testDir, { recursive: true, force: true });
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async function () {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  test('serializes long operations across managers', async function () {
+    const first = new StateManager(stateFile);
+    const second = new StateManager(stateFile);
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+
+    const firstDone = first.withOperationLock(async function runFirstOperation() {
+      events.push('first:start');
+      await new Promise<void>(function waitForRelease(resolve) {
+        releaseFirst = resolve;
+      });
+      events.push('first:end');
+    });
+
+    await waitForEvent(events, 'first:start');
+
+    const secondDone = second.withOperationLock(async function runSecondOperation() {
+      events.push('second:start');
+    });
+
+    await Bun.sleep(150);
+    expect(events).toEqual(['first:start']);
+
+    releaseFirst();
+    await firstDone;
+    await secondDone;
+
+    expect(events).toEqual(['first:start', 'first:end', 'second:start']);
+  });
+
+  test('removes stale operation locks from dead processes', async function () {
+    const state = new StateManager(stateFile);
+    await fs.writeFile(operationLockFile, '999999999');
+
+    await state.withOperationLock(async function runOperation() {
+      expect(await Bun.file(operationLockFile).exists()).toBe(true);
+    });
+
+    expect(await Bun.file(operationLockFile).exists()).toBe(false);
+  });
+
+  test('creates the lock directory before first state write', async function () {
+    await fs.rm(testDir, { recursive: true, force: true });
+
+    const state = new StateManager(stateFile);
+    await state.withOperationLock(async function runOperation() {
+      expect(await Bun.file(operationLockFile).exists()).toBe(true);
+    });
+
+    expect(await Bun.file(operationLockFile).exists()).toBe(false);
+  });
+
+  test('prevents duplicate concurrent branch creation', async function () {
+    const setup = new StateManager(stateFile);
+    await setup.initialize('tank', 'velo/databases');
+    await setup.projects.add(createProject());
+
+    const first = createBranchLikeService(new StateManager(stateFile), 'branch-2');
+    const second = createBranchLikeService(new StateManager(stateFile), 'branch-3');
+
+    const results = await Promise.allSettled([first, second]);
+    const fulfilled = results.filter(function isFulfilled(result) {
+      return result.status === 'fulfilled';
+    });
+    const rejected = results.filter(function isRejected(result) {
+      return result.status === 'rejected';
+    });
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const state = new StateManager(stateFile);
+    await state.load();
+
+    const project = state.projects.getByName('api');
+    const branches = project?.branches.filter(function filterDevBranch(branch) {
+      return branch.name === 'api/dev';
+    });
+
+    expect(branches).toHaveLength(1);
+  });
+});
+
+async function waitForEvent(events: string[], event: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (events.includes(event)) {
+      return;
+    }
+    await Bun.sleep(10);
+  }
+
+  throw new Error(`Timed out waiting for ${event}`);
+}
+
+async function createBranchLikeService(state: StateManager, branchId: string): Promise<string> {
+  return state.withOperationLock(async function runCreateBranch() {
+    await state.load();
+
+    const project = state.projects.getByName('api');
+    if (!project) {
+      throw new Error('Project not found');
+    }
+
+    if (project.branches.some(function hasBranch(branch) {
+      return branch.name === 'api/dev';
+    })) {
+      throw new Error("Branch 'api/dev' already exists");
+    }
+
+    await Bun.sleep(100);
+
+    const branch = createBranch({
+      id: branchId,
+      name: 'api/dev',
+      parentBranchId: 'branch-1',
+      isPrimary: false,
+    });
+
+    await state.branches.add(project.id, branch);
+    return branch.id;
+  });
+}
+
+function createProject(): Project {
+  return {
+    id: 'project-1',
+    name: 'api',
+    dockerImage: 'postgres:17-alpine',
+    sslCertDir: '/tmp/certs',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    credentials: {
+      username: 'postgres',
+      password: 'secret',
+      database: 'postgres',
+    },
+    branches: [
+      createBranch({
+        id: 'branch-1',
+        name: 'api/main',
+        parentBranchId: null,
+        isPrimary: true,
+      }),
+    ],
+  };
+}
+
+function createBranch(overrides: Partial<Branch>): Branch {
+  return {
+    id: 'branch-id',
+    name: 'api/main',
+    projectName: 'api',
+    parentBranchId: null,
+    isPrimary: true,
+    snapshotName: null,
+    zfsDataset: 'api.main',
+    containerName: 'velo-api.main',
+    port: 5432,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    status: 'running',
+    ...overrides,
+  };
+}

--- a/src/managers/state.ts
+++ b/src/managers/state.ts
@@ -9,6 +9,7 @@ import { CURRENT_STATE_SCHEMA_VERSION, migrateState } from './state-migration';
 export class StateManager {
   private state: State | null = null;
   private lockFile: string;
+  private operationLockFile: string;
 
   // Lazy-initialized repositories
   private _projects: ProjectRepository | null = null;
@@ -17,6 +18,7 @@ export class StateManager {
 
   constructor(private filePath: string) {
     this.lockFile = `${filePath}.lock`;
+    this.operationLockFile = `${filePath}.operation.lock`;
   }
 
   // Repository accessors (lazy initialization)
@@ -161,6 +163,20 @@ export class StateManager {
     }
   }
 
+  async withOperationLock<T>(operation: () => Promise<T>): Promise<T> {
+    await this.acquireFileLock(
+      this.operationLockFile,
+      'Another velo command is changing state',
+      'Wait for it to finish, then try again.'
+    );
+
+    try {
+      return await operation();
+    } finally {
+      await this.releaseFileLock(this.operationLockFile);
+    }
+  }
+
   async hasBackup(): Promise<boolean> {
     const backupFile = `${this.filePath}.backup`;
     try {
@@ -257,23 +273,36 @@ export class StateManager {
   }
 
   private async acquireLock(): Promise<void> {
+    await this.acquireFileLock(
+      this.lockFile,
+      'Failed to acquire state lock after 5 seconds',
+      'Another velo process may be running. Try again in a moment.'
+    );
+  }
+
+  private async acquireFileLock(lockFile: string, message: string, hint: string): Promise<void> {
     const maxAttempts = 50; // 5 seconds total (50 * 100ms)
+    const dir = lockFile.substring(0, lockFile.lastIndexOf('/'));
+
+    if (dir) {
+      await fs.mkdir(dir, { recursive: true });
+    }
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
-        await fs.writeFile(this.lockFile, process.pid.toString(), { flag: 'wx' });
+        await fs.writeFile(lockFile, process.pid.toString(), { flag: 'wx' });
         return;
       } catch (error: any) {
         if (error.code === 'EEXIST') {
           // Check if lock is stale
           try {
-            const lockPid = parseInt(await fs.readFile(this.lockFile, 'utf-8'), 10);
+            const lockPid = parseInt(await fs.readFile(lockFile, 'utf-8'), 10);
             if (!isNaN(lockPid)) {
               try {
                 process.kill(lockPid, 0); // Check if process exists
               } catch {
                 // Process doesn't exist, remove stale lock
-                await fs.unlink(this.lockFile).catch(() => {});
+                await fs.unlink(lockFile).catch(() => {});
                 continue; // Try again immediately
               }
             }
@@ -287,15 +316,16 @@ export class StateManager {
       }
     }
 
-    throw new SystemError(
-      'Failed to acquire state lock after 5 seconds',
-      'Another velo process may be running. Try again in a moment.'
-    );
+    throw new SystemError(message, hint);
   }
 
   private async releaseLock(): Promise<void> {
+    await this.releaseFileLock(this.lockFile);
+  }
+
+  private async releaseFileLock(lockFile: string): Promise<void> {
     try {
-      await fs.unlink(this.lockFile);
+      await fs.unlink(lockFile);
     } catch (error) {
       // Ignore errors
     }

--- a/src/utils/command-wrapper.ts
+++ b/src/utils/command-wrapper.ts
@@ -1,5 +1,11 @@
 import chalk from 'chalk';
 import { UserError, SystemError } from '../errors';
+import { StateManager } from '../managers/state';
+import { PATHS } from './paths';
+
+export interface CommandWrapperOptions {
+  operationLock?: boolean;
+}
 
 /**
  * Wraps command functions with consistent error handling.
@@ -19,11 +25,19 @@ import { UserError, SystemError } from '../errors';
  * ```
  */
 export function wrapCommand<T extends any[]>(
-  fn: (...args: T) => Promise<void>
+  fn: (...args: T) => Promise<void>,
+  options: CommandWrapperOptions = {}
 ): (...args: T) => Promise<void> {
-  return async (...args: T) => {
+  return async function wrappedCommand(...args: T) {
     try {
-      await fn(...args);
+      if (options.operationLock) {
+        const state = new StateManager(PATHS.STATE);
+        await state.withOperationLock(async function runLockedCommand() {
+          await fn(...args);
+        });
+      } else {
+        await fn(...args);
+      }
     } catch (error) {
       if (error instanceof UserError) {
         console.error(chalk.red('✗'), error.message);


### PR DESCRIPTION
## Summary
- add an operation lock for mutating command critical sections
- reuse stale pid cleanup for state and operation locks
- cover concurrent duplicate branch creation with a race test

## Checks
- bun test src
- bun run typecheck
- bun run build

Closes #44