### PR TITLE
fix(sql): surface sql editor errors

### DIFF
--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ORPCError } from '@orpc/server';
 import { getDb } from '#db/client';
 import { publicProcedure } from './context';
 import { createJob, runJob } from '#server/services/job-service';
@@ -73,7 +74,16 @@ export const branchesRouter = {
     run: publicProcedure
       .input(runSqlInput)
       .handler(async function runSql({ input }) {
-        return runBranchSql(input);
+        try {
+          return await runBranchSql(input);
+        } catch (error: any) {
+          const message = error?.message || 'SQL failed';
+
+          throw new ORPCError('BAD_REQUEST', {
+            message,
+            data: { message },
+          });
+        }
       }),
   },
   restore: publicProcedure

--- a/src/web/routes/branch/$branchId/sql.tsx
+++ b/src/web/routes/branch/$branchId/sql.tsx
@@ -54,7 +54,7 @@ function SqlEditorPage() {
       });
       setResult(nextResult);
     } catch (caught: any) {
-      setError(caught?.message || 'SQL failed');
+      setError(getErrorMessage(caught, 'SQL failed'));
       setResult(null);
     }
   }
@@ -212,6 +212,10 @@ function formatDuration(durationMs: number): string {
   }
 
   return `${(durationMs / 1000).toFixed(2)} s`;
+}
+
+function getErrorMessage(error: any, fallback: string): string {
+  return error?.data?.message || error?.json?.data?.message || error?.message || fallback;
 }
 
 function SqlLoadingPage(props: { message: string }) {


### PR DESCRIPTION
## What changed

- Return SQL editor failures as client-visible BAD_REQUEST errors.
- Include the raw SQL error message in structured error data.
- Read structured error messages in the SQL editor UI.

## API routes, procedures, contracts

- Updated `branches.sql.run` error contract to return `BAD_REQUEST` with `data.message` for SQL execution failures.
- No routes added or deleted.

## Why

Invalid SQL showed only `Internal server error`, hiding the useful Postgres message.

## Validation

- `bun run typecheck`
- `bun test src/server/control-plane.test.ts`
