### PR TITLE
test(hetzner): add e2e suite

### DIFF
--- a/scripts/ci-hetzner.sh
+++ b/scripts/ci-hetzner.sh
@@ -10,6 +10,12 @@ VELO_CI_SERVER_TYPE="${VELO_CI_SERVER_TYPE:-cx23}"
 VELO_CI_IMAGE="${VELO_CI_IMAGE:-ubuntu-24.04}"
 VELO_CI_LOCATION="${VELO_CI_LOCATION:-hel1}"
 
+KNOWN_HOSTS_CREATED=0
+if [ -z "${VELO_SSH_KNOWN_HOSTS_FILE:-}" ]; then
+  VELO_SSH_KNOWN_HOSTS_FILE="$(mktemp)"
+  KNOWN_HOSTS_CREATED=1
+fi
+
 if [ -z "$HETZNER_API_TOKEN" ]; then
   echo "Set HETZNER_API_TOKEN"
   exit 1
@@ -55,6 +61,10 @@ cleanup() {
   if [ -n "$SSH_KEY_ID" ] && [ "$SSH_KEY_CREATED" = "1" ]; then
     echo "Deleting SSH key $SSH_KEY_ID"
     hcloud DELETE "/ssh_keys/$SSH_KEY_ID" >/dev/null || true
+  fi
+
+  if [ "$KNOWN_HOSTS_CREATED" = "1" ]; then
+    rm -f "$VELO_SSH_KNOWN_HOSTS_FILE"
   fi
 }
 
@@ -147,7 +157,7 @@ wait_for_ssh() {
   local host="$1"
 
   for _ in $(seq 1 60); do
-    if ssh -i "$VELO_DEPLOY_KEY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 "root@$host" "echo ready" >/dev/null 2>&1; then
+    if ssh -i "$VELO_DEPLOY_KEY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile="$VELO_SSH_KNOWN_HOSTS_FILE" -o ConnectTimeout=5 "root@$host" "echo ready" >/dev/null 2>&1; then
       return
     fi
     sleep 5
@@ -172,6 +182,8 @@ main() {
     VELO_DEPLOY_KEY="$VELO_DEPLOY_KEY" \
     VELO_REPO="$VELO_REPO" \
     VELO_REF="$VELO_REF" \
+    VELO_E2E_SOURCE_DIR="${VELO_E2E_SOURCE_DIR:-$PWD}" \
+    VELO_SSH_KNOWN_HOSTS_FILE="$VELO_SSH_KNOWN_HOSTS_FILE" \
     scripts/e2e-hetzner.sh
 }
 

--- a/scripts/deploy-hetzner.sh
+++ b/scripts/deploy-hetzner.sh
@@ -10,11 +10,13 @@ VELO_REF="${VELO_REF:-$(git rev-parse HEAD)}"
 VELO_PORT="${VELO_PORT:-3000}"
 VELO_DEPLOY_DIR="${VELO_DEPLOY_DIR:-${VELO_DEV_DIR:-/opt/velo}}"
 VELO_REMOTE_KEY_PATH="${VELO_REMOTE_KEY_PATH:-/root/.ssh/frost-e2e-ci}"
+VELO_SSH_KNOWN_HOSTS_FILE="${VELO_SSH_KNOWN_HOSTS_FILE:-$HOME/.ssh/known_hosts}"
 
 SSH_ARGS=(
   -i "$VELO_DEPLOY_KEY"
   -o BatchMode=yes
   -o StrictHostKeyChecking=accept-new
+  -o UserKnownHostsFile="$VELO_SSH_KNOWN_HOSTS_FILE"
   -o ConnectTimeout=8
 )
 

--- a/scripts/e2e-hetzner.sh
+++ b/scripts/e2e-hetzner.sh
@@ -6,12 +6,15 @@ VELO_DEPLOY_PROD_HOST="${VELO_DEPLOY_PROD_HOST:?Set VELO_DEPLOY_PROD_HOST}"
 VELO_DEPLOY_USER="${VELO_DEPLOY_USER:-root}"
 VELO_DEPLOY_KEY="${VELO_DEPLOY_KEY:?Set VELO_DEPLOY_KEY}"
 VELO_DEPLOY_DIR="${VELO_DEPLOY_DIR:-/opt/velo}"
+VELO_E2E_SOURCE_DIR="${VELO_E2E_SOURCE_DIR:-}"
 VELO_PORT="${VELO_PORT:-3000}"
+VELO_SSH_KNOWN_HOSTS_FILE="${VELO_SSH_KNOWN_HOSTS_FILE:-$HOME/.ssh/known_hosts}"
 
 SSH_ARGS=(
   -i "$VELO_DEPLOY_KEY"
   -o BatchMode=yes
   -o StrictHostKeyChecking=accept-new
+  -o UserKnownHostsFile="$VELO_SSH_KNOWN_HOSTS_FILE"
   -o ConnectTimeout=8
 )
 
@@ -25,65 +28,54 @@ ssh_run() {
   ssh "${SSH_ARGS[@]}" "$remote" "$command"
 }
 
+sync_source() {
+  if [ -z "$VELO_E2E_SOURCE_DIR" ]; then
+    return
+  fi
+
+  echo "Syncing E2E source tree"
+  rsync -az --delete \
+    --exclude .git \
+    --exclude node_modules \
+    --exclude .velo \
+    --exclude dist \
+    --exclude .env \
+    --exclude .tanstack \
+    --exclude '*.tsbuildinfo' \
+    -e "ssh -i $VELO_DEPLOY_KEY -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$VELO_SSH_KNOWN_HOSTS_FILE -o ConnectTimeout=8" \
+    "$VELO_E2E_SOURCE_DIR/" "$APP_REMOTE:$VELO_DEPLOY_DIR/"
+
+  ssh_run "$APP_REMOTE" "
+set -e
+cd $(shell_quote "$VELO_DEPLOY_DIR")
+/root/.bun/bin/bun install --frozen-lockfile
+VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun run db:migrate
+/root/.bun/bin/bun run web:build
+systemctl restart velo-web
+"
+}
+
 shell_quote() {
   printf "'%s'" "${1//\'/\'\\\'\'}"
 }
 
 print_debug() {
   echo "app server logs"
-  ssh_run "$APP_REMOTE" "systemctl status velo-web --no-pager -l || true; journalctl -u velo-web -n 160 --no-pager || true" || true
+  ssh_run "$APP_REMOTE" "
+systemctl status velo-web --no-pager -l || true
+journalctl -u velo-web -n 160 --no-pager || true
+docker ps -a || true
+zfs list -r tank/velo/databases || true
+cd $(shell_quote "$VELO_DEPLOY_DIR") && VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun -e '
+import { Database } from \"bun:sqlite\";
+const db = new Database(process.env.VELO_DB);
+console.log(\"branches\", db.query(\"select id, slug, status, parent_branch_id from branches order by id\").all());
+console.log(\"jobs\", db.query(\"select id, type, status, error from jobs order by id desc limit 10\").all());
+db.close();
+' || true
+" || true
   echo "database server logs"
   ssh_run "$PROD_REMOTE" "systemctl status postgresql --no-pager -l || true; journalctl -u postgresql -n 160 --no-pager || true" || true
-}
-
-create_dev_branch() {
-  ssh_run "$APP_REMOTE" "
-set -e
-cd $(shell_quote "$VELO_DEPLOY_DIR")
-VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun -e '
-import { createReplicaBase } from \"./src/server/services/replica-service.ts\";
-import { createBranchFromBase } from \"./src/server/services/branch-service.ts\";
-
-function assertOk(result) {
-  if (!result.ok) {
-    throw new Error(result.message);
-  }
-}
-
-assertOk(await createReplicaBase());
-await createBranchFromBase({ name: \"dev\", slug: \"dev\", parentBranchId: null });
-'
-"
-}
-
-check_dev_branch() {
-  ssh_run "$APP_REMOTE" "
-set -e
-cd $(shell_quote "$VELO_DEPLOY_DIR")
-CONNECTION_URL=\$(VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun -e '
-import { Database } from \"bun:sqlite\";
-
-const db = new Database(process.env.VELO_DB);
-const branch = db.query(\"select slug, status, connection_url from branches where slug = ?\").get(\"dev\");
-const steps = db.query(\"select key, status from setup_steps where key in (?, ?) order by key\").all(\"replica\", \"first-branch\");
-
-if (!branch || branch.status !== \"running\" || !branch.connection_url) {
-  throw new Error(\"bad dev branch: \" + JSON.stringify(branch));
-}
-
-if (steps.length !== 2 || steps.some(function isBad(step) { return step.status !== \"done\"; })) {
-  throw new Error(\"bad branch setup steps: \" + JSON.stringify(steps));
-}
-
-console.log(branch.connection_url);
-db.close();
-')
-psql \"\$CONNECTION_URL\" -tAc 'select 1' | grep -qx 1
-set -a
-. /etc/velo.env
-set +a
-curl -fsS -I -u \"\$VELO_BASIC_AUTH_USERNAME:\$VELO_BASIC_AUTH_PASSWORD\" http://127.0.0.1:$VELO_PORT/branch/dev/overview >/dev/null
-"
 }
 
 main() {
@@ -91,12 +83,17 @@ main() {
 
   echo "Deploying fresh Hetzner app and prod database"
   scripts/deploy-hetzner.sh
+  sync_source
 
-  echo "Creating dev branch through product services"
-  create_dev_branch
-
-  echo "Checking dev branch"
-  check_dev_branch
+  echo "Running Hetzner E2E suite"
+  ssh_run "$APP_REMOTE" "
+set -e
+cd $(shell_quote "$VELO_DEPLOY_DIR")
+VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") \\
+VELO_PORT=$(shell_quote "$VELO_PORT") \\
+VELO_E2E_RUN_ID=$(shell_quote "${VELO_CI_RUN_ID:-$(date +%s)}") \\
+/root/.bun/bin/bun scripts/e2e/hetzner-suite.ts
+"
 
   echo "Hetzner E2E passed"
 }

--- a/scripts/e2e/hetzner-suite.ts
+++ b/scripts/e2e/hetzner-suite.ts
@@ -1,0 +1,504 @@
+import { SQL } from 'bun';
+import { getDb } from '#db/client';
+import type { Branch } from '#db/schema';
+import { createApiClient } from '#api/router';
+import { getSetting } from '#server/services/settings-service';
+import { runCommand, runSshCommand } from '#server/services/command-service';
+import { TABLE_ROW_ID_COLUMN } from '#server/services/table-browser-service';
+import { getContainerName, getDatasetName } from '#utils/naming';
+
+const api = createApiClient();
+const PROJECT_NAME = 'prod';
+const RUN_ID = normalizeRunId(process.env.VELO_E2E_RUN_ID || process.env.GITHUB_RUN_ID || String(Date.now()));
+const PORT = process.env.VELO_PORT || '3000';
+const JOB_TIMEOUT_MS = 20 * 60 * 1000;
+
+const trackedBranches = new Set<string>();
+
+interface TestCase {
+  name: string;
+  run: () => Promise<void>;
+}
+
+interface QueryResult {
+  columns: string[];
+  rows: Array<Record<string, string | number | boolean | null>>;
+}
+
+async function main() {
+  const tests: TestCase[] = [
+    { name: 'dashboard and web smoke', run: testDashboardAndWebSmoke },
+    { name: 'replica base', run: testReplicaBase },
+    { name: 'branch lifecycle', run: testBranchLifecycle },
+    { name: 'branch data, sql, table browser, reset', run: testBranchDataSqlTablesAndReset },
+    { name: 'pgBackRest branch PITR', run: testBranchPitr },
+    { name: 'production PITR restore', run: testProductionPitrRestore },
+  ];
+
+  try {
+    for (const test of tests) {
+      await runTest(test);
+    }
+  } finally {
+    await cleanupTrackedBranches();
+  }
+}
+
+async function runTest(test: TestCase): Promise<void> {
+  const startedAt = performance.now();
+  console.log(`e2e start: ${test.name}`);
+  await test.run();
+  console.log(`e2e ok: ${test.name} (${Math.round(performance.now() - startedAt)}ms)`);
+}
+
+async function testDashboardAndWebSmoke(): Promise<void> {
+  const state = await api.dashboard.retrieve();
+  assert(state.servers.length === 2, 'expected prod and dev servers');
+  assert(state.servers.every(function isOk(server) {
+    return server.status === 'ok';
+  }), `expected healthy servers: ${JSON.stringify(state.servers)}`);
+  assert(hasDoneStep(state.setupSteps, 'dev-check'), 'dev-check should be done');
+  assert(hasDoneStep(state.setupSteps, 'prod-check'), 'prod-check should be done');
+  assert(hasDoneStep(state.setupSteps, 'prod-setup'), 'prod-setup should be done');
+  assert(hasDoneStep(state.setupSteps, 'backups'), 'backups should be done');
+
+  await appHead('/');
+  await appHead('/settings');
+}
+
+async function testReplicaBase(): Promise<void> {
+  const job = await api.replicaBase.create();
+  await waitForJob(job.id, JOB_TIMEOUT_MS);
+
+  const state = await api.dashboard.retrieve();
+  assert(hasDoneStep(state.setupSteps, 'replica'), 'replica step should be done');
+  await assertZfsDatasetExists(getDatasetName(PROJECT_NAME, 'base'));
+}
+
+async function testBranchLifecycle(): Promise<void> {
+  const branch = await createBranch(`e2e_life_${RUN_ID}`);
+
+  await assertBranchConnects(branch.slug);
+  await assertDockerContainerHealthy(getContainerName(PROJECT_NAME, branch.slug));
+  await assertZfsDatasetExists(branch.dataset);
+
+  await deleteBranchBySlug(branch.slug);
+  await assertBranchMissing(branch.slug);
+  await assertDockerContainerMissing(getContainerName(PROJECT_NAME, branch.slug));
+  await assertZfsDatasetMissing(branch.dataset);
+}
+
+async function testBranchDataSqlTablesAndReset(): Promise<void> {
+  const parent = await createBranch(`e2e_parent_${RUN_ID}`);
+  const table = `e2e_items_${RUN_ID}`;
+  const browserTable = `e2e_browser_${RUN_ID}`;
+
+  await runBranchSql(parent.slug, [
+    `create table ${table} (id integer primary key, note text not null)`,
+    `insert into ${table} (id, note) values (1, 'parent')`,
+  ].join('; '));
+
+  const parentRows = await runBranchSql(parent.slug, `select note from ${table} order by id`);
+  assertSingleValue(parentRows, 'note', 'parent');
+
+  const child = await createBranch(`e2e_child_${RUN_ID}`, parent.id);
+  const childRows = await runBranchSql(child.slug, `select note from ${table} order by id`);
+  assertSingleValue(childRows, 'note', 'parent');
+
+  await runBranchSql(child.slug, [
+    `update ${table} set note = 'child' where id = 1`,
+    `insert into ${table} (id, note) values (2, 'child-only')`,
+  ].join('; '));
+
+  const changedChildRows = await runBranchSql(child.slug, `select note from ${table} order by id`);
+  assert(changedChildRows.rows.map(function getNote(row) {
+    return row.note;
+  }).join(',') === 'child,child-only', 'child should have isolated data');
+
+  const unchangedParentRows = await runBranchSql(parent.slug, `select note from ${table} order by id`);
+  assertSingleValue(unchangedParentRows, 'note', 'parent');
+
+  await assertSqlError(child.slug, 'select * from table_that_should_not_exist');
+
+  await runBranchSql(child.slug, [
+    `create table ${browserTable} (id integer primary key, note text not null, active boolean not null default true)`,
+    `insert into ${browserTable} (id, note, active) values (1, 'from sql', true)`,
+  ].join('; '));
+
+  const metadata = await api.tables.browse({ branchId: child.slug, schema: 'public', table: browserTable });
+  assert(metadata.selectedTable?.name === browserTable, 'table browser should select created table');
+
+  await api.tables.insert({
+    branchId: child.slug,
+    database: metadata.selectedDatabase,
+    schema: 'public',
+    table: browserTable,
+    values: { id: '2', note: 'inserted', active: 'false' },
+  });
+
+  let rows = await api.tables.rows({
+    branchId: child.slug,
+    database: metadata.selectedDatabase,
+    schema: 'public',
+    table: browserTable,
+  });
+  assert(rows.rowCount === 2, `expected two table browser rows: ${JSON.stringify(rows.rows)}`);
+
+  const inserted = rows.rows.find(function findInserted(row) {
+    return row.note === 'inserted';
+  });
+  assert(inserted, 'inserted row should be visible');
+  const rowId = inserted[TABLE_ROW_ID_COLUMN];
+  assert(typeof rowId === 'string', 'inserted row should expose ctid');
+
+  await api.tables.update({
+    branchId: child.slug,
+    database: metadata.selectedDatabase,
+    schema: 'public',
+    table: browserTable,
+    rowId,
+    values: { note: 'updated', active: 'true' },
+  });
+
+  rows = await api.tables.rows({
+    branchId: child.slug,
+    database: metadata.selectedDatabase,
+    schema: 'public',
+    table: browserTable,
+  });
+  const updated = rows.rows.find(function findUpdated(row) {
+    return row.note === 'updated';
+  });
+  assert(updated?.active === true, 'updated row should be active');
+  const updatedRowId = updated[TABLE_ROW_ID_COLUMN];
+  assert(typeof updatedRowId === 'string', 'updated row should expose ctid');
+
+  await api.tables.delete({
+    branchId: child.slug,
+    database: metadata.selectedDatabase,
+    schema: 'public',
+    table: browserTable,
+    rowId: updatedRowId,
+  });
+
+  rows = await api.tables.rows({
+    branchId: child.slug,
+    database: metadata.selectedDatabase,
+    schema: 'public',
+    table: browserTable,
+  });
+  assert(rows.rowCount === 1, 'delete should leave one row');
+
+  await waitForJob((await api.branches.reset({ id: child.id })).id, JOB_TIMEOUT_MS);
+  const resetRows = await runBranchSql(child.slug, `select note from ${table} order by id`);
+  assertSingleValue(resetRows, 'note', 'parent');
+  await assertSqlError(child.slug, `select * from ${browserTable}`);
+}
+
+async function testBranchPitr(): Promise<void> {
+  const table = `e2e_pitr_${RUN_ID}`;
+  const branchName = `e2e_pitr_${RUN_ID}`;
+  const targetTime = await preparePitrFixture(table);
+
+  await syncProdBackupRepoToApp();
+  trackedBranches.add(branchName);
+
+  const job = await api.branches.restore({
+    targetBranch: branchName,
+    sourceBranch: 'prod',
+    restoreTime: targetTime,
+  });
+  await waitForJob(job.id, JOB_TIMEOUT_MS);
+
+  const rows = await runBranchSql(branchName, `select label from ${table} order by id`);
+  assert(rows.rows.map(function getLabel(row) {
+    return row.label;
+  }).join(',') === 'before', `PITR branch should restore before row only: ${JSON.stringify(rows.rows)}`);
+}
+
+async function testProductionPitrRestore(): Promise<void> {
+  const table = `e2e_prod_pitr_${RUN_ID}`;
+  const targetTime = await preparePitrFixture(table);
+
+  const job = await api.branches.restore({
+    targetBranch: 'prod',
+    sourceBranch: 'prod',
+    restoreTime: targetTime,
+  });
+  await waitForJob(job.id, JOB_TIMEOUT_MS);
+
+  await appHead('/');
+  const rows = await runBranchSql('prod', `select label from ${table} order by id`);
+  assert(rows.rows.map(function getLabel(row) {
+    return row.label;
+  }).join(',') === 'before', `prod restore should keep before row only: ${JSON.stringify(rows.rows)}`);
+}
+
+async function preparePitrFixture(table: string): Promise<string> {
+  await runBranchSql('prod', [
+    `drop table if exists ${table}`,
+    `create table ${table} (id integer primary key, label text not null)`,
+    `insert into ${table} (id, label) values (1, 'before')`,
+  ].join('; '));
+
+  const target = await prodScalar("select (clock_timestamp() + interval '1 second')::timestamptz as target", 'target');
+  await sleep(1500);
+  await runBranchSql('prod', 'select pg_switch_wal()');
+  await sleep(1500);
+
+  await runBranchSql('prod', `insert into ${table} (id, label) values (2, 'after')`);
+  await runBranchSql('prod', 'select pg_switch_wal()');
+  await waitForProdArchive();
+
+  return new Date(String(target)).toISOString();
+}
+
+async function createBranch(name: string, parentBranchId?: number | null): Promise<Branch> {
+  const result = await api.branches.create({ name, parentBranchId });
+  trackedBranches.add(result.branchSlug);
+  await waitForJob(result.id, JOB_TIMEOUT_MS);
+  return getBranch(result.branchSlug);
+}
+
+async function deleteBranchBySlug(slug: string): Promise<void> {
+  const branch = await findBranch(slug);
+
+  if (!branch) {
+    trackedBranches.delete(slug);
+    return;
+  }
+
+  const job = await api.branches.delete({ id: branch.id });
+  await waitForJob(job.id, JOB_TIMEOUT_MS);
+  trackedBranches.delete(slug);
+}
+
+async function cleanupTrackedBranches(): Promise<void> {
+  const branches = Array.from(trackedBranches).reverse();
+
+  for (const slug of branches) {
+    try {
+      await deleteBranchBySlug(slug);
+    } catch (error: any) {
+      console.error(`cleanup failed for ${slug}: ${error?.message || String(error)}`);
+    }
+  }
+}
+
+async function waitForJob(jobId: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let latest: Awaited<ReturnType<typeof api.jobs.retrieve>> | null = null;
+
+  while (Date.now() < deadline) {
+    latest = await api.jobs.retrieve({ id: jobId });
+
+    if (latest.status === 'done') {
+      return;
+    }
+
+    if (latest.status === 'error') {
+      throw new Error(`job ${jobId} failed: ${latest.error || JSON.stringify(latest.logs)}`);
+    }
+
+    await sleep(1500);
+  }
+
+  throw new Error(`job ${jobId} timed out: ${JSON.stringify(latest)}`);
+}
+
+async function runBranchSql(branchId: string, sql: string): Promise<QueryResult> {
+  return api.branches.sql.run({ branchId, sql });
+}
+
+async function assertSqlError(branchId: string, sql: string): Promise<void> {
+  try {
+    await runBranchSql(branchId, sql);
+  } catch {
+    return;
+  }
+
+  throw new Error(`expected SQL to fail: ${sql}`);
+}
+
+async function assertBranchConnects(slug: string): Promise<void> {
+  const result = await runBranchSql(slug, 'select 1 as ok');
+  assertSingleValue(result, 'ok', 1);
+}
+
+async function prodScalar(sql: string, column: string): Promise<unknown> {
+  const connectionUrl = await getSetting('prod.connectionUrl');
+  assert(connectionUrl, 'prod connection URL is missing');
+  const client = new SQL({ url: connectionUrl, max: 1 });
+
+  try {
+    const rows = await client.unsafe<Array<Record<string, unknown>>>(sql);
+    return rows[0]?.[column];
+  } finally {
+    await client.close();
+  }
+}
+
+async function syncProdBackupRepoToApp(): Promise<void> {
+  const prod = await getDb()
+    .selectFrom('servers')
+    .selectAll()
+    .where('role', '=', 'prod')
+    .executeTakeFirstOrThrow();
+
+  await assertCommandOk(await runCommand([
+    'sh',
+    '-lc',
+    [
+      'set -e',
+      'rm -rf /var/lib/pgbackrest',
+      `ssh -i ${shellQuote(prod.sshKeyPath)} -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8 ${shellQuote(`${prod.sshUser}@${prod.host}`)} ${shellQuote('sudo tar -C /var/lib -cf - pgbackrest')} | tar -C /var/lib -xf -`,
+      'chmod -R a+rX /var/lib/pgbackrest',
+      'pgbackrest --stanza=main info --output=json >/dev/null',
+    ].join('\n'),
+  ], 5 * 60 * 1000), 'sync prod pgBackRest repo');
+}
+
+async function waitForProdArchive(): Promise<void> {
+  const prod = await getDb()
+    .selectFrom('servers')
+    .selectAll()
+    .where('role', '=', 'prod')
+    .executeTakeFirstOrThrow();
+
+  await assertCommandOk(await runSshCommand({
+    host: prod.host,
+    user: prod.sshUser,
+    keyPath: prod.sshKeyPath,
+  }, 'sudo -u postgres pgbackrest --stanza=main check', 2 * 60 * 1000), 'prod pgBackRest archive check');
+}
+
+async function appHead(path: string): Promise<void> {
+  const command = [
+    'set -e',
+    'set -a',
+    '. /etc/velo.env',
+    'set +a',
+    `curl -fsS -I -u "$VELO_BASIC_AUTH_USERNAME:$VELO_BASIC_AUTH_PASSWORD" ${shellQuote(`http://127.0.0.1:${PORT}${path}`)} >/dev/null`,
+  ].join('\n');
+
+  await assertCommandOk(await runCommand(['sh', '-lc', command], 30000), `HEAD ${path}`);
+}
+
+async function assertDockerContainerHealthy(containerName: string): Promise<void> {
+  const result = await runCommand([
+    'docker',
+    'inspect',
+    '--format',
+    '{{.State.Status}}',
+    containerName,
+  ]);
+
+  await assertCommandOk(result, `docker inspect ${containerName}`);
+  assert(result.stdout === 'running', `${containerName} should be running, got ${result.stdout}`);
+}
+
+async function assertDockerContainerMissing(containerName: string): Promise<void> {
+  const result = await runCommand(['docker', 'inspect', containerName]);
+  assert(result.exitCode !== 0, `${containerName} should be deleted`);
+}
+
+async function assertZfsDatasetExists(dataset: string): Promise<void> {
+  await assertCommandOk(await runCommand(['zfs', 'list', `tank/velo/databases/${dataset}`]), `zfs list ${dataset}`);
+}
+
+async function assertZfsDatasetMissing(dataset: string): Promise<void> {
+  const result = await runCommand(['zfs', 'list', `tank/velo/databases/${dataset}`]);
+  assert(result.exitCode !== 0, `${dataset} ZFS dataset should be deleted`);
+}
+
+async function getBranch(slug: string): Promise<Branch> {
+  const branch = await findBranch(slug);
+  assert(branch, `branch missing: ${slug}`);
+  return branch;
+}
+
+async function findBranch(slug: string): Promise<Branch | undefined> {
+  return getDb()
+    .selectFrom('branches')
+    .selectAll()
+    .where('slug', '=', slug)
+    .executeTakeFirst();
+}
+
+async function assertBranchMissing(slug: string): Promise<void> {
+  const branch = await findBranch(slug);
+  assert(!branch, `branch should be deleted: ${slug}`);
+}
+
+async function assertCommandOk(result: { exitCode: number; stdout: string; stderr: string }, label: string): Promise<void> {
+  if (result.exitCode !== 0) {
+    throw new Error(`${label} failed: ${result.stderr || result.stdout || `exit ${result.exitCode}`}`);
+  }
+}
+
+function assertSingleValue(result: QueryResult, column: string, expected: string | number | boolean | null): void {
+  assert(result.rows.length === 1, `expected one row: ${JSON.stringify(result.rows)}`);
+  assert(result.rows[0]?.[column] === expected, `expected ${String(expected)} for ${column}: ${JSON.stringify(result.rows)}`);
+}
+
+function hasDoneStep(steps: Array<{ key: string; status: string }>, key: string): boolean {
+  return steps.some(function hasMatchingStep(step) {
+    return step.key === key && step.status === 'done';
+  });
+}
+
+function assert(value: unknown, message: string): asserts value {
+  if (!value) {
+    throw new Error(message);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(function wait(resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+function normalizeRunId(value: string): string {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]/g, '').slice(-10);
+  return normalized || String(Date.now()).slice(-10);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+main().catch(async function handleError(error) {
+  console.error(error?.stack || error?.message || String(error));
+  await printDebugState().catch(function ignoreDebugError(debugError) {
+    console.error(debugError?.message || String(debugError));
+  });
+  process.exit(1);
+});
+
+async function printDebugState(): Promise<void> {
+  console.error('e2e debug: branches');
+  console.error(JSON.stringify(await getDb().selectFrom('branches').selectAll().execute(), null, 2));
+  console.error('e2e debug: recent jobs');
+  console.error(JSON.stringify(await api.jobs.list(), null, 2));
+  console.error('e2e debug: docker');
+  console.error((await runCommand(['docker', 'ps', '-a'])).stdout);
+  console.error('e2e debug: zfs');
+  console.error((await runCommand(['zfs', 'list', '-r', 'tank/velo/databases'])).stdout);
+
+  const prod = await getDb()
+    .selectFrom('servers')
+    .selectAll()
+    .where('role', '=', 'prod')
+    .executeTakeFirst();
+
+  if (prod) {
+    const result = await runSshCommand({
+      host: prod.host,
+      user: prod.sshUser,
+      keyPath: prod.sshKeyPath,
+    }, 'systemctl status postgresql --no-pager -l || true; sudo -u postgres pgbackrest --stanza=main info || true', 30000);
+    console.error('e2e debug: prod');
+    console.error(result.stdout || result.stderr);
+  }
+}

--- a/src/managers/docker.ts
+++ b/src/managers/docker.ts
@@ -1,4 +1,5 @@
 import Dockerode from 'dockerode';
+import { existsSync } from 'node:fs';
 import { BACKUP_LABEL_PREFIX } from '../config/constants';
 import { SystemError } from '../errors';
 
@@ -15,6 +16,7 @@ export interface PostgresConfig {
   publicAccess?: boolean;
   readOnly?: boolean;
   restoreCommand?: string | null;
+  pgBackRestRepoPath?: string | null;
 }
 
 export interface ContainerStatus {
@@ -81,6 +83,7 @@ export class DockerManager {
           `${config.dataPath}:/var/lib/postgresql/data`,
           `${config.walArchivePath}:/wal-archive`,
           `${config.sslCertDir}:/etc/ssl/certs/postgresql:ro`,
+          ...getPgBackRestRepoBinds(config),
         ],
         RestartPolicy: {
           Name: 'unless-stopped',
@@ -328,4 +331,12 @@ function getRestoreCommandArgs(config: Pick<PostgresConfig, 'restoreCommand'>): 
   }
 
   return ['-c', `restore_command=${config.restoreCommand || 'cp /wal-archive/%f %p'}`];
+}
+
+function getPgBackRestRepoBinds(config: Pick<PostgresConfig, 'pgBackRestRepoPath'>): string[] {
+  if (!config.pgBackRestRepoPath || !existsSync(config.pgBackRestRepoPath)) {
+    return [];
+  }
+
+  return [`${config.pgBackRestRepoPath}:/var/lib/pgbackrest:ro`];
 }

--- a/src/server/services/backup-availability-service.ts
+++ b/src/server/services/backup-availability-service.ts
@@ -46,10 +46,6 @@ interface PgBackRestStanza {
 export async function getBackupAvailability(): Promise<BackupAvailability> {
   const backup = await getBackupSettings();
 
-  if (!backup.enabled) {
-    return unavailable('Backups are not enabled');
-  }
-
   if (isLocalDockerMode()) {
     try {
       return capLocalPitrWindow(parsePgBackRestInfo(await getLocalPgBackRestInfo(), backup.pitrDays));

--- a/src/server/services/pgbackrest-restore-service.ts
+++ b/src/server/services/pgbackrest-restore-service.ts
@@ -13,7 +13,7 @@ import { getZFSPool } from '../../utils/zfs-pool';
 import { getBackupAvailability } from './backup-availability-service';
 import { buildPgBackRestConfig } from './bootstrap-service';
 import { runCommand, runSshCommand } from './command-service';
-import { getSetting, setSetting } from './settings-service';
+import { getBackupSettings, getSetting, setSetting } from './settings-service';
 import { createLocalDockerPitrBranch, isLocalDockerMode, restoreLocalDockerProduction } from './local-docker-service';
 
 const PROJECT_NAME = 'prod';
@@ -59,6 +59,7 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
     .where('role', '=', 'dev')
     .executeTakeFirst();
   const prodPassword = await getProdPassword();
+  const backup = await getBackupSettings();
 
   if (!prodPassword) {
     throw new Error('Production password is missing. Run prod setup first.');
@@ -115,6 +116,7 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
       publicAccess: input.publicAccess === true,
       readOnly: input.readOnly === true,
       restoreCommand: null,
+      pgBackRestRepoPath: backup.enabled ? null : '/var/lib/pgbackrest',
     });
 
     await docker.startContainer(containerId);


### PR DESCRIPTION
## Summary
- add a reusable Hetzner E2E suite that runs on throwaway app/prod servers
- cover dashboard health, replica base, branch lifecycle, data isolation, SQL editor, table browser CRUD, reset, branch PITR, and prod PITR
- make CI SSH host keys isolated per run so recycled Hetzner IPs do not break local/CI runs
- fix local pgBackRest PITR branch recovery by mounting the local repo into restored containers

## API routes / procedures / contracts
- no API routes added, updated, or deleted
- E2E now exercises existing ORPC procedures: dashboard.retrieve, replicaBase.create, branches.create/delete/reset/restore/sql.run, tables.browse/rows/insert/update/delete, jobs.retrieve/list
- Docker Postgres config contract now accepts optional pgBackRestRepoPath for local-repo restore containers

## Validation
- bash -n scripts/*.sh
- bun run typecheck
- bun run test
- bun run web:build
- full throwaway Hetzner E2E passed via scripts/ci-hetzner.sh
- GitHub HETZNER_API_TOKEN secret synced from local .env
