### PR TITLE
feat(tables): add read-only table browser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Commit and PR titles use `type(scope): short description`.
 - In PR descriptions, clearly state any API routes, procedures, or contracts that were added, updated, or deleted.
 - For UI, use shadcn components from `src/web/components/ui`. If a needed shadcn component is missing, add the local wrapper first, then use it. Avoid raw browser prompts/confirms and custom one-off buttons, menus, modals, tabs, inputs, or textareas in routes.
+- For UI data loading, keep stable metadata separate from volatile content. A page/filter/poll/refresh action should only reload the UI region it affects. Use smaller APIs and query keys, preserve previous data during page changes when useful, and avoid making sidebars, titles, selectors, or table lists flash because a grid page, row set, or job status changed.
 
 ## Current Velo Setup
 

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -148,9 +148,220 @@ create table if not exists velo_local_notes (
   created_at timestamptz not null default now()
 );
 
+create table if not exists velo_local_accounts (
+  id serial primary key,
+  account_key text not null unique,
+  company_name text not null,
+  plan text not null,
+  seats integer not null,
+  balance numeric(12,2) not null,
+  active boolean not null,
+  tags text[] not null,
+  metadata jsonb not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null
+);
+
+create table if not exists velo_local_events (
+  id bigserial primary key,
+  account_key text not null,
+  event_name text not null,
+  event_index integer not null,
+  score double precision not null,
+  payload jsonb not null,
+  happened_at timestamptz not null
+);
+
+create table if not exists velo_local_wide_profiles (
+  id serial primary key,
+  external_id text not null unique,
+  first_name text not null,
+  last_name text not null,
+  email text not null,
+  phone text,
+  company text not null,
+  job_title text not null,
+  department text not null,
+  country text not null,
+  region text not null,
+  city text not null,
+  postal_code text not null,
+  address_line_1 text not null,
+  address_line_2 text,
+  latitude numeric(9,6) not null,
+  longitude numeric(9,6) not null,
+  signup_date date not null,
+  last_seen_at timestamptz not null,
+  login_count integer not null,
+  lifetime_value numeric(12,2) not null,
+  is_active boolean not null,
+  is_admin boolean not null,
+  preferred_locale text not null,
+  timezone text not null,
+  tags text[] not null,
+  settings jsonb not null,
+  notes text,
+  risk_score double precision not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null
+);
+
+create table if not exists velo_local_mixed_types (
+  id serial primary key,
+  sample_uuid uuid not null,
+  sample_text text not null,
+  sample_varchar varchar(24) not null,
+  sample_integer integer not null,
+  sample_bigint bigint not null,
+  sample_numeric numeric(10,4) not null,
+  sample_double double precision not null,
+  sample_boolean boolean not null,
+  sample_date date not null,
+  sample_time time not null,
+  sample_timestamp timestamp not null,
+  sample_timestamptz timestamptz not null,
+  sample_json jsonb not null,
+  sample_array text[] not null,
+  sample_inet inet not null
+);
+
 insert into velo_local_notes (body)
 select 'hello from local prod'
 where not exists (select 1 from velo_local_notes);
+
+insert into velo_local_accounts (account_key, company_name, plan, seats, balance, active, tags, metadata, created_at, updated_at)
+select
+  'acct-' || item,
+  'Company ' || item,
+  case when item % 3 = 0 then 'enterprise' when item % 3 = 1 then 'team' else 'free' end,
+  5 + item,
+  (item * 137.42)::numeric(12,2),
+  item % 4 <> 0,
+  array['local', 'seed', 'tier-' || (item % 3)],
+  jsonb_build_object('source', 'local', 'priority', item % 5, 'owner', 'user-' || item),
+  now() - (item || ' days')::interval,
+  now() - (item || ' hours')::interval
+from generate_series(1, 12) as item
+where not exists (select 1 from velo_local_accounts);
+
+insert into velo_local_events (account_key, event_name, event_index, score, payload, happened_at)
+select
+  'acct-' || ((item % 12) + 1),
+  case when item % 5 = 0 then 'branch.created' when item % 5 = 1 then 'query.run' when item % 5 = 2 then 'backup.completed' when item % 5 = 3 then 'restore.previewed' else 'user.invited' end,
+  item,
+  round((random() * 100)::numeric, 3)::double precision,
+  jsonb_build_object('index', item, 'ok', item % 7 <> 0, 'batch', item / 100),
+  now() - (item || ' minutes')::interval
+from generate_series(1, 3000) as item
+where not exists (select 1 from velo_local_events);
+
+insert into velo_local_wide_profiles (
+  external_id,
+  first_name,
+  last_name,
+  email,
+  phone,
+  company,
+  job_title,
+  department,
+  country,
+  region,
+  city,
+  postal_code,
+  address_line_1,
+  address_line_2,
+  latitude,
+  longitude,
+  signup_date,
+  last_seen_at,
+  login_count,
+  lifetime_value,
+  is_active,
+  is_admin,
+  preferred_locale,
+  timezone,
+  tags,
+  settings,
+  notes,
+  risk_score,
+  created_at,
+  updated_at
+)
+select
+  'profile-' || item,
+  'First' || item,
+  'Last' || item,
+  'person' || item || '@example.test',
+  '+1-555-010' || item,
+  'Company ' || ((item % 12) + 1),
+  case when item % 2 = 0 then 'Engineer' else 'Designer' end,
+  case when item % 3 = 0 then 'Product' when item % 3 = 1 then 'Data' else 'Ops' end,
+  'US',
+  'CA',
+  'San Francisco',
+  '9410' || (item % 10),
+  item || ' Market St',
+  null,
+  37.700000 + (item * 0.001),
+  -122.400000 - (item * 0.001),
+  current_date - item,
+  now() - (item || ' hours')::interval,
+  item * 3,
+  (item * 42.75)::numeric(12,2),
+  item % 5 <> 0,
+  item = 1,
+  'en-US',
+  'America/Los_Angeles',
+  array['wide', 'profile', 'group-' || (item % 4)],
+  jsonb_build_object('theme', case when item % 2 = 0 then 'light' else 'dark' end, 'email_updates', item % 3 <> 0),
+  'seed profile ' || item,
+  round((random() * 10)::numeric, 2)::double precision,
+  now() - (item || ' days')::interval,
+  now() - (item || ' minutes')::interval
+from generate_series(1, 40) as item
+where not exists (select 1 from velo_local_wide_profiles);
+
+insert into velo_local_mixed_types (
+  sample_uuid,
+  sample_text,
+  sample_varchar,
+  sample_integer,
+  sample_bigint,
+  sample_numeric,
+  sample_double,
+  sample_boolean,
+  sample_date,
+  sample_time,
+  sample_timestamp,
+  sample_timestamptz,
+  sample_json,
+  sample_array,
+  sample_inet
+)
+select
+  ('00000000-0000-4000-8000-' || lpad(item::text, 12, '0'))::uuid,
+  'mixed row ' || item,
+  'varchar-' || item,
+  item,
+  item * 1000000000::bigint,
+  (item * 12.3456)::numeric(10,4),
+  item / 3.0,
+  item % 2 = 0,
+  current_date - item,
+  ('08:00:00'::time + (item || ' minutes')::interval)::time,
+  (now() - (item || ' days')::interval)::timestamp,
+  now() - (item || ' hours')::interval,
+  jsonb_build_object('row', item, 'nested', jsonb_build_object('enabled', item % 2 = 0)),
+  array['alpha', 'beta', 'item-' || item],
+  ('10.0.0.' || item)::inet
+from generate_series(1, 10) as item
+where not exists (select 1 from velo_local_mixed_types);
+
+analyze velo_local_notes;
+analyze velo_local_accounts;
+analyze velo_local_events;
+analyze velo_local_wide_profiles;
+analyze velo_local_mixed_types;
 SQL
 }
 

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -7,6 +7,7 @@ import { dashboardRouter } from './dashboard';
 import { jobsRouter } from './jobs';
 import { replicaBaseRouter } from './replica-base';
 import { serversRouter } from './servers';
+import { tablesRouter } from './tables';
 
 export const appRouter = {
   dashboard: dashboardRouter,
@@ -16,6 +17,7 @@ export const appRouter = {
   bootstrap: bootstrapRouter,
   replicaBase: replicaBaseRouter,
   branches: branchesRouter,
+  tables: tablesRouter,
 };
 
 export type AppRouter = typeof appRouter;

--- a/src/api/tables.ts
+++ b/src/api/tables.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { publicProcedure } from './context';
+import { getTableBrowserMetadata, getTableRows } from '#server/services/table-browser-service';
+
+const tableBrowserInput = z.object({
+  branchId: z.string().min(1),
+  database: z.string().min(1).optional(),
+  schema: z.string().min(1).optional(),
+  table: z.string().min(1).optional(),
+});
+
+const tableRowsInput = z.object({
+  branchId: z.string().min(1),
+  database: z.string().min(1),
+  schema: z.string().min(1),
+  table: z.string().min(1),
+  offset: z.number().int().min(0).optional(),
+});
+
+export const tablesRouter = {
+  browse: publicProcedure
+    .input(tableBrowserInput)
+    .handler(async function browseTables({ input }) {
+      return getTableBrowserMetadata(input);
+    }),
+  rows: publicProcedure
+    .input(tableRowsInput)
+    .handler(async function browseRows({ input }) {
+      return getTableRows(input);
+    }),
+};

--- a/src/server/services/table-browser-service.ts
+++ b/src/server/services/table-browser-service.ts
@@ -1,0 +1,385 @@
+import { SQL } from 'bun';
+import { getDb } from '#db/client';
+import { getSetting } from './settings-service';
+
+export interface TableBrowserInput {
+  branchId: string;
+  database?: string | undefined;
+  schema?: string | undefined;
+  table?: string | undefined;
+}
+
+export interface TableRowsInput {
+  branchId: string;
+  database: string;
+  schema: string;
+  table: string;
+  offset?: number | undefined;
+}
+
+export interface TableBrowserTable {
+  schema: string;
+  name: string;
+  rowEstimate: number;
+}
+
+export interface TableBrowserColumn {
+  name: string;
+  type: string;
+  nullable: boolean;
+  defaultValue: string | null;
+  ordinal: number;
+}
+
+export interface TableBrowserMetadata {
+  branchId: string;
+  databases: string[];
+  selectedDatabase: string;
+  schemas: string[];
+  selectedSchema: string | null;
+  tables: TableBrowserTable[];
+  selectedTable: TableBrowserTable | null;
+  elapsedMs: number;
+}
+
+export interface TableRowsResult {
+  columns: TableBrowserColumn[];
+  rows: Array<Record<string, unknown>>;
+  rowLimit: number;
+  rowOffset: number;
+  rowCount: number;
+  elapsedMs: number;
+}
+
+export interface TableBrowserResult extends TableBrowserMetadata, TableRowsResult {
+  columns: TableBrowserColumn[];
+  rows: Array<Record<string, unknown>>;
+  rowLimit: number;
+  rowOffset: number;
+  rowCount: number;
+}
+
+const ROW_LIMIT = 50;
+
+export async function getTableBrowser(input: TableBrowserInput): Promise<TableBrowserResult> {
+  const metadata = await getTableBrowserMetadata(input);
+
+  if (!metadata.selectedTable || !metadata.selectedSchema) {
+    return {
+      ...metadata,
+      columns: [],
+      rows: [],
+      rowLimit: ROW_LIMIT,
+      rowOffset: 0,
+      rowCount: 0,
+    };
+  }
+
+  const rows = await getTableRows({
+    branchId: input.branchId,
+    database: metadata.selectedDatabase,
+    schema: metadata.selectedSchema,
+    table: metadata.selectedTable.name,
+  });
+
+  return {
+    ...metadata,
+    ...rows,
+  };
+}
+
+export async function getTableBrowserMetadata(input: TableBrowserInput): Promise<TableBrowserMetadata> {
+  const startedAt = performance.now();
+  const connectionUrl = await getBranchConnectionUrl(input.branchId);
+
+  if (!connectionUrl) {
+    throw new Error(`No connection string found for ${input.branchId}`);
+  }
+
+  let databases: string[];
+  let selectedDatabase: string;
+  const metadataSql = createSql(connectionUrl);
+
+  try {
+    databases = await listDatabases(metadataSql);
+    const currentDatabase = await getCurrentDatabase(metadataSql);
+    selectedDatabase = selectDatabase(databases, input.database, currentDatabase);
+  } finally {
+    await metadataSql.close({ timeout: 0 });
+  }
+
+  const sql = createSql(withDatabase(connectionUrl, selectedDatabase));
+
+  try {
+    const [tables, schemas] = await Promise.all([
+      listTables(sql),
+      listSchemas(sql),
+    ]);
+    const selectedSchema = selectSchema(schemas, input.schema);
+    const schemaTables = selectedSchema
+      ? tables.filter(function tableInSchema(table) {
+        return table.schema === selectedSchema;
+      })
+      : tables;
+    const selectedTable = selectTable(schemaTables, selectedSchema || undefined, input.table);
+
+    return {
+      branchId: input.branchId,
+      databases,
+      selectedDatabase,
+      schemas,
+      selectedSchema,
+      tables: schemaTables,
+      selectedTable,
+      elapsedMs: Math.max(0, Math.round(performance.now() - startedAt)),
+    };
+  } finally {
+    await sql.close({ timeout: 0 });
+  }
+}
+
+export async function getTableRows(input: TableRowsInput): Promise<TableRowsResult> {
+  const startedAt = performance.now();
+  const connectionUrl = await getBranchConnectionUrl(input.branchId);
+
+  if (!connectionUrl) {
+    throw new Error(`No connection string found for ${input.branchId}`);
+  }
+
+  const sql = createSql(withDatabase(connectionUrl, input.database));
+
+  try {
+    const table = {
+      schema: input.schema,
+      name: input.table,
+      rowEstimate: 0,
+    };
+    const columns = await listColumns(sql, table);
+    const rowCount = await countRows(sql, table);
+    const rowOffset = normalizeOffset(input.offset, rowCount);
+    const rows = await listRows(sql, table, columns, rowOffset);
+
+    return {
+      columns,
+      rows,
+      rowLimit: ROW_LIMIT,
+      rowOffset,
+      rowCount,
+      elapsedMs: Math.max(0, Math.round(performance.now() - startedAt)),
+    };
+  } finally {
+    await sql.close({ timeout: 0 });
+  }
+}
+
+async function getBranchConnectionUrl(branchId: string): Promise<string | null> {
+  if (branchId === 'prod') {
+    return getSetting('prod.connectionUrl');
+  }
+
+  const branch = await getDb()
+    .selectFrom('branches')
+    .select('connectionUrl')
+    .where('slug', '=', branchId)
+    .executeTakeFirst();
+
+  return branch?.connectionUrl || null;
+}
+
+async function listTables(sql: SQL): Promise<TableBrowserTable[]> {
+  const rows = await sql<TableBrowserTable[]>`
+    select
+      c.table_schema as schema,
+      c.table_name as name,
+      coalesce(pg_class.reltuples, 0)::bigint as "rowEstimate"
+    from information_schema.tables c
+    left join pg_namespace on pg_namespace.nspname = c.table_schema
+    left join pg_class on pg_class.relname = c.table_name
+      and pg_class.relnamespace = pg_namespace.oid
+    where c.table_type = 'BASE TABLE'
+      and c.table_schema not in ('pg_catalog', 'information_schema')
+    order by c.table_schema, c.table_name
+  `;
+
+  return rows.map(function normalizeTable(row) {
+    return {
+      schema: row.schema,
+      name: row.name,
+      rowEstimate: Math.max(0, Number(row.rowEstimate) || 0),
+    };
+  });
+}
+
+async function listDatabases(sql: SQL): Promise<string[]> {
+  const rows = await sql<Array<{ name: string }>>`
+    select datname as name
+    from pg_database
+    where datallowconn
+      and not datistemplate
+    order by datname
+  `;
+
+  return rows.map(function mapDatabase(row) {
+    return row.name;
+  });
+}
+
+async function getCurrentDatabase(sql: SQL): Promise<string> {
+  const rows = await sql<Array<{ name: string }>>`select current_database() as name`;
+  return rows[0]?.name || 'postgres';
+}
+
+async function listSchemas(sql: SQL): Promise<string[]> {
+  const rows = await sql<Array<{ name: string }>>`
+    select schema_name as name
+    from information_schema.schemata
+    where schema_name not in ('information_schema', 'pg_catalog')
+      and schema_name not like 'pg_toast%'
+      and schema_name not like 'pg_temp_%'
+    order by schema_name
+  `;
+
+  return rows.map(function mapSchema(row) {
+    return row.name;
+  });
+}
+
+async function listColumns(sql: SQL, table: TableBrowserTable): Promise<TableBrowserColumn[]> {
+  const rows = await sql<TableBrowserColumn[]>`
+    select
+      column_name as name,
+      data_type as type,
+      is_nullable = 'YES' as nullable,
+      column_default as "defaultValue",
+      ordinal_position as ordinal
+    from information_schema.columns
+    where table_schema = ${table.schema}
+      and table_name = ${table.name}
+    order by ordinal_position
+  `;
+
+  return rows.map(function normalizeColumn(row) {
+    return {
+      name: row.name,
+      type: row.type,
+      nullable: Boolean(row.nullable),
+      defaultValue: row.defaultValue,
+      ordinal: Number(row.ordinal),
+    };
+  });
+}
+
+async function countRows(sql: SQL, table: TableBrowserTable): Promise<number> {
+  const tableName = `${quoteIdentifier(table.schema)}.${quoteIdentifier(table.name)}`;
+  const rows = await sql.unsafe<Array<{ count: string | number }>>(`select count(*)::bigint as count from ${tableName}`);
+  return Number(rows[0]?.count) || 0;
+}
+
+async function listRows(
+  sql: SQL,
+  table: TableBrowserTable,
+  columns: TableBrowserColumn[],
+  offset: number
+): Promise<Array<Record<string, unknown>>> {
+  const tableName = `${quoteIdentifier(table.schema)}.${quoteIdentifier(table.name)}`;
+  const orderBy = columns[0] ? ` order by ${quoteIdentifier(columns[0].name)}` : '';
+  const rows = await sql.unsafe<Array<Record<string, unknown>>>(
+    `select * from ${tableName}${orderBy} limit ${ROW_LIMIT} offset ${offset}`
+  );
+  return rows.map(function normalizeRow(row) {
+    return normalizeValue(row) as Record<string, unknown>;
+  });
+}
+
+function selectTable(tables: TableBrowserTable[], schema?: string, name?: string): TableBrowserTable | null {
+  if (schema && name) {
+    const match = tables.find(function findMatchingTable(table) {
+      return table.schema === schema && table.name === name;
+    });
+
+    if (match) {
+      return match;
+    }
+  }
+
+  return tables[0] || null;
+}
+
+function selectDatabase(databases: string[], requested: string | undefined, current: string): string {
+  if (requested && databases.includes(requested)) {
+    return requested;
+  }
+
+  if (databases.includes(current)) {
+    return current;
+  }
+
+  return databases[0] || current;
+}
+
+function selectSchema(schemas: string[], requested: string | undefined): string | null {
+  if (requested && schemas.includes(requested)) {
+    return requested;
+  }
+
+  if (schemas.includes('public')) {
+    return 'public';
+  }
+
+  return schemas[0] || null;
+}
+
+function normalizeOffset(offset: number | undefined, rowCount: number): number {
+  const requested = Math.max(0, offset || 0);
+
+  if (rowCount === 0 || requested < rowCount) {
+    return requested;
+  }
+
+  return Math.max(0, Math.floor((rowCount - 1) / ROW_LIMIT) * ROW_LIMIT);
+}
+
+function withDatabase(connectionUrl: string, database: string): string {
+  const url = new URL(connectionUrl);
+  url.pathname = `/${encodeURIComponent(database)}`;
+  return url.toString();
+}
+
+function createSql(connectionUrl: string): SQL {
+  return new SQL(connectionUrl, {
+    max: 1,
+    idleTimeout: 1,
+  });
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (value instanceof Uint8Array) {
+    return `<${value.byteLength} bytes>`;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeValue);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(function normalizeEntry([key, item]) {
+        return [key, normalizeValue(item)];
+      })
+    );
+  }
+
+  return value;
+}

--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   Settings2,
   ShieldCheck,
+  Table2,
   Trash2,
 } from 'lucide-react';
 import { cn } from '#lib/utils';
@@ -126,7 +127,7 @@ export interface AppSidebarProps {
     displayName: string;
   }>;
   activeProject?: 'dashboard' | 'settings';
-  activeBranchPage?: 'overview' | 'sql' | 'backup';
+  activeBranchPage?: 'overview' | 'sql' | 'tables' | 'backup';
   selectedBranch?: string;
 }
 
@@ -135,6 +136,7 @@ export function AppSidebar(props: AppSidebarProps) {
   const selectedBranchParam = encodeURIComponent(selectedBranch);
   const overviewHref = `/branch/${selectedBranchParam}/overview`;
   const sqlHref = `/branch/${selectedBranchParam}/sql`;
+  const tablesHref = `/branch/${selectedBranchParam}/tables`;
   const backupHref = `/branch/${selectedBranchParam}/backup-restore`;
 
   function changeBranch(value: string) {
@@ -180,6 +182,7 @@ export function AppSidebar(props: AppSidebarProps) {
         <div className="mt-3 grid gap-1">
           <NavItem icon={LayoutDashboard} label="Overview" href={overviewHref} active={props.activeBranchPage === 'overview'} />
           <NavItem icon={Code2} label="SQL editor" href={sqlHref} active={props.activeBranchPage === 'sql'} />
+          <NavItem icon={Table2} label="Tables" href={tablesHref} active={props.activeBranchPage === 'tables'} />
           <NavItem icon={ArchiveRestore} label="Backup & Restore" href={backupHref} active={props.activeBranchPage === 'backup'} />
         </div>
       </SidebarSection>

--- a/src/web/routeTree.gen.ts
+++ b/src/web/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BranchBranchIdTablesRouteImport } from './routes/branch/$branchId/tables'
 import { Route as BranchBranchIdSqlRouteImport } from './routes/branch/$branchId/sql'
 import { Route as BranchBranchIdOverviewRouteImport } from './routes/branch/$branchId/overview'
 import { Route as BranchBranchIdBackupRestoreRouteImport } from './routes/branch/$branchId/backup-restore'
@@ -25,6 +26,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BranchBranchIdTablesRoute = BranchBranchIdTablesRouteImport.update({
+  id: '/branch/$branchId/tables',
+  path: '/branch/$branchId/tables',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BranchBranchIdSqlRoute = BranchBranchIdSqlRouteImport.update({
@@ -62,6 +68,7 @@ export interface FileRoutesByFullPath {
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
   '/branch/$branchId/overview': typeof BranchBranchIdOverviewRoute
   '/branch/$branchId/sql': typeof BranchBranchIdSqlRoute
+  '/branch/$branchId/tables': typeof BranchBranchIdTablesRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -71,6 +78,7 @@ export interface FileRoutesByTo {
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
   '/branch/$branchId/overview': typeof BranchBranchIdOverviewRoute
   '/branch/$branchId/sql': typeof BranchBranchIdSqlRoute
+  '/branch/$branchId/tables': typeof BranchBranchIdTablesRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -81,6 +89,7 @@ export interface FileRoutesById {
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
   '/branch/$branchId/overview': typeof BranchBranchIdOverviewRoute
   '/branch/$branchId/sql': typeof BranchBranchIdSqlRoute
+  '/branch/$branchId/tables': typeof BranchBranchIdTablesRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -92,6 +101,7 @@ export interface FileRouteTypes {
     | '/branch/$branchId/backup-restore'
     | '/branch/$branchId/overview'
     | '/branch/$branchId/sql'
+    | '/branch/$branchId/tables'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -101,6 +111,7 @@ export interface FileRouteTypes {
     | '/branch/$branchId/backup-restore'
     | '/branch/$branchId/overview'
     | '/branch/$branchId/sql'
+    | '/branch/$branchId/tables'
   id:
     | '__root__'
     | '/'
@@ -110,6 +121,7 @@ export interface FileRouteTypes {
     | '/branch/$branchId/backup-restore'
     | '/branch/$branchId/overview'
     | '/branch/$branchId/sql'
+    | '/branch/$branchId/tables'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -120,6 +132,7 @@ export interface RootRouteChildren {
   BranchBranchIdBackupRestoreRoute: typeof BranchBranchIdBackupRestoreRoute
   BranchBranchIdOverviewRoute: typeof BranchBranchIdOverviewRoute
   BranchBranchIdSqlRoute: typeof BranchBranchIdSqlRoute
+  BranchBranchIdTablesRoute: typeof BranchBranchIdTablesRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -136,6 +149,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/branch/$branchId/tables': {
+      id: '/branch/$branchId/tables'
+      path: '/branch/$branchId/tables'
+      fullPath: '/branch/$branchId/tables'
+      preLoaderRoute: typeof BranchBranchIdTablesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/branch/$branchId/sql': {
@@ -184,6 +204,7 @@ const rootRouteChildren: RootRouteChildren = {
   BranchBranchIdBackupRestoreRoute: BranchBranchIdBackupRestoreRoute,
   BranchBranchIdOverviewRoute: BranchBranchIdOverviewRoute,
   BranchBranchIdSqlRoute: BranchBranchIdSqlRoute,
+  BranchBranchIdTablesRoute: BranchBranchIdTablesRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/web/routes/branch/$branchId/tables.tsx
+++ b/src/web/routes/branch/$branchId/tables.tsx
@@ -1,0 +1,393 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Database,
+  RefreshCw,
+  Search,
+  Table2,
+} from 'lucide-react';
+import { AppSidebar } from '#web/components/control-plane';
+import { Badge } from '#web/components/ui/badge';
+import { Button } from '#web/components/ui/button';
+import { Input } from '#web/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '#web/components/ui/select';
+import { orpc } from '#web/lib/api-client';
+import { cn } from '#lib/utils';
+
+export const Route = createFileRoute('/branch/$branchId/tables')({
+  component: BranchTablesPage,
+});
+
+function BranchTablesPage() {
+  const params = Route.useParams();
+  const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
+  const [selected, setSelected] = useState<TableKey | null>(null);
+  const [search, setSearch] = useState('');
+  const metadata = useQuery(orpc.tables.browse.queryOptions({
+    input: {
+      branchId: params.branchId,
+      database: selected?.database,
+      schema: selected?.schema,
+    },
+  }));
+  const selectedDatabase = metadata.data?.selectedDatabase || selected?.database || 'postgres';
+  const selectedSchema = metadata.data?.selectedSchema || selected?.schema || 'public';
+  const selectedTable = selected?.name || metadata.data?.selectedTable?.name || '';
+  const rows = useQuery({
+    ...orpc.tables.rows.queryOptions({
+      input: {
+        branchId: params.branchId,
+        database: selectedDatabase,
+        schema: selectedSchema,
+        table: selectedTable,
+        offset: selected?.offset,
+      },
+    }),
+    enabled: Boolean(selectedTable),
+    placeholderData: function keepRowsVisible(previousData) {
+      return previousData;
+    },
+  });
+
+  useEffect(function setInitialTable() {
+    if (selected || !metadata.data?.selectedTable) {
+      return;
+    }
+
+    setSelected({
+      database: metadata.data.selectedDatabase,
+      schema: metadata.data.selectedTable.schema,
+      name: metadata.data.selectedTable.name,
+      offset: 0,
+    });
+  }, [selected, metadata.data]);
+
+  const branches = dashboard.data?.branches || [];
+  const filteredTables = useMemo(function filterTables() {
+    const term = search.trim().toLowerCase();
+
+    if (!term) {
+      return metadata.data?.tables || [];
+    }
+
+    return (metadata.data?.tables || []).filter(function tableMatches(table) {
+      return `${table.schema}.${table.name}`.toLowerCase().includes(term);
+    });
+  }, [search, metadata.data?.tables]);
+
+  function selectDatabase(database: string) {
+    setSelected({ database, schema: 'public', offset: 0 });
+  }
+
+  function selectSchema(schema: string) {
+    setSelected({
+      database: metadata.data?.selectedDatabase || selected?.database,
+      schema,
+      offset: 0,
+    });
+  }
+
+  function selectPage(offset: number) {
+    setSelected({
+      database: metadata.data?.selectedDatabase || selected?.database,
+      schema: metadata.data?.selectedSchema || selected?.schema || 'public',
+      name: metadata.data?.selectedTable?.name || selected?.name,
+      offset,
+    });
+  }
+
+  const rowOffset = rows.data?.rowOffset || selected?.offset || 0;
+  const rowLimit = rows.data?.rowLimit || 50;
+  const rowEnd = rows.data ? Math.min(rows.data.rowOffset + rows.data.rowLimit, rows.data.rowCount) : rowOffset + rowLimit;
+  const canPageBack = rowOffset > 0;
+  const canPageForward = rows.data ? rowOffset + rowLimit < rows.data.rowCount : false;
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="grid min-h-screen lg:grid-cols-[244px_1fr]">
+        <AppSidebar branches={branches} activeBranchPage="tables" selectedBranch={params.branchId} />
+
+        <section className="grid min-h-screen min-w-0 grid-rows-[auto_1fr]">
+          <header className="border-b border-border px-5 py-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">Tables</Badge>
+                  <Badge variant="secondary">read only</Badge>
+                </div>
+                <h1 className="mt-2 text-2xl font-semibold tracking-normal">Tables</h1>
+                <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+                  <span>{params.branchId}</span>
+                  <span>/</span>
+                  <span>{metadata.data?.selectedTable ? metadata.data.selectedTable.name : 'no table'}</span>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <div className="grid min-h-0 lg:grid-cols-[280px_1fr]">
+            <aside className="grid min-h-0 grid-rows-[auto_auto_1fr] border-r border-border bg-muted/20">
+              <div className="border-b border-border p-4">
+                <Select value={metadata.data?.selectedDatabase || selected?.database || 'postgres'} onValueChange={selectDatabase}>
+                  <SelectTrigger className="h-10 w-full bg-background font-medium">
+                    <Database className="size-4 text-muted-foreground" />
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {(metadata.data?.databases || [metadata.data?.selectedDatabase || selected?.database || 'postgres']).map(function renderDatabase(database) {
+                        return (
+                          <SelectItem key={database} value={database}>
+                            {database}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="border-b border-border p-4">
+                <Select value={metadata.data?.selectedSchema || selected?.schema || 'public'} onValueChange={selectSchema}>
+                  <SelectTrigger className="h-10 w-full bg-background font-medium">
+                    <Table2 className="size-4 text-muted-foreground" />
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {(metadata.data?.schemas || [metadata.data?.selectedSchema || selected?.schema || 'public']).map(function renderSchema(schema) {
+                        return (
+                          <SelectItem key={schema} value={schema}>
+                            {schema}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                <div className="mt-3 flex gap-2">
+                  <div className="relative min-w-0 flex-1">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      value={search}
+                      onChange={function updateSearch(event) {
+                        setSearch(event.target.value);
+                      }}
+                      className="pl-9"
+                      placeholder="Search..."
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <div className="min-h-0 overflow-auto p-3">
+                {metadata.isLoading ? (
+                  <EmptySideLabel label="Loading tables..." />
+                ) : filteredTables.length === 0 ? (
+                  <EmptySideLabel label="No tables" />
+                ) : (
+                  <div className="grid gap-1">
+                    {filteredTables.map(function renderTable(table) {
+                      const active = metadata.data?.selectedTable?.schema === table.schema
+                        && metadata.data.selectedTable.name === table.name;
+
+                      return (
+                        <button
+                          key={`${table.schema}.${table.name}`}
+                          type="button"
+                          className={cn(
+                            'flex h-9 min-w-0 items-center gap-2 rounded-md px-3 text-left text-sm text-muted-foreground hover:bg-background hover:text-foreground',
+                            active && 'bg-background font-medium text-foreground shadow-sm'
+                          )}
+                          onClick={function selectTable() {
+                            setSelected({
+                              database: metadata.data?.selectedDatabase || selected?.database,
+                              schema: table.schema,
+                              name: table.name,
+                              offset: 0,
+                            });
+                          }}
+                        >
+                          <Table2 className="size-4 shrink-0" />
+                          <span className="truncate">{table.name}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </aside>
+
+            <div className="grid min-h-0 grid-rows-[auto_1fr]">
+              <div className="flex flex-wrap items-center justify-end gap-2 border-b border-border px-3 py-2">
+                <div className="text-xs text-muted-foreground">
+                  {rows.data ? `${rows.data.rowLimit} rows · ${rows.data.elapsedMs}ms` : 'Loading...'}
+                </div>
+                <div className="flex h-8 overflow-hidden rounded-md border border-input bg-background">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 rounded-none border-r border-border"
+                    disabled={!canPageBack}
+                    onClick={function pageBack() {
+                      selectPage(Math.max(0, rowOffset - rowLimit));
+                    }}
+                  >
+                    <ChevronLeft className="size-3.5" />
+                  </Button>
+                  <div className="grid h-8 w-11 place-items-center border-r border-border font-mono text-xs">
+                    {rowOffset}
+                  </div>
+                  <div className="grid h-8 w-11 place-items-center border-r border-border font-mono text-xs">
+                    {rowEnd}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 rounded-none"
+                    disabled={!canPageForward}
+                    onClick={function pageForward() {
+                      selectPage(rowOffset + rowLimit);
+                    }}
+                  >
+                    <ChevronRight className="size-3.5" />
+                  </Button>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label="Refresh rows"
+                  className="size-8"
+                  onClick={function refreshRows() {
+                    void rows.refetch();
+                  }}
+                >
+                  <RefreshCw className="size-3.5" />
+                </Button>
+              </div>
+
+              <TableGrid data={rows.data} loading={rows.isLoading} error={rows.error} />
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+interface TableKey {
+  database?: string;
+  schema: string;
+  name?: string;
+  offset?: number;
+}
+
+interface TableGridProps {
+  data: Awaited<ReturnType<typeof orpc.tables.rows.call>> | undefined;
+  loading: boolean;
+  error: Error | null;
+}
+
+function TableGrid(props: TableGridProps) {
+  if (props.loading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading rows...</div>;
+  }
+
+  if (props.error) {
+    return <div className="p-6 text-sm text-destructive">{props.error.message}</div>;
+  }
+
+  if (!props.data) {
+    return <div className="p-6 text-sm text-muted-foreground">No table selected.</div>;
+  }
+
+  const data = props.data;
+
+  return (
+    <div className="min-h-0 overflow-auto">
+      <table className="min-w-full border-separate border-spacing-0 text-sm">
+        <thead className="sticky top-0 z-10 bg-background">
+          <tr>
+            <th className="h-9 w-10 border-b border-r border-border px-3 text-left font-medium text-muted-foreground" />
+            {data.columns.map(function renderColumn(column) {
+              return (
+                <th
+                  key={column.name}
+                  className="h-9 min-w-48 border-b border-r border-border px-3 text-left font-medium text-muted-foreground"
+                  title={`${column.name} ${column.type}`}
+                >
+                  <span className="block max-w-64 truncate">
+                    {column.name} <span className="font-normal">{column.type}</span>
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {props.data.rows.length === 0 ? (
+            <tr>
+              <td className="p-6 text-sm text-muted-foreground" colSpan={data.columns.length + 1}>
+                No rows.
+              </td>
+            </tr>
+          ) : (
+            data.rows.map(function renderRow(row, index) {
+              return (
+                <tr key={index} className="hover:bg-muted/40">
+                  <td className="h-9 border-b border-r border-border px-3 font-mono text-xs text-muted-foreground">
+                    {data.rowOffset + index + 1}
+                  </td>
+                  {data.columns.map(function renderCell(column) {
+                    return (
+                      <td
+                        key={column.name}
+                        className="h-9 max-w-72 border-b border-r border-border px-3 font-mono text-xs"
+                        title={formatCell(row[column.name])}
+                      >
+                        <span className="block truncate">{formatCell(row[column.name])}</span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function EmptySideLabel(props: { label: string }) {
+  return <div className="px-3 py-2 text-sm text-muted-foreground">{props.label}</div>;
+}
+
+function formatCell(value: unknown): string {
+  if (value === null) {
+    return 'NULL';
+  }
+
+  if (value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}


### PR DESCRIPTION
## Summary
- add a Tables branch nav item and route
- add a read-only table browser with database, schema, table, and paged row browsing
- seed local Docker prod with richer table data for browser testing
- document UI query-boundary guidance in AGENTS.md

## API changes
- add `tables.browse` ORPC procedure for stable metadata: databases, schemas, tables, and selected table
- add `tables.rows` ORPC procedure for volatile row data: columns, paged rows, row count, limit, offset, and timing

## Validation
- bun run typecheck
- bun run test
- bun run web:build
- bash -n scripts/*.sh