### PR TITLE
refactor(dashboard): simplify branch navigation

### DIFF
--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -1,5 +1,6 @@
 import type { FormEvent, ReactNode } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
 import {
   Activity,
   AlertTriangle,
@@ -85,10 +86,10 @@ export function ProductionSummaryPanel(props: ProductionSummaryPanelProps) {
           <InfoCell label="Backup repo" value={props.backupMode} />
           <InfoCell label="Backup status" value={props.backupMessage || props.backupStatus} />
         </div>
-        <a className={cn(buttonVariants({ variant: 'outline' }), 'w-full')} href="/branch/prod/overview">
+        <Link className={cn(buttonVariants({ variant: 'outline' }), 'w-full')} to="/branch/$branchId/overview" params={{ branchId: 'prod' }}>
           <Database />
           Open production
-        </a>
+        </Link>
       </CardContent>
     </Card>
   );
@@ -132,15 +133,38 @@ export interface AppSidebarProps {
 }
 
 export function AppSidebar(props: AppSidebarProps) {
-  const selectedBranch = props.selectedBranch || 'prod';
+  const navigate = useNavigate();
+  const [savedBranch, setSavedBranch] = useState(function getInitialBranch() {
+    return props.selectedBranch || 'prod';
+  });
+  const selectedBranch = getSelectedBranch(props.selectedBranch || savedBranch, props.branches);
   const selectedBranchParam = encodeURIComponent(selectedBranch);
   const overviewHref = `/branch/${selectedBranchParam}/overview`;
   const sqlHref = `/branch/${selectedBranchParam}/sql`;
   const tablesHref = `/branch/${selectedBranchParam}/tables`;
   const backupHref = `/branch/${selectedBranchParam}/backup-restore`;
 
+  useEffect(function saveSelectedBranch() {
+    if (!props.selectedBranch) {
+      return;
+    }
+
+    setSavedBranch(props.selectedBranch);
+    window.localStorage.setItem('velo.selectedBranch', props.selectedBranch);
+  }, [props.selectedBranch]);
+
+  useEffect(function loadSavedBranch() {
+    if (props.selectedBranch) {
+      return;
+    }
+
+    setSavedBranch(window.localStorage.getItem('velo.selectedBranch') || 'prod');
+  }, [props.selectedBranch]);
+
   function changeBranch(value: string) {
-    window.location.href = `/branch/${encodeURIComponent(value)}/overview`;
+    setSavedBranch(value);
+    window.localStorage.setItem('velo.selectedBranch', value);
+    void navigate({ to: '/branch/$branchId/overview', params: { branchId: value } });
   }
 
   return (
@@ -190,6 +214,18 @@ export function AppSidebar(props: AppSidebarProps) {
   );
 }
 
+function getSelectedBranch(selectedBranch: string, branches: AppSidebarProps['branches']): string {
+  if (selectedBranch === 'prod') {
+    return selectedBranch;
+  }
+
+  const branchExists = branches.some(function hasBranch(branch) {
+    return branch.slug === selectedBranch;
+  });
+
+  return branchExists ? selectedBranch : 'prod';
+}
+
 interface SidebarSectionProps {
   label: string;
   className?: string;
@@ -218,8 +254,8 @@ function NavItem(props: NavItemProps) {
   const Icon = props.icon;
 
   return (
-    <a
-      href={props.href}
+    <Link
+      to={props.href}
       className={cn(
         'flex h-9 items-center gap-2 rounded-md px-3 text-muted-foreground',
         'transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
@@ -228,7 +264,7 @@ function NavItem(props: NavItemProps) {
     >
       <Icon className="size-4" />
       <span>{props.label}</span>
-    </a>
+    </Link>
   );
 }
 
@@ -394,6 +430,157 @@ export interface BranchesPanelProps {
   busy: string | null;
   onCreate: (formData: FormData) => Promise<void>;
   onDelete: (id: number, name: string) => Promise<void>;
+}
+
+interface BranchTreePanelProps {
+  branches: Array<{
+    id: number;
+    slug: string;
+    displayName: string;
+    status: string;
+    parentBranchId: number | null;
+    parentName: string | null;
+    parentSlug: string | null;
+  }>;
+  prodReady: boolean;
+}
+
+interface BranchTreeNode {
+  branch: BranchTreePanelProps['branches'][number];
+  children: BranchTreeNode[];
+}
+
+export function BranchTreePanel(props: BranchTreePanelProps) {
+  const tree = buildBranchTree(props.branches);
+
+  return (
+    <Card>
+      <CardContent className="p-2">
+        <Link
+          className={cn(
+            'flex min-h-14 items-center gap-3 rounded-md px-3 py-2',
+            'transition-colors hover:bg-accent hover:text-accent-foreground'
+          )}
+          to="/branch/$branchId/overview"
+          params={{ branchId: 'prod' }}
+          onClick={function saveProdBranch() {
+            window.localStorage.setItem('velo.selectedBranch', 'prod');
+          }}
+        >
+          <div className="grid size-8 shrink-0 place-items-center rounded-md bg-primary text-primary-foreground">
+            <Database className="size-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <p className="truncate font-medium">prod</p>
+              <Badge variant="outline">production</Badge>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">root branch</p>
+          </div>
+          <StatusBadge status={props.prodReady ? 'ready' : 'pending'} />
+        </Link>
+
+        {tree.length > 0 ? (
+          <div className="ml-7 border-l border-border pl-4">
+            {tree.map(function renderRoot(node) {
+              return <BranchTreeItem key={node.branch.id} node={node} />;
+            })}
+          </div>
+        ) : (
+          <div className="ml-7 border-l border-border py-6 pl-4 text-sm text-muted-foreground">
+            No dev branches yet.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BranchTreeItem(props: { node: BranchTreeNode }) {
+  const branch = props.node.branch;
+
+  return (
+    <div className="relative">
+      <div className="absolute left-[-1rem] top-7 h-px w-4 bg-border" />
+      <Link
+        className={cn(
+          'my-1 flex min-h-14 items-center gap-3 rounded-md px-3 py-2',
+          'transition-colors hover:bg-accent hover:text-accent-foreground'
+        )}
+        to="/branch/$branchId/overview"
+        params={{ branchId: branch.slug }}
+        onClick={function saveBranch() {
+          window.localStorage.setItem('velo.selectedBranch', branch.slug);
+        }}
+      >
+        <div className="grid size-8 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground">
+          <GitBranch className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <p className="truncate font-medium">{branch.displayName}</p>
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            from {branch.parentName || branch.parentSlug || 'prod'}
+          </p>
+        </div>
+        <StatusBadge status={branch.status} />
+      </Link>
+
+      {props.node.children.length > 0 ? (
+        <div className="ml-7 border-l border-border pl-4">
+          {props.node.children.map(function renderChild(child) {
+            return <BranchTreeItem key={child.branch.id} node={child} />;
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function buildBranchTree(branches: BranchTreePanelProps['branches']): BranchTreeNode[] {
+  const nodesById = new Map<number, BranchTreeNode>();
+  const roots: BranchTreeNode[] = [];
+
+  branches.forEach(function addNode(branch) {
+    nodesById.set(branch.id, { branch, children: [] });
+  });
+
+  branches.forEach(function linkNode(branch) {
+    const node = nodesById.get(branch.id);
+
+    if (!node) {
+      return;
+    }
+
+    if (!branch.parentBranchId) {
+      roots.push(node);
+      return;
+    }
+
+    const parent = nodesById.get(branch.parentBranchId);
+
+    if (!parent) {
+      roots.push(node);
+      return;
+    }
+
+    parent.children.push(node);
+  });
+
+  sortBranchNodes(roots);
+
+  return roots;
+}
+
+function sortBranchNodes(nodes: BranchTreeNode[]) {
+  nodes.sort(function sortByName(first, second) {
+    return first.branch.displayName.localeCompare(second.branch.displayName);
+  });
+
+  nodes.forEach(function sortChildren(node) {
+    sortBranchNodes(node.children);
+  });
 }
 
 export function BranchesPanel(props: BranchesPanelProps) {

--- a/src/web/routes/branch/$branchId/overview.tsx
+++ b/src/web/routes/branch/$branchId/overview.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
@@ -51,6 +51,7 @@ export const Route = createFileRoute('/branch/$branchId/overview')({
 
 function BranchOverviewPage() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
   const createBranch = useMutation(orpc.branches.create.mutationOptions({ onSuccess: refreshDashboard }));
   const deleteBranch = useMutation(orpc.branches.delete.mutationOptions({ onSuccess: refreshDashboard }));
@@ -126,7 +127,7 @@ function BranchOverviewPage() {
     setCreateModalOpen(false);
 
     if (result.branchSlug) {
-      window.location.href = `/branch/${encodeURIComponent(result.branchSlug)}/overview`;
+      await navigate({ to: '/branch/$branchId/overview', params: { branchId: result.branchSlug } });
     }
   }
 
@@ -147,7 +148,7 @@ function BranchOverviewPage() {
 
     setMessage(null);
     await deleteBranch.mutateAsync({ id: branch.rowId! });
-    window.location.href = `/branch/${encodeURIComponent(branch.parentSlug || 'prod')}/overview`;
+    await navigate({ to: '/branch/$branchId/overview', params: { branchId: branch.parentSlug || 'prod' } });
   }
 
   function handleConfirmAction() {

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -1,26 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import {
-  Activity,
-  ArchiveRestore,
-  Database,
-  GitBranch,
-  Loader2,
-  Play,
-  RefreshCw,
-} from 'lucide-react';
-import { Badge } from '#web/components/ui/badge';
-import { Button, buttonVariants } from '#web/components/ui/button';
+import { Database, Loader2 } from 'lucide-react';
 import {
   AppSidebar,
-  BranchesPanel,
-  MetricCard,
-  ProductionSummaryPanel,
-  SetupPanel,
-  StatusBadge,
-  SystemPanel,
-  type ServerRole,
+  BranchTreePanel,
 } from '#web/components/control-plane';
 import { orpc } from '#web/lib/api-client';
 
@@ -29,13 +13,7 @@ export const Route = createFileRoute('/')({
 });
 
 function HomePage() {
-  const queryClient = useQueryClient();
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
-  const startBootstrap = useMutation(orpc.bootstrap.start.mutationOptions({ onSuccess: refreshDashboard }));
-  const createBranch = useMutation(orpc.branches.create.mutationOptions({ onSuccess: refreshDashboard }));
-  const deleteBranch = useMutation(orpc.branches.delete.mutationOptions({ onSuccess: refreshDashboard }));
-  const createReplicaBase = useMutation(orpc.replicaBase.create.mutationOptions({ onSuccess: refreshDashboard }));
-  const busy = getBusyKey();
   const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
     return job.status === 'queued' || job.status === 'running';
   }).length ?? 0;
@@ -54,69 +32,11 @@ function HomePage() {
     };
   }, [activeJobs, dashboard]);
 
-  async function refreshDashboard() {
-    await queryClient.invalidateQueries({ queryKey: orpc.dashboard.retrieve.key() });
-  }
-
-  function getBusyKey(): string | null {
-    if (startBootstrap.isPending) {
-      return `bootstrap-${startBootstrap.variables?.target || 'dev'}`;
-    }
-
-    if (createBranch.isPending) {
-      return 'create-branch';
-    }
-
-    if (deleteBranch.isPending) {
-      return `delete-branch-${deleteBranch.variables?.id}`;
-    }
-
-    if (createReplicaBase.isPending) {
-      return 'create-replica';
-    }
-
-    return null;
-  }
-
   if (!dashboard.data) {
     return <LoadingPage message={dashboard.error ? 'Could not load dashboard.' : 'Loading dashboard...'} />;
   }
 
   const state = dashboard.data;
-
-  async function handleBootstrap(kind: ServerRole) {
-    await startBootstrap.mutateAsync({ target: kind });
-  }
-
-  async function handleCreateBranch(formData: FormData) {
-    const name = String(formData.get('name') || '');
-    await createBranch.mutateAsync({ name });
-  }
-
-  async function handleDeleteBranch(id: number) {
-    await deleteBranch.mutateAsync({ id });
-  }
-
-  async function handleCreateReplica() {
-    await createReplicaBase.mutateAsync(undefined);
-  }
-
-  const prodServer = state.servers.find(function findProd(server) {
-    return server.role === 'prod';
-  });
-  const devServer = state.servers.find(function findDev(server) {
-    return server.role === 'dev';
-  });
-  const doneSteps = state.setupSteps.filter(function countDone(step) {
-    return step.status === 'done';
-  }).length;
-  const setupComplete = doneSteps === state.setupSteps.length;
-  const backupsStep = state.setupSteps.find(function findBackupsStep(step) {
-    return step.key === 'backups';
-  });
-  const dashboardTitle = setupComplete ? 'Production ready. Branching is live.' : 'Finish setup to start branching.';
-
-  const backupMode = state.backup.enabled ? 'S3/R2' : 'local';
 
   return (
     <main className="min-h-screen bg-background text-foreground">
@@ -124,7 +44,7 @@ function HomePage() {
         <AppSidebar branches={state.branches} activeProject="dashboard" />
 
         <section className="min-w-0">
-          <div className="mx-auto grid w-full max-w-[1400px] gap-6 px-4 py-6 sm:px-6 lg:px-8">
+          <div className="mx-auto grid w-full max-w-4xl gap-6 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between gap-4 lg:hidden">
               <div className="flex items-center gap-3">
                 <div className="grid size-9 place-items-center rounded-lg bg-primary text-primary-foreground">
@@ -135,97 +55,16 @@ function HomePage() {
                   <div className="mt-1 text-xs text-muted-foreground">Control plane</div>
                 </div>
               </div>
-              <StatusBadge status={setupComplete ? 'done' : activeJobs > 0 ? 'running' : 'pending'} />
             </div>
 
-            <header id="overview" className="scroll-mt-6 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-              <div>
-                <div className="flex items-center gap-2">
-                  <Badge variant="outline">Overview</Badge>
-                  <Badge variant={setupComplete ? 'success' : 'warning'}>
-                    {setupComplete ? 'ready' : 'setup needed'}
-                  </Badge>
-                </div>
-                <h1 className="mt-3 text-3xl font-semibold tracking-normal md:text-4xl">
-                  {dashboardTitle}
-                </h1>
-                <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                  Create dev databases, copy connection strings, and confirm production is protected.
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <a className={buttonVariants()} href="#branches">
-                  <GitBranch />
-                  New branch
-                </a>
-                <Button
-                  variant="outline"
-                  onClick={function refreshPage() {
-                    void dashboard.refetch();
-                  }}
-                >
-                  <RefreshCw />
-                  Refresh
-                </Button>
-                <Button
-                  onClick={function createReplicaClick() {
-                    void handleCreateReplica();
-                  }}
-                  disabled={busy === 'create-replica' || !prodServer}
-                >
-                  {busy === 'create-replica' ? <Loader2 className="animate-spin" /> : <Play />}
-                  Sync replica
-                </Button>
-              </div>
+            <header className="pt-2">
+              <h1 className="text-3xl font-semibold tracking-normal md:text-4xl">Branches</h1>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Pick a database branch.
+              </p>
             </header>
 
-            <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-              <MetricCard title="Production" value={state.prodConnectionUrl ? 'Ready' : 'Pending'} detail={prodServer?.host || 'no host'} icon={Database} tone="emerald" />
-              <MetricCard title="Backups" value={backupMode} detail={backupsStep?.status || 'pending'} icon={ArchiveRestore} tone="blue" />
-              <MetricCard title="Branches" value={String(state.branches.length)} detail="ready to use" icon={GitBranch} tone="violet" />
-              <MetricCard title="Active work" value={String(activeJobs)} detail="running jobs" icon={Activity} tone="amber" />
-            </section>
-
-            <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_390px]">
-              <div id="branches" className="scroll-mt-6">
-                <BranchesPanel
-                  branches={state.branches}
-                  busy={busy}
-                  onCreate={handleCreateBranch}
-                  onDelete={handleDeleteBranch}
-                />
-              </div>
-
-              <div className="grid content-start gap-6">
-                <ProductionSummaryPanel
-                  connectionUrl={state.prodConnectionUrl}
-                  serverHost={prodServer?.host || null}
-                  backupStatus={backupsStep?.status || 'pending'}
-                  backupMessage={backupsStep?.message || null}
-                  backupMode={backupMode}
-                />
-                <SystemPanel
-                  setupDone={doneSteps}
-                  setupTotal={state.setupSteps.length}
-                  healthyServers={state.servers.filter(function countOk(server) {
-                    return server.status === 'ok';
-                  }).length}
-                  totalServers={state.servers.length}
-                  backupMode={backupMode}
-                  activeJobs={activeJobs}
-                />
-              </div>
-            </div>
-
-            {!setupComplete ? (
-              <SetupPanel
-                steps={state.setupSteps}
-                busy={busy}
-                prodServerReady={Boolean(prodServer)}
-                onBootstrap={handleBootstrap}
-                onCreateReplica={handleCreateReplica}
-              />
-            ) : null}
+            <BranchTreePanel branches={state.branches} prodReady={Boolean(state.prodConnectionUrl)} />
           </div>
         </section>
       </div>

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -8,9 +8,11 @@ import { orpc } from '#web/lib/api-client';
 import {
   AppSidebar,
   BackupPanel,
+  BranchesPanel,
   JobsPanel,
   MetricCard,
   ServerPanel,
+  SetupPanel,
   StatusBadge,
   SystemPanel,
   type ServerRole,
@@ -26,6 +28,10 @@ function SettingsPage() {
   const saveServer = useMutation(orpc.servers.update.mutationOptions({ onSuccess: refreshDashboard }));
   const checkServer = useMutation(orpc.servers.check.mutationOptions({ onSuccess: refreshDashboard }));
   const saveBackupSettings = useMutation(orpc.backup.settings.update.mutationOptions({ onSuccess: refreshDashboard }));
+  const startBootstrap = useMutation(orpc.bootstrap.start.mutationOptions({ onSuccess: refreshDashboard }));
+  const createBranch = useMutation(orpc.branches.create.mutationOptions({ onSuccess: refreshDashboard }));
+  const deleteBranch = useMutation(orpc.branches.delete.mutationOptions({ onSuccess: refreshDashboard }));
+  const createReplicaBase = useMutation(orpc.replicaBase.create.mutationOptions({ onSuccess: refreshDashboard }));
   const busy = getBusyKey();
   const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
     return job.status === 'queued' || job.status === 'running';
@@ -60,6 +66,22 @@ function SettingsPage() {
 
     if (saveBackupSettings.isPending) {
       return 'save-backup';
+    }
+
+    if (startBootstrap.isPending) {
+      return `bootstrap-${startBootstrap.variables?.target || 'dev'}`;
+    }
+
+    if (createBranch.isPending) {
+      return 'create-branch';
+    }
+
+    if (deleteBranch.isPending) {
+      return `delete-branch-${deleteBranch.variables?.id}`;
+    }
+
+    if (createReplicaBase.isPending) {
+      return 'create-replica';
     }
 
     return null;
@@ -113,10 +135,27 @@ function SettingsPage() {
     });
   }
 
+  async function handleBootstrap(kind: ServerRole) {
+    await startBootstrap.mutateAsync({ target: kind });
+  }
+
+  async function handleCreateBranch(formData: FormData) {
+    const name = String(formData.get('name') || '');
+    await createBranch.mutateAsync({ name });
+  }
+
+  async function handleDeleteBranch(id: number) {
+    await deleteBranch.mutateAsync({ id });
+  }
+
+  async function handleCreateReplica() {
+    await createReplicaBase.mutateAsync(undefined);
+  }
+
   return (
     <main className="min-h-screen bg-background text-foreground">
       <div className="grid min-h-screen lg:grid-cols-[244px_1fr]">
-        <AppSidebar branches={state.branches} activeProject="settings" selectedBranch="prod" />
+        <AppSidebar branches={state.branches} activeProject="settings" />
 
         <section className="min-w-0">
           <div className="mx-auto grid w-full max-w-[1400px] gap-6 px-4 py-6 sm:px-6 lg:px-8">
@@ -146,6 +185,19 @@ function SettingsPage() {
 
             <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_390px]">
               <div className="grid min-w-0 gap-6">
+                <SetupPanel
+                  steps={state.setupSteps}
+                  busy={busy}
+                  prodServerReady={Boolean(prodServer)}
+                  onBootstrap={handleBootstrap}
+                  onCreateReplica={handleCreateReplica}
+                />
+                <BranchesPanel
+                  branches={state.branches}
+                  busy={busy}
+                  onCreate={handleCreateBranch}
+                  onDelete={handleDeleteBranch}
+                />
                 <div className="grid gap-6 lg:grid-cols-2">
                   <ServerPanel title="Production" role="prod" server={prodServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
                   <ServerPanel title="Development" role="dev" server={devServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />


### PR DESCRIPTION
## Summary
- simplify the dashboard to a branch tree with production first
- move setup, branch management, and system controls to settings
- keep branch navigation persistent across dashboard, settings, and branch pages
- use TanStack Router navigation for internal links to avoid full reloads

## Validation
- bun run typecheck
- bun run web:build
