### PR TITLE
feat(setup): add onboarding wizard

### DIFF
--- a/src/api/bootstrap.ts
+++ b/src/api/bootstrap.ts
@@ -1,8 +1,12 @@
 import { z } from 'zod';
+import { getDb } from '#db/client';
 import { assertOk } from './helpers';
 import { publicProcedure } from './context';
 import { runDevBootstrap, runProdBootstrap } from '#server/services/bootstrap-service';
 import { createJob, getActiveJob, runJob } from '#server/services/job-service';
+import { createBranchFromBase } from '#server/services/branch-service';
+import { createReplicaBase } from '#server/services/replica-service';
+import { checkServer } from '#server/services/setup-state-service';
 
 const bootstrapInput = z.object({
   target: z.enum(['prod', 'dev']),
@@ -29,4 +33,49 @@ export const bootstrapRouter = {
     });
     return job;
   }),
+  complete: publicProcedure.handler(async function completeSetup() {
+    const active = await getActiveJob('setup');
+    if (active) {
+      return active;
+    }
+
+    const job = await createJob('setup');
+    runJob(job, async function runSetupJob(context) {
+      if (!(await isStepDone('dev-check'))) {
+        await context.log('setting up dev server');
+        assertOk(await runDevBootstrap());
+      }
+
+      if (!(await isStepDone('prod-check'))) {
+        await context.log('checking prod server');
+        await checkServer('prod');
+      }
+
+      if (!(await isStepDone('prod-setup')) || !(await isStepDone('backups'))) {
+        await context.log('setting up prod Postgres and backups');
+        assertOk(await runProdBootstrap());
+      }
+
+      if (!(await isStepDone('replica'))) {
+        await context.log('creating dev replica base');
+        assertOk(await createReplicaBase());
+      }
+
+      if (!(await isStepDone('first-branch'))) {
+        await context.log('creating first dev branch');
+        await createBranchFromBase({ name: 'dev' });
+      }
+    });
+    return job;
+  }),
 };
+
+async function isStepDone(key: string): Promise<boolean> {
+  const step = await getDb()
+    .selectFrom('setupSteps')
+    .select(['status'])
+    .where('key', '=', key)
+    .executeTakeFirst();
+
+  return step?.status === 'done';
+}

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { closeDb, getDb } from '../db/client';
 import { migrateDatabase } from '../db/migrate';
 import { createJob, getActiveJob, getJob, listJobs, runJob } from './services/job-service';
+import { createBranchFromBase } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, saveServer } from './services/setup-state-service';
@@ -143,6 +144,18 @@ describe('control plane database', function controlPlaneDatabase() {
     expect(backup.endpoint).toBe('https://new.example.com');
     expect(backup.secretConfigured).toBe(true);
     expect(secret.value).toBe('keep-me');
+  });
+
+  test('blocks first branch before replica base is ready', async function testBranchNeedsReplica() {
+    await expect(createBranchFromBase({ name: 'dev' })).rejects.toThrow('Create the dev replica before creating a branch');
+
+    const firstBranchStep = await getDb()
+      .selectFrom('setupSteps')
+      .select(['status'])
+      .where('key', '=', 'first-branch')
+      .executeTakeFirstOrThrow();
+
+    expect(firstBranchStep.status).toBe('pending');
   });
 });
 

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -52,37 +52,43 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
     throw new Error('A branch cannot be created from itself');
   }
 
+  await ensureBranchSourceReady(source.slug);
   await setStepStatus('first-branch', 'running', `creating ${displayName}`);
 
-  if (isLocalDockerMode()) {
-    const result = await createLocalDockerBranch({
+  try {
+    if (isLocalDockerMode()) {
+      const result = await createLocalDockerBranch({
+        slug: branchSlug,
+        displayName,
+        sourceSlug: source.slug,
+        sourceDatabase: source.dataset,
+        sourceReplayAt: new Date().toISOString(),
+        parentBranchId: source.id,
+      });
+
+      await setStepStatus('first-branch', 'done', `${displayName} ready`);
+
+      return result;
+    }
+
+    const result = await createBranchClone({
       slug: branchSlug,
       displayName,
-      sourceSlug: source.slug,
-      sourceDatabase: source.dataset,
+      sourceBranch: source.slug,
+      sourceDataset: source.dataset,
       sourceReplayAt: new Date().toISOString(),
       parentBranchId: source.id,
+      publicAccess: true,
+      readOnly: false,
     });
 
     await setStepStatus('first-branch', 'done', `${displayName} ready`);
 
     return result;
+  } catch (error: any) {
+    await setStepStatus('first-branch', 'error', error?.message || 'branch create failed');
+    throw error;
   }
-
-  const result = await createBranchClone({
-    slug: branchSlug,
-    displayName,
-    sourceBranch: source.slug,
-    sourceDataset: source.dataset,
-    sourceReplayAt: new Date().toISOString(),
-    parentBranchId: source.id,
-    publicAccess: true,
-    readOnly: false,
-  });
-
-  await setStepStatus('first-branch', 'done', `${displayName} ready`);
-
-  return result;
 }
 
 export async function createPreviewBranch(input: CreatePreviewBranchInput): Promise<CreateBranchResult> {
@@ -281,6 +287,22 @@ async function resolveBranchSource(parentBranchId: number | null | undefined): P
     slug: sourceBranch.slug,
     dataset: sourceBranch.dataset,
   };
+}
+
+async function ensureBranchSourceReady(sourceSlug: string): Promise<void> {
+  if (sourceSlug !== 'prod') {
+    return;
+  }
+
+  const replicaStep = await getDb()
+    .selectFrom('setupSteps')
+    .select(['status'])
+    .where('key', '=', 'replica')
+    .executeTakeFirst();
+
+  if (replicaStep?.status !== 'done') {
+    throw new Error('Create the dev replica before creating a branch');
+  }
 }
 
 export async function deleteBranch(input: DeleteBranchInput): Promise<DeleteBranchResult> {

--- a/src/web/components/onboarding-wizard.tsx
+++ b/src/web/components/onboarding-wizard.tsx
@@ -1,0 +1,247 @@
+import { useEffect } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  CheckCircle2,
+  Database,
+  GitBranch,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react';
+import { Badge } from '#web/components/ui/badge';
+import { Button } from '#web/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '#web/components/ui/card';
+import { orpc, type ControlPlaneState } from '#web/lib/api-client';
+import {
+  BackupPanel,
+  JobsPanel,
+  ServerPanel,
+  StatusBadge,
+  type ServerRole,
+} from './control-plane';
+
+export function isSetupComplete(state: ControlPlaneState): boolean {
+  return state.setupSteps.every(function isDone(step) {
+    return step.status === 'done';
+  });
+}
+
+export function OnboardingWizard() {
+  const queryClient = useQueryClient();
+  const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
+  const saveServer = useMutation(orpc.servers.update.mutationOptions({ onSuccess: refreshDashboard }));
+  const checkServer = useMutation(orpc.servers.check.mutationOptions({ onSuccess: refreshDashboard }));
+  const saveBackupSettings = useMutation(orpc.backup.settings.update.mutationOptions({ onSuccess: refreshDashboard }));
+  const completeSetup = useMutation(orpc.bootstrap.complete.mutationOptions({ onSuccess: refreshDashboard }));
+
+  const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
+    return job.status === 'queued' || job.status === 'running';
+  }) ?? [];
+  const busy = getBusyKey();
+
+  useEffect(function pollActiveJobs() {
+    if (activeJobs.length === 0) {
+      return;
+    }
+
+    const interval = window.setInterval(function refreshActiveJobs() {
+      void dashboard.refetch();
+    }, 2000);
+
+    return function clearPoll() {
+      window.clearInterval(interval);
+    };
+  }, [activeJobs.length, dashboard]);
+
+  async function refreshDashboard() {
+    await queryClient.invalidateQueries({ queryKey: orpc.dashboard.retrieve.key() });
+  }
+
+  function getBusyKey(): string | null {
+    const activeJob = activeJobs[0];
+
+    if (activeJob) {
+      return activeJob.type;
+    }
+
+    if (saveServer.isPending) {
+      return `save-${saveServer.variables?.role || 'prod'}`;
+    }
+
+    if (checkServer.isPending) {
+      return `check-${checkServer.variables?.role || 'prod'}`;
+    }
+
+    if (saveBackupSettings.isPending) {
+      return 'save-backup';
+    }
+
+    if (completeSetup.isPending) {
+      return 'setup';
+    }
+
+    return null;
+  }
+
+  if (!dashboard.data) {
+    return <OnboardingLoading message={dashboard.error ? 'Could not load setup.' : 'Loading setup...'} />;
+  }
+
+  const state = dashboard.data;
+  const nextStep = getNextStep(state);
+  const prodServer = state.servers.find(function findProd(server) {
+    return server.role === 'prod';
+  });
+  const devServer = state.servers.find(function findDev(server) {
+    return server.role === 'dev';
+  });
+  const doneSteps = state.setupSteps.filter(function countDone(step) {
+    return step.status === 'done';
+  }).length;
+
+  async function handleSave(formData: FormData) {
+    const role = formData.get('role') === 'prod' ? 'prod' : 'dev';
+    await saveServer.mutateAsync({
+      role,
+      host: String(formData.get('host') || ''),
+      sshUser: String(formData.get('sshUser') || ''),
+      sshKeyPath: String(formData.get('sshKeyPath') || ''),
+    });
+  }
+
+  async function handleCheck(role: ServerRole) {
+    await checkServer.mutateAsync({ role });
+  }
+
+  async function handleSaveBackup(formData: FormData) {
+    await saveBackupSettings.mutateAsync({
+      enabled: formData.get('enabled') === 'on',
+      endpoint: String(formData.get('endpoint') || ''),
+      bucket: String(formData.get('bucket') || ''),
+      region: String(formData.get('region') || 'auto'),
+      accessKeyId: String(formData.get('accessKeyId') || ''),
+      secretAccessKey: String(formData.get('secretAccessKey') || ''),
+      path: String(formData.get('path') || '/prod'),
+      pitrDays: Number(formData.get('pitrDays') || 7),
+      fullBackupRetentionDays: Number(formData.get('fullBackupRetentionDays') || 90),
+    });
+  }
+
+  async function handleCompleteSetup() {
+    if (!nextStep || busy) {
+      return;
+    }
+
+    await completeSetup.mutateAsync(undefined);
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <section className="mx-auto grid w-full max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:px-8">
+        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline">Setup</Badge>
+              <StatusBadge status={isSetupComplete(state) ? 'done' : 'running'} />
+            </div>
+            <h1 className="mt-3 text-3xl font-semibold tracking-normal md:text-4xl">Set up Velo</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+              Finish setup before using branches, SQL, tables, or restore tools.
+            </p>
+          </div>
+          <Button variant="outline" onClick={function refreshPage() { void dashboard.refetch(); }}>
+            <RefreshCw />
+            Refresh
+          </Button>
+        </header>
+
+        <Card>
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <CardTitle>{doneSteps}/{state.setupSteps.length} complete</CardTitle>
+              <CardDescription>{nextStep ? `Next: ${nextStep.label}` : 'Setup complete'}</CardDescription>
+            </div>
+            <Button onClick={handleCompleteSetup} disabled={!nextStep || Boolean(busy)}>
+              {busy ? <Loader2 className="animate-spin" /> : getStepIcon(nextStep?.key)}
+              {busy ? 'Working...' : nextStep ? 'Finish setup' : 'Done'}
+            </Button>
+          </CardHeader>
+          <CardContent className="grid gap-3 md:grid-cols-2">
+            {state.setupSteps.map(function renderStep(step) {
+              const isActive = nextStep?.key === step.key;
+
+              return (
+                <div className="rounded-lg border border-border bg-muted/20 p-4" key={step.key}>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="font-medium">{step.label}</p>
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                        {step.message || (isActive ? 'Ready' : 'Waiting')}
+                      </p>
+                    </div>
+                    <StatusBadge status={isActive && busy ? 'running' : step.status} />
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="grid gap-6">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <ServerPanel title="Production" role="prod" server={prodServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
+              <ServerPanel title="Development" role="dev" server={devServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
+            </div>
+            <BackupPanel backup={state.backup} busy={busy === 'save-backup'} onSave={handleSaveBackup} />
+          </div>
+          <JobsPanel jobs={state.jobs} activeJobs={activeJobs.length} />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function getNextStep(state: ControlPlaneState) {
+  return state.setupSteps.find(function isIncomplete(step) {
+    return step.status !== 'done';
+  });
+}
+
+function getStepIcon(key: string | undefined) {
+  if (key === 'dev-check') {
+    return <HardDrive />;
+  }
+
+  if (key === 'prod-check' || key === 'prod-setup' || key === 'backups') {
+    return <ShieldCheck />;
+  }
+
+  if (key === 'replica') {
+    return <Database />;
+  }
+
+  if (key === 'first-branch') {
+    return <GitBranch />;
+  }
+
+  return <CheckCircle2 />;
+}
+
+function OnboardingLoading(props: Readonly<{ message: string }>) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-background px-4 text-foreground">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="animate-spin" />
+        {props.message}
+      </div>
+    </main>
+  );
+}

--- a/src/web/routes/branch/$branchId/backup-restore.tsx
+++ b/src/web/routes/branch/$branchId/backup-restore.tsx
@@ -40,6 +40,7 @@ import {
   AppSidebar,
   StatusBadge,
 } from '#web/components/control-plane';
+import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
 
 export const Route = createFileRoute('/branch/$branchId/backup-restore')({
   component: BackupRestorePage,
@@ -90,6 +91,11 @@ function BackupRestorePage() {
   }
 
   const state = dashboard.data;
+
+  if (!isSetupComplete(state)) {
+    return <OnboardingWizard />;
+  }
+
   const branchId = params.branchId;
   const isProd = branchId === 'prod';
   const branch = isProd ? null : state.branches.find(function findBranch(item) {

--- a/src/web/routes/branch/$branchId/overview.tsx
+++ b/src/web/routes/branch/$branchId/overview.tsx
@@ -44,6 +44,7 @@ import {
   BranchOverviewPanel,
   StatusBadge,
 } from '#web/components/control-plane';
+import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
 
 export const Route = createFileRoute('/branch/$branchId/overview')({
   component: BranchOverviewPage,
@@ -89,6 +90,11 @@ function BranchOverviewPage() {
   }
 
   const state = dashboard.data;
+
+  if (!isSetupComplete(state)) {
+    return <OnboardingWizard />;
+  }
+
   const branch = getBranchView(state, params.branchId);
 
   function getBusyKey(): string | null {

--- a/src/web/routes/branch/$branchId/sql.tsx
+++ b/src/web/routes/branch/$branchId/sql.tsx
@@ -23,6 +23,7 @@ import {
   AppSidebar,
   StatusBadge,
 } from '#web/components/control-plane';
+import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
 
 export const Route = createFileRoute('/branch/$branchId/sql')({
   component: SqlEditorPage,
@@ -48,6 +49,11 @@ function SqlEditorPage() {
   }
 
   const state = dashboard.data;
+
+  if (!isSetupComplete(state)) {
+    return <OnboardingWizard />;
+  }
+
   const branch = getBranchView(state, params.branchId);
 
   async function handleRunSql(event: FormEvent<HTMLFormElement>) {

--- a/src/web/routes/branch/$branchId/tables.tsx
+++ b/src/web/routes/branch/$branchId/tables.tsx
@@ -15,6 +15,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { AppSidebar } from '#web/components/control-plane';
+import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -64,13 +65,17 @@ function BranchTablesPage() {
   const [editorError, setEditorError] = useState<string | null>(null);
   const [rowToDelete, setRowToDelete] = useState<DeleteRowState | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const metadata = useQuery(orpc.tables.browse.queryOptions({
-    input: {
-      branchId: params.branchId,
-      database: selected?.database,
-      schema: selected?.schema,
-    },
-  }));
+  const setupDone = Boolean(dashboard.data && isSetupComplete(dashboard.data));
+  const metadata = useQuery({
+    ...orpc.tables.browse.queryOptions({
+      input: {
+        branchId: params.branchId,
+        database: selected?.database,
+        schema: selected?.schema,
+      },
+    }),
+    enabled: setupDone,
+  });
   const selectedDatabase = metadata.data?.selectedDatabase || selected?.database || 'postgres';
   const selectedSchema = metadata.data?.selectedSchema || selected?.schema || 'public';
   const selectedTable = selected?.name || metadata.data?.selectedTable?.name || '';
@@ -84,7 +89,7 @@ function BranchTablesPage() {
         offset: selected?.offset,
       },
     }),
-    enabled: Boolean(selectedTable),
+    enabled: setupDone && Boolean(selectedTable),
     placeholderData: function keepRowsVisible(previousData) {
       return previousData;
     },
@@ -132,6 +137,10 @@ function BranchTablesPage() {
       return `${table.schema}.${table.name}`.toLowerCase().includes(term);
     });
   }, [search, metadata.data?.tables]);
+
+  if (dashboard.data && !setupDone) {
+    return <OnboardingWizard />;
+  }
 
   function selectDatabase(database: string) {
     setSelected({ database, schema: 'public', offset: 0 });

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -6,6 +6,7 @@ import {
   AppSidebar,
   BranchTreePanel,
 } from '#web/components/control-plane';
+import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
 import { orpc } from '#web/lib/api-client';
 
 export const Route = createFileRoute('/')({
@@ -37,6 +38,10 @@ function HomePage() {
   }
 
   const state = dashboard.data;
+
+  if (!isSetupComplete(state)) {
+    return <OnboardingWizard />;
+  }
 
   return (
     <main className="min-h-screen bg-background text-foreground">

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -17,6 +17,7 @@ import {
   SystemPanel,
   type ServerRole,
 } from '#web/components/control-plane';
+import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
 
 export const Route = createFileRoute('/settings')({
   component: SettingsPage,
@@ -92,6 +93,10 @@ function SettingsPage() {
   }
 
   const state = dashboard.data;
+
+  if (!isSetupComplete(state)) {
+    return <OnboardingWizard />;
+  }
 
   const prodServer = state.servers.find(function findProd(server) {
     return server.role === 'prod';


### PR DESCRIPTION
## Summary
- add an onboarding wizard that locks the main UI until setup is complete
- add a single setup job that runs remaining setup steps in order
- guard first branch creation until the replica base is ready

## API routes, procedures, and contracts
- Added `bootstrap.complete` ORPC procedure.
- It creates or reuses an active `setup` job.
- The job runs incomplete setup steps in order: dev bootstrap, prod check, prod bootstrap/backups, replica base, first `dev` branch.
- Branch creation now requires the `replica` setup step to be `done` when branching from prod.

## Validation
- `bun run typecheck`
- `bun test src/server/control-plane.test.ts`
- `bun run web:build`
