### PR TITLE
fix(branch): bind data actions to current branch

### DIFF
--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { getDb } from '#db/client';
 import { publicProcedure } from './context';
+import { userFacingError } from './errors';
 import { createJob, runJob } from '#server/services/job-service';
 import { createBranchFromBase, createPreviewBranch, deleteBranch, normalizeBranchSlug, resetBranchFromParent } from '#server/services/branch-service';
 import { restoreDevelopmentBranchFromPgBackRest, restoreProductionFromPgBackRest } from '#server/services/pgbackrest-restore-service';
@@ -73,7 +74,11 @@ export const branchesRouter = {
     run: publicProcedure
       .input(runSqlInput)
       .handler(async function runSql({ input }) {
-        return runBranchSql(input);
+        try {
+          return await runBranchSql(input);
+        } catch (error) {
+          throw userFacingError(error, 'SQL failed');
+        }
       }),
   },
   restore: publicProcedure

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,0 +1,50 @@
+import { ORPCError } from '@orpc/server';
+
+export function userFacingError(error: unknown, fallback: string): ORPCError<'BAD_REQUEST', undefined> {
+  return new ORPCError('BAD_REQUEST', {
+    message: getErrorMessage(error, fallback),
+    cause: error,
+  });
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) {
+    return formatErrorMessage(error);
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error;
+  }
+
+  return fallback;
+}
+
+function formatErrorMessage(error: Error): string {
+  const parts = [error.message];
+  const detail = getStringProperty(error, 'detail');
+  const hint = getStringProperty(error, 'hint');
+
+  if (detail) {
+    parts.push(detail);
+  }
+
+  if (hint) {
+    parts.push(`Hint: ${hint}`);
+  }
+
+  return parts.join('\n');
+}
+
+function getStringProperty(value: unknown, key: string): string | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const item = (value as Record<string, unknown>)[key];
+
+  if (typeof item === 'string' && item.trim()) {
+    return item;
+  }
+
+  return null;
+}

--- a/src/api/tables.ts
+++ b/src/api/tables.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import { publicProcedure } from './context';
-import { getTableBrowserMetadata, getTableRows } from '#server/services/table-browser-service';
+import { userFacingError } from './errors';
+import {
+  deleteTableRow,
+  getTableBrowserMetadata,
+  getTableRows,
+  insertTableRow,
+  updateTableRow,
+} from '#server/services/table-browser-service';
 
 const tableBrowserInput = z.object({
   branchId: z.string().min(1),
@@ -17,6 +24,24 @@ const tableRowsInput = z.object({
   offset: z.number().int().min(0).optional(),
 });
 
+const tableRowValues = z.record(z.string(), z.string().nullable());
+
+const tableInsertInput = z.object({
+  branchId: z.string().min(1),
+  database: z.string().min(1),
+  schema: z.string().min(1),
+  table: z.string().min(1),
+  values: tableRowValues,
+});
+
+const tableUpdateInput = tableInsertInput.extend({
+  rowId: z.string().min(1),
+});
+
+const tableDeleteInput = tableRowsInput.extend({
+  rowId: z.string().min(1),
+});
+
 export const tablesRouter = {
   browse: publicProcedure
     .input(tableBrowserInput)
@@ -27,5 +52,32 @@ export const tablesRouter = {
     .input(tableRowsInput)
     .handler(async function browseRows({ input }) {
       return getTableRows(input);
+    }),
+  insert: publicProcedure
+    .input(tableInsertInput)
+    .handler(async function insertRow({ input }) {
+      try {
+        return await insertTableRow(input);
+      } catch (error) {
+        throw userFacingError(error, 'Could not insert row');
+      }
+    }),
+  update: publicProcedure
+    .input(tableUpdateInput)
+    .handler(async function updateRow({ input }) {
+      try {
+        return await updateTableRow(input);
+      } catch (error) {
+        throw userFacingError(error, 'Could not update row');
+      }
+    }),
+  delete: publicProcedure
+    .input(tableDeleteInput)
+    .handler(async function deleteRow({ input }) {
+      try {
+        return await deleteTableRow(input);
+      } catch (error) {
+        throw userFacingError(error, 'Could not delete row');
+      }
     }),
 };

--- a/src/server/services/table-browser-service.ts
+++ b/src/server/services/table-browser-service.ts
@@ -17,6 +17,26 @@ export interface TableRowsInput {
   offset?: number | undefined;
 }
 
+export interface TableRowInsertInput {
+  branchId: string;
+  database: string;
+  schema: string;
+  table: string;
+  values: Record<string, string | null>;
+}
+
+export interface TableRowUpdateInput extends TableRowInsertInput {
+  rowId: string;
+}
+
+export interface TableRowDeleteInput {
+  branchId: string;
+  database: string;
+  schema: string;
+  table: string;
+  rowId: string;
+}
+
 export interface TableBrowserTable {
   schema: string;
   name: string;
@@ -43,6 +63,10 @@ export interface TableBrowserMetadata {
 }
 
 export interface TableRowsResult {
+  branchId: string;
+  database: string;
+  schema: string;
+  table: string;
   columns: TableBrowserColumn[];
   rows: Array<Record<string, unknown>>;
   rowLimit: number;
@@ -60,6 +84,12 @@ export interface TableBrowserResult extends TableBrowserMetadata, TableRowsResul
 }
 
 const ROW_LIMIT = 50;
+export const TABLE_ROW_ID_COLUMN = '__velo_ctid';
+const BOOLEAN_TYPES = new Set(['boolean']);
+const INTEGER_TYPES = new Set(['smallint', 'integer', 'bigint']);
+const NUMBER_TYPES = new Set(['real', 'double precision', 'numeric', 'decimal']);
+const JSON_TYPES = new Set(['json', 'jsonb']);
+const ARRAY_TYPES = new Set(['array']);
 
 export async function getTableBrowser(input: TableBrowserInput): Promise<TableBrowserResult> {
   const metadata = await getTableBrowserMetadata(input);
@@ -67,6 +97,9 @@ export async function getTableBrowser(input: TableBrowserInput): Promise<TableBr
   if (!metadata.selectedTable || !metadata.selectedSchema) {
     return {
       ...metadata,
+      database: metadata.selectedDatabase,
+      schema: metadata.selectedSchema || '',
+      table: metadata.selectedTable?.name || '',
       columns: [],
       rows: [],
       rowLimit: ROW_LIMIT,
@@ -160,6 +193,10 @@ export async function getTableRows(input: TableRowsInput): Promise<TableRowsResu
     const rows = await listRows(sql, table, columns, rowOffset);
 
     return {
+      branchId: input.branchId,
+      database: input.database,
+      schema: input.schema,
+      table: input.table,
       columns,
       rows,
       rowLimit: ROW_LIMIT,
@@ -167,6 +204,73 @@ export async function getTableRows(input: TableRowsInput): Promise<TableRowsResu
       rowCount,
       elapsedMs: Math.max(0, Math.round(performance.now() - startedAt)),
     };
+  } finally {
+    await sql.close({ timeout: 0 });
+  }
+}
+
+export async function insertTableRow(input: TableRowInsertInput): Promise<void> {
+  const connectionUrl = await getBranchConnectionUrl(input.branchId);
+
+  if (!connectionUrl) {
+    throw new Error(`No connection string found for ${input.branchId}`);
+  }
+
+  const sql = createSql(withDatabase(connectionUrl, input.database));
+
+  try {
+    const table = {
+      schema: input.schema,
+      name: input.table,
+      rowEstimate: 0,
+    };
+    const columns = await listColumns(sql, table);
+    const parts = buildMutationSql(input.values, columns);
+    const tableName = `${quoteIdentifier(table.schema)}.${quoteIdentifier(table.name)}`;
+    await sql.unsafe(`insert into ${tableName} (${parts.columnsSql}) values (${parts.valuesSql})`);
+  } finally {
+    await sql.close({ timeout: 0 });
+  }
+}
+
+export async function updateTableRow(input: TableRowUpdateInput): Promise<void> {
+  const connectionUrl = await getBranchConnectionUrl(input.branchId);
+
+  if (!connectionUrl) {
+    throw new Error(`No connection string found for ${input.branchId}`);
+  }
+
+  const sql = createSql(withDatabase(connectionUrl, input.database));
+
+  try {
+    const table = {
+      schema: input.schema,
+      name: input.table,
+      rowEstimate: 0,
+    };
+    const columns = await listColumns(sql, table);
+    const parts = buildMutationSql(input.values, columns);
+    const tableName = `${quoteIdentifier(table.schema)}.${quoteIdentifier(table.name)}`;
+    const result = await sql.unsafe(`update ${tableName} set ${parts.setSql} where ctid = '${escapeSqlString(input.rowId)}'::tid`);
+    assertRowWasChanged(result, 'Row no longer exists');
+  } finally {
+    await sql.close({ timeout: 0 });
+  }
+}
+
+export async function deleteTableRow(input: TableRowDeleteInput): Promise<void> {
+  const connectionUrl = await getBranchConnectionUrl(input.branchId);
+
+  if (!connectionUrl) {
+    throw new Error(`No connection string found for ${input.branchId}`);
+  }
+
+  const sql = createSql(withDatabase(connectionUrl, input.database));
+
+  try {
+    const tableName = `${quoteIdentifier(input.schema)}.${quoteIdentifier(input.table)}`;
+    const result = await sql.unsafe(`delete from ${tableName} where ctid = '${escapeSqlString(input.rowId)}'::tid`);
+    assertRowWasChanged(result, 'Row no longer exists');
   } finally {
     await sql.close({ timeout: 0 });
   }
@@ -284,7 +388,7 @@ async function listRows(
   const tableName = `${quoteIdentifier(table.schema)}.${quoteIdentifier(table.name)}`;
   const orderBy = columns[0] ? ` order by ${quoteIdentifier(columns[0].name)}` : '';
   const rows = await sql.unsafe<Array<Record<string, unknown>>>(
-    `select * from ${tableName}${orderBy} limit ${ROW_LIMIT} offset ${offset}`
+    `select *, ctid::text as ${quoteIdentifier(TABLE_ROW_ID_COLUMN)} from ${tableName}${orderBy} limit ${ROW_LIMIT} offset ${offset}`
   );
   return rows.map(function normalizeRow(row) {
     return normalizeValue(row) as Record<string, unknown>;
@@ -354,6 +458,144 @@ function createSql(connectionUrl: string): SQL {
 
 function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
+}
+
+function assertRowWasChanged(result: unknown, message: string): void {
+  const count = typeof result === 'object' && result !== null
+    ? Number((result as { count?: unknown }).count ?? 0)
+    : 0;
+
+  if (count === 0) {
+    throw new Error(message);
+  }
+}
+
+function escapeSqlString(value: string): string {
+  return value.replaceAll("'", "''");
+}
+
+function buildMutationSql(
+  values: Record<string, string | null>,
+  columns: TableBrowserColumn[]
+): { columnsSql: string; valuesSql: string; setSql: string } {
+  const columnByName = new Map(
+    columns.map(function toEntry(column) {
+      return [column.name, column] as const;
+    })
+  );
+  const entries = Object.entries(values).filter(function keepKnownColumn([name]) {
+    return name !== TABLE_ROW_ID_COLUMN && columnByName.has(name);
+  });
+
+  if (entries.length === 0) {
+    throw new Error('Add at least one value');
+  }
+
+  const prepared = entries.map(function prepareValue([name, value]) {
+    const column = columnByName.get(name);
+
+    if (!column) {
+      throw new Error(`Unknown column: ${name}`);
+    }
+
+    return {
+      column,
+      sqlValue: toTypedSqlLiteral(value, column),
+    };
+  });
+
+  return {
+    columnsSql: prepared.map(function getColumnSql(item) {
+      return quoteIdentifier(item.column.name);
+    }).join(', '),
+    valuesSql: prepared.map(function getValueSql(item) {
+      return item.sqlValue;
+    }).join(', '),
+    setSql: prepared.map(function getSetSql(item) {
+      return `${quoteIdentifier(item.column.name)} = ${item.sqlValue}`;
+    }).join(', '),
+  };
+}
+
+function toTypedSqlLiteral(value: string | null, column: TableBrowserColumn): string {
+  if (value === null) {
+    return 'NULL';
+  }
+
+  const dataType = column.type.toLowerCase();
+  const trimmed = value.trim();
+
+  if (BOOLEAN_TYPES.has(dataType)) {
+    if (['true', 't', '1', 'yes', 'y'].includes(trimmed.toLowerCase())) {
+      return 'TRUE';
+    }
+
+    if (['false', 'f', '0', 'no', 'n'].includes(trimmed.toLowerCase())) {
+      return 'FALSE';
+    }
+
+    throw new Error(`${column.name} expects boolean`);
+  }
+
+  if (INTEGER_TYPES.has(dataType)) {
+    if (!/^-?\d+$/.test(trimmed)) {
+      throw new Error(`${column.name} expects integer`);
+    }
+
+    return trimmed;
+  }
+
+  if (NUMBER_TYPES.has(dataType)) {
+    const numeric = Number(trimmed);
+
+    if (!Number.isFinite(numeric)) {
+      throw new Error(`${column.name} expects number`);
+    }
+
+    return trimmed;
+  }
+
+  if (JSON_TYPES.has(dataType)) {
+    try {
+      return `'${escapeSqlString(JSON.stringify(JSON.parse(value)))}'::${dataType}`;
+    } catch {
+      throw new Error(`${column.name} expects JSON`);
+    }
+  }
+
+  if (ARRAY_TYPES.has(dataType)) {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new Error(`${column.name} expects JSON array`);
+    }
+
+    if (!Array.isArray(parsed)) {
+      throw new Error(`${column.name} expects JSON array`);
+    }
+
+    return `ARRAY[${parsed.map(formatArrayItem).join(', ')}]`;
+  }
+
+  return `'${escapeSqlString(value)}'`;
+}
+
+function formatArrayItem(value: unknown): string {
+  if (value === null) {
+    return 'NULL';
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (typeof value === 'object') {
+    return `'${escapeSqlString(JSON.stringify(value))}'`;
+  }
+
+  return `'${escapeSqlString(String(value))}'`;
 }
 
 function normalizeValue(value: unknown): unknown {

--- a/src/web/routes/branch/$branchId/sql.tsx
+++ b/src/web/routes/branch/$branchId/sql.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import type { FormEvent } from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Database,
   GitBranch,
@@ -32,9 +32,16 @@ function SqlEditorPage() {
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
   const runSql = useMutation(orpc.branches.sql.run.mutationOptions());
   const params = Route.useParams();
+  const currentBranchIdRef = useRef(params.branchId);
   const [sql, setSql] = useState('select * from velo_local_notes limit 20;');
   const [result, setResult] = useState<SqlResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(function syncCurrentBranch() {
+    currentBranchIdRef.current = params.branchId;
+    setResult(null);
+    setError(null);
+  }, [params.branchId]);
 
   if (!dashboard.data) {
     return <SqlLoadingPage message={dashboard.error ? 'Could not load branch.' : 'Loading branch...'} />;
@@ -45,15 +52,25 @@ function SqlEditorPage() {
 
   async function handleRunSql(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const branchId = params.branchId;
     setError(null);
 
     try {
       const nextResult = await runSql.mutateAsync({
-        branchId: branch.id,
+        branchId,
         sql,
       });
+
+      if (currentBranchIdRef.current !== branchId) {
+        return;
+      }
+
       setResult(nextResult);
     } catch (caught: any) {
+      if (currentBranchIdRef.current !== branchId) {
+        return;
+      }
+
       setError(caught?.message || 'SQL failed');
       setResult(null);
     }
@@ -93,7 +110,7 @@ function SqlEditorPage() {
                     type="submit"
                     size="sm"
                     className="h-8"
-                    disabled={runSql.isPending || !sql.trim()}
+                    disabled={runSql.isPending || !sql.trim() || branch.status === 'missing'}
                   >
                     {runSql.isPending ? <Loader2 className="animate-spin" /> : <Play />}
                     Run

--- a/src/web/routes/branch/$branchId/tables.tsx
+++ b/src/web/routes/branch/$branchId/tables.tsx
@@ -1,18 +1,43 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import type { FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import {
   ChevronLeft,
   ChevronRight,
   Database,
+  Loader2,
+  Pencil,
+  Plus,
   RefreshCw,
   Search,
   Table2,
+  Trash2,
 } from 'lucide-react';
 import { AppSidebar } from '#web/components/control-plane';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '#web/components/ui/alert-dialog';
 import { Badge } from '#web/components/ui/badge';
 import { Button } from '#web/components/ui/button';
+import { Checkbox } from '#web/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#web/components/ui/dialog';
 import { Input } from '#web/components/ui/input';
+import { Label } from '#web/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -28,11 +53,17 @@ export const Route = createFileRoute('/branch/$branchId/tables')({
   component: BranchTablesPage,
 });
 
+const TABLE_ROW_ID_COLUMN = '__velo_ctid';
+
 function BranchTablesPage() {
   const params = Route.useParams();
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
   const [selected, setSelected] = useState<TableKey | null>(null);
   const [search, setSearch] = useState('');
+  const [editor, setEditor] = useState<RowEditorState | null>(null);
+  const [editorError, setEditorError] = useState<string | null>(null);
+  const [rowToDelete, setRowToDelete] = useState<DeleteRowState | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const metadata = useQuery(orpc.tables.browse.queryOptions({
     input: {
       branchId: params.branchId,
@@ -58,6 +89,23 @@ function BranchTablesPage() {
       return previousData;
     },
   });
+  const insertRow = useMutation(orpc.tables.insert.mutationOptions({
+    onSuccess: refreshAfterMutation,
+  }));
+  const updateRow = useMutation(orpc.tables.update.mutationOptions({
+    onSuccess: refreshAfterMutation,
+  }));
+  const deleteRow = useMutation(orpc.tables.delete.mutationOptions({
+    onSuccess: refreshAfterMutation,
+  }));
+
+  useEffect(function resetBranchScopedState() {
+    setSelected(null);
+    setEditor(null);
+    setEditorError(null);
+    setRowToDelete(null);
+    setDeleteError(null);
+  }, [params.branchId]);
 
   useEffect(function setInitialTable() {
     if (selected || !metadata.data?.selectedTable) {
@@ -106,24 +154,199 @@ function BranchTablesPage() {
     });
   }
 
+  function refreshAfterMutation() {
+    void rows.refetch();
+  }
+
+  function getCurrentRowsTarget(): TableActionTarget | null {
+    if (!rows.data || !rowDataMatches(rows.data, params.branchId, selectedDatabase, selectedSchema, selectedTable)) {
+      return null;
+    }
+
+    return {
+      branchId: rows.data.branchId,
+      database: rows.data.database,
+      schema: rows.data.schema,
+      table: rows.data.table,
+    };
+  }
+
+  function openAddRow() {
+    const target = getCurrentRowsTarget();
+
+    if (!rows.data || !target) {
+      return;
+    }
+
+    setEditor({
+      mode: 'insert',
+      target,
+      rowId: null,
+      fields: createInsertDraft(rows.data.columns),
+    });
+    setEditorError(null);
+  }
+
+  function openEditRow(row: Record<string, unknown>) {
+    const target = getCurrentRowsTarget();
+
+    if (!rows.data || !target) {
+      return;
+    }
+
+    setEditor({
+      mode: 'edit',
+      target,
+      rowId: formatCell(row[TABLE_ROW_ID_COLUMN]),
+      fields: createEditDraft(rows.data.columns, row),
+    });
+    setEditorError(null);
+  }
+
+  function openDeleteRow(row: Record<string, unknown>) {
+    const target = getCurrentRowsTarget();
+
+    if (!rows.data || !target) {
+      return;
+    }
+
+    setRowToDelete({
+      target,
+      rowId: formatCell(row[TABLE_ROW_ID_COLUMN]),
+      label: createDeleteLabel(row, rows.data.columns),
+    });
+    setDeleteError(null);
+  }
+
+  function closeEditor() {
+    if (insertRow.isPending || updateRow.isPending) {
+      return;
+    }
+
+    setEditor(null);
+    setEditorError(null);
+  }
+
+  function closeDeleteDialog() {
+    if (deleteRow.isPending) {
+      return;
+    }
+
+    setRowToDelete(null);
+    setDeleteError(null);
+  }
+
+  async function confirmDeleteRow() {
+    if (!rowToDelete) {
+      return;
+    }
+
+    if (rowToDelete.target.branchId !== params.branchId) {
+      setDeleteError('Branch changed. Reopen this row from the current branch.');
+      return;
+    }
+
+    try {
+      setDeleteError(null);
+      await deleteRow.mutateAsync({
+        branchId: rowToDelete.target.branchId,
+        database: rowToDelete.target.database,
+        schema: rowToDelete.target.schema,
+        table: rowToDelete.target.table,
+        rowId: rowToDelete.rowId,
+      });
+      setRowToDelete(null);
+    } catch (caught: any) {
+      setDeleteError(caught?.message || 'Could not delete row');
+    }
+  }
+
+  function updateDraftField(column: string, patch: Partial<RowDraftField>) {
+    setEditor(function updateCurrentEditor(current) {
+      if (!current) {
+        return current;
+      }
+
+      return {
+        ...current,
+        fields: current.fields.map(function updateField(field) {
+          if (field.column !== column) {
+            return field;
+          }
+
+          return {
+            ...field,
+            ...patch,
+          };
+        }),
+      };
+    });
+  }
+
+  async function saveEditor(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!editor) {
+      return;
+    }
+
+    if (editor.target.branchId !== params.branchId) {
+      setEditorError('Branch changed. Reopen this row from the current branch.');
+      return;
+    }
+
+    const values = buildEditorValues(editor);
+
+    try {
+      setEditorError(null);
+
+      if (editor.mode === 'insert') {
+        await insertRow.mutateAsync({
+          branchId: editor.target.branchId,
+          database: editor.target.database,
+          schema: editor.target.schema,
+          table: editor.target.table,
+          values,
+        });
+      } else if (editor.rowId) {
+        await updateRow.mutateAsync({
+          branchId: editor.target.branchId,
+          database: editor.target.database,
+          schema: editor.target.schema,
+          table: editor.target.table,
+          rowId: editor.rowId,
+          values,
+        });
+      }
+
+      setEditor(null);
+    } catch (caught: any) {
+      setEditorError(caught?.message || 'Could not save row');
+    }
+  }
+
   const rowOffset = rows.data?.rowOffset || selected?.offset || 0;
   const rowLimit = rows.data?.rowLimit || 50;
   const rowEnd = rows.data ? Math.min(rows.data.rowOffset + rows.data.rowLimit, rows.data.rowCount) : rowOffset + rowLimit;
   const canPageBack = rowOffset > 0;
   const canPageForward = rows.data ? rowOffset + rowLimit < rows.data.rowCount : false;
+  const saving = insertRow.isPending || updateRow.isPending;
+  const deleting = deleteRow.isPending;
+  const rowsReady = Boolean(rows.data && rowDataMatches(rows.data, params.branchId, selectedDatabase, selectedSchema, selectedTable));
 
   return (
-    <main className="min-h-screen bg-background text-foreground">
-      <div className="grid min-h-screen lg:grid-cols-[244px_1fr]">
-        <AppSidebar branches={branches} activeBranchPage="tables" selectedBranch={params.branchId} />
+    <>
+      <main className="min-h-screen bg-background text-foreground">
+        <div className="grid min-h-screen lg:grid-cols-[244px_1fr]">
+          <AppSidebar branches={branches} activeBranchPage="tables" selectedBranch={params.branchId} />
 
-        <section className="grid min-h-screen min-w-0 grid-rows-[auto_1fr]">
+          <section className="grid min-h-screen min-w-0 grid-rows-[auto_1fr]">
           <header className="border-b border-border px-5 py-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <div className="flex items-center gap-2">
                   <Badge variant="outline">Tables</Badge>
-                  <Badge variant="secondary">read only</Badge>
+                  <Badge variant="secondary">editable</Badge>
                 </div>
                 <h1 className="mt-2 text-2xl font-semibold tracking-normal">Tables</h1>
                 <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
@@ -233,6 +456,17 @@ function BranchTablesPage() {
                 <div className="text-xs text-muted-foreground">
                   {rows.data ? `${rows.data.rowLimit} rows · ${rows.data.elapsedMs}ms` : 'Loading...'}
                 </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  disabled={!rowsReady || !rows.data || rows.data.columns.length === 0}
+                  onClick={openAddRow}
+                >
+                  <Plus className="size-3.5" />
+                  Add row
+                </Button>
                 <div className="flex h-8 overflow-hidden rounded-md border border-input bg-background">
                   <Button
                     type="button"
@@ -279,12 +513,108 @@ function BranchTablesPage() {
                 </Button>
               </div>
 
-              <TableGrid data={rows.data} loading={rows.isLoading} error={rows.error} />
+              <TableGrid
+                data={rows.data}
+                loading={rows.isLoading}
+                error={rows.error}
+                actionsDisabled={!rowsReady}
+                onEditRow={openEditRow}
+                onDeleteRow={openDeleteRow}
+              />
             </div>
           </div>
-        </section>
-      </div>
-    </main>
+          </section>
+        </div>
+      </main>
+
+      <Dialog open={editor !== null} onOpenChange={function handleEditorOpenChange(open) {
+        if (!open) {
+          closeEditor();
+        }
+      }}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>{editor?.mode === 'insert' ? 'Add row' : 'Edit row'}</DialogTitle>
+            <DialogDescription>
+              {editor ? `${editor.target.schema}.${editor.target.table}` : `${selectedSchema}.${selectedTable}`}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="grid gap-4" onSubmit={saveEditor}>
+            {editorError ? (
+              <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {editorError}
+              </div>
+            ) : null}
+
+            {editor ? (
+              <RowFieldsEditor
+                fields={editor.fields}
+                mode={editor.mode}
+                disabled={saving}
+                onChangeField={updateDraftField}
+              />
+            ) : null}
+
+            <DialogFooter>
+              <Button type="button" variant="ghost" disabled={saving} onClick={closeEditor}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving || !editor}>
+                {saving ? <Loader2 className="animate-spin" /> : null}
+                Save
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={rowToDelete !== null} onOpenChange={function handleDeleteOpenChange(open) {
+        if (!open) {
+          closeDeleteDialog();
+        }
+      }}>
+        <AlertDialogContent
+          onKeyDown={function handleDeleteDialogKeyDown(event) {
+            if (event.key !== 'Enter' || deleting) {
+              return;
+            }
+
+            event.preventDefault();
+            void confirmDeleteRow();
+          }}
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete row?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {rowToDelete ? `Delete ${rowToDelete.label} from ${rowToDelete.target.schema}.${rowToDelete.target.table}.` : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {deleteError ? (
+            <div className="whitespace-pre-wrap rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {deleteError}
+            </div>
+          ) : null}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              autoFocus
+              className="bg-destructive text-white hover:bg-destructive/90"
+              disabled={deleting}
+              onClick={function deleteConfirmed(event) {
+                event.preventDefault();
+                void confirmDeleteRow();
+              }}
+            >
+              {deleting ? <Loader2 className="animate-spin" /> : null}
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 
@@ -299,6 +629,9 @@ interface TableGridProps {
   data: Awaited<ReturnType<typeof orpc.tables.rows.call>> | undefined;
   loading: boolean;
   error: Error | null;
+  actionsDisabled: boolean;
+  onEditRow: (row: Record<string, unknown>) => void;
+  onDeleteRow: (row: Record<string, unknown>) => void;
 }
 
 function TableGrid(props: TableGridProps) {
@@ -335,19 +668,20 @@ function TableGrid(props: TableGridProps) {
                 </th>
               );
             })}
+            <th className="sticky right-0 z-20 h-9 w-20 border-b border-l border-r border-border bg-white px-3 text-left font-medium text-muted-foreground" />
           </tr>
         </thead>
         <tbody>
           {props.data.rows.length === 0 ? (
             <tr>
-              <td className="p-6 text-sm text-muted-foreground" colSpan={data.columns.length + 1}>
+              <td className="p-6 text-sm text-muted-foreground" colSpan={data.columns.length + 2}>
                 No rows.
               </td>
             </tr>
           ) : (
             data.rows.map(function renderRow(row, index) {
               return (
-                <tr key={index} className="hover:bg-muted/40">
+                <tr key={index} className="group hover:bg-muted/40">
                   <td className="h-9 border-b border-r border-border px-3 font-mono text-xs text-muted-foreground">
                     {data.rowOffset + index + 1}
                   </td>
@@ -362,12 +696,196 @@ function TableGrid(props: TableGridProps) {
                       </td>
                     );
                   })}
+                  <td className="sticky right-0 h-9 border-b border-l border-r border-border bg-white px-2 group-hover:bg-white">
+                    <div className="flex items-center gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 bg-white hover:bg-accent"
+                        aria-label="Edit row"
+                        disabled={props.actionsDisabled}
+                        onClick={function editRow() {
+                          props.onEditRow(row);
+                        }}
+                      >
+                        <Pencil className="size-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 bg-white hover:bg-accent"
+                        aria-label="Delete row"
+                        disabled={props.actionsDisabled}
+                        onClick={function deleteRow() {
+                          props.onDeleteRow(row);
+                        }}
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    </div>
+                  </td>
                 </tr>
               );
             })
           )}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+type RowEditorMode = 'insert' | 'edit';
+
+interface TableActionTarget {
+  branchId: string;
+  database: string;
+  schema: string;
+  table: string;
+}
+
+interface RowDraftField {
+  column: string;
+  type: string;
+  value: string;
+  isNull: boolean;
+  enabled: boolean;
+}
+
+interface RowEditorState {
+  mode: RowEditorMode;
+  target: TableActionTarget;
+  rowId: string | null;
+  fields: RowDraftField[];
+}
+
+interface DeleteRowState {
+  target: TableActionTarget;
+  rowId: string;
+  label: string;
+}
+
+function createInsertDraft(columns: Array<{ name: string; type: string; nullable: boolean; defaultValue: string | null }>): RowDraftField[] {
+  return columns.map(function createField(column) {
+    return {
+      column: column.name,
+      type: column.type,
+      value: '',
+      isNull: column.nullable && column.defaultValue === null,
+      enabled: column.defaultValue === null,
+    };
+  });
+}
+
+function createEditDraft(columns: Array<{ name: string; type: string }>, row: Record<string, unknown>): RowDraftField[] {
+  return columns.map(function createField(column) {
+    const value = row[column.name];
+    const isNull = value === null;
+
+    return {
+      column: column.name,
+      type: column.type,
+      value: isNull ? '' : formatCell(value),
+      isNull,
+      enabled: true,
+    };
+  });
+}
+
+function createDeleteLabel(row: Record<string, unknown>, columns: Array<{ name: string }>): string {
+  const firstColumn = columns[0]?.name;
+
+  if (!firstColumn) {
+    return `row ${formatCell(row[TABLE_ROW_ID_COLUMN])}`;
+  }
+
+  const firstValue = formatCell(row[firstColumn]);
+  return `${firstColumn} ${firstValue}`;
+}
+
+function rowDataMatches(
+  data: Awaited<ReturnType<typeof orpc.tables.rows.call>>,
+  branchId: string,
+  database: string,
+  schema: string,
+  table: string
+): boolean {
+  return data.branchId === branchId
+    && data.database === database
+    && data.schema === schema
+    && data.table === table;
+}
+
+function buildEditorValues(editor: RowEditorState): Record<string, string | null> {
+  return Object.fromEntries(
+    editor.fields
+      .filter(function keepField(field) {
+        return field.enabled;
+      })
+      .map(function mapField(field) {
+        return [field.column, field.isNull ? null : field.value];
+      })
+  );
+}
+
+interface RowFieldsEditorProps {
+  fields: RowDraftField[];
+  mode: RowEditorMode;
+  disabled: boolean;
+  onChangeField: (column: string, patch: Partial<RowDraftField>) => void;
+}
+
+function RowFieldsEditor(props: RowFieldsEditorProps) {
+  return (
+    <div className="grid gap-2">
+      {props.fields.map(function renderField(field) {
+        const valueDisabled = props.disabled || field.isNull || !field.enabled;
+
+        return (
+          <div
+            key={field.column}
+            className="grid gap-2 rounded-md border border-border bg-muted/20 p-2 md:grid-cols-[minmax(140px,1fr)_minmax(180px,2fr)_auto_auto]"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              {props.mode === 'insert' ? (
+                <Checkbox
+                  checked={field.enabled}
+                  disabled={props.disabled}
+                  onChange={function toggleEnabled(event) {
+                    props.onChangeField(field.column, { enabled: event.target.checked });
+                  }}
+                  aria-label={`Include ${field.column}`}
+                />
+              ) : null}
+              <div className="min-w-0">
+                <div className="truncate font-mono text-xs font-medium">{field.column}</div>
+                <div className="truncate text-[11px] text-muted-foreground">{field.type}</div>
+              </div>
+            </div>
+
+            <Input
+              value={field.value}
+              disabled={valueDisabled}
+              className="h-8 font-mono text-xs"
+              onChange={function updateValue(event) {
+                props.onChangeField(field.column, { value: event.target.value });
+              }}
+            />
+
+            <Label className="inline-flex h-8 items-center gap-2 rounded-md border border-border px-2 text-xs text-muted-foreground">
+              <Checkbox
+                checked={field.isNull}
+                disabled={props.disabled || !field.enabled}
+                onChange={function toggleNull(event) {
+                  props.onChangeField(field.column, { isNull: event.target.checked });
+                }}
+              />
+              null
+            </Label>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add table row insert, edit, and delete actions
- bind table row mutations to the loaded branch/database/schema/table target
- reset stale table and SQL editor state when the user changes branch
- surface SQL error detail and hints in SQL editor/table mutations

## API routes / procedures / contracts
- added `tables.insert`
- added `tables.update`
- added `tables.delete`
- updated `tables.rows` response with `branchId`, `database`, `schema`, and `table` action target metadata
- updated `branches.sql.run` error handling to return user-facing SQL errors

## Checks
- `bun run typecheck`
- `bun run web:build`
- agent-browser smoke test on `http://localhost:3000`