### PR TITLE
fix(deploy): keep test setup open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,23 @@ Production-like deployed code path:
 
 ## Deploy
 
-Use this for stable checkpoints:
+### Hetzner Test Setup
+
+Use this to redeploy latest `main` fresh to the two-server test setup:
+
+```sh
+bun run deploy:main
+```
+
+The test setup is:
+
+- app/control server: `157.180.22.136`
+- prod-db server: `89.167.89.255`
+
+`deploy:main` uses `gh` to resolve latest `main`, resets both servers, installs Velo, bootstraps Postgres/pgBackRest, and starts `velo-web`.
+Do not add auth to this test setup. The app URL should stay directly open.
+
+Use this to deploy the current local commit instead:
 
 ```sh
 VELO_DEPLOY_DEV_HOST=157.180.22.136 \
@@ -109,7 +125,7 @@ VELO_DEPLOY_KEY=$HOME/.ssh/frost-e2e-ci \
 bun run deploy
 ```
 
-`deploy` resets the Hetzner app/database state, installs Velo, bootstraps Postgres/pgBackRest, and starts `velo-web`.
+`deploy` resets the Hetzner app/database state, installs Velo from local `HEAD`, bootstraps Postgres/pgBackRest, and starts `velo-web`.
 `deploy:dev` only rsyncs the local worktree to the app server.
 `remote:dev` stops `velo-web` and starts `velo-web-dev`.
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "remote:sync:once": "scripts/remote-sync.sh --once",
     "deploy": "scripts/deploy-hetzner.sh",
     "deploy:hetzner": "scripts/deploy-hetzner.sh",
+    "deploy:main": "scripts/deploy-main.sh",
     "deploy:dev": "scripts/deploy-dev.sh",
     "e2e:hetzner": "scripts/e2e-hetzner.sh",
     "db:migrate": "bun run src/db/migrate.ts",

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -50,8 +50,7 @@ if [ ! -f /etc/velo.env ]; then
 fi
 
 grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' '$VELO_PUBLIC_URL' >>/etc/velo.env
-grep -q '^VELO_BASIC_AUTH_USERNAME=' /etc/velo.env || printf 'VELO_BASIC_AUTH_USERNAME=%s\n' 'velo' >>/etc/velo.env
-grep -q '^VELO_BASIC_AUTH_PASSWORD=' /etc/velo.env || printf 'VELO_BASIC_AUTH_PASSWORD=%s\n' \"\$(openssl rand -base64 32)\" >>/etc/velo.env
+sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
 
 cat >/etc/systemd/system/velo-web.service <<SERVICE
 [Unit]
@@ -90,5 +89,5 @@ sleep 1
 systemctl is-active --quiet velo-web
 "
 
-ssh "${SSH_ARGS[@]}" "$REMOTE" "set -a; . /etc/velo.env; set +a; curl -fsS -I -u \"\$VELO_BASIC_AUTH_USERNAME:\$VELO_BASIC_AUTH_PASSWORD\" 'http://127.0.0.1:$VELO_PORT' >/dev/null"
+ssh "${SSH_ARGS[@]}" "$REMOTE" "curl -fsS -I 'http://127.0.0.1:$VELO_PORT' >/dev/null"
 echo "Deployed: http://$VELO_DEPLOY_HOST:$VELO_PORT"

--- a/scripts/deploy-hetzner.sh
+++ b/scripts/deploy-hetzner.sh
@@ -58,7 +58,7 @@ if command -v zfs >/dev/null 2>&1; then
   zfs destroy -r tank/velo >/dev/null 2>&1 || true
   zpool destroy tank >/dev/null 2>&1 || true
 fi
-rm -rf $(shell_quote "$VELO_DEPLOY_DIR/.velo") /opt/velo-dev /root/.velo /etc/velo.env /var/lib/velo/zfs-pool.img
+rm -rf $(shell_quote "$VELO_DEPLOY_DIR") /opt/velo-dev /root/.velo /etc/velo.env /var/lib/velo/zfs-pool.img
 "
 }
 
@@ -142,6 +142,8 @@ cd $(shell_quote "$VELO_DEPLOY_DIR")
 VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun -e '
 import { checkServer } from \"./src/server/services/setup-state-service.ts\";
 import { runDevBootstrap, runProdBootstrap } from \"./src/server/services/bootstrap-service.ts\";
+import { createReplicaBase } from \"./src/server/services/replica-service.ts\";
+import { createBranchFromBase } from \"./src/server/services/branch-service.ts\";
 
 function assertOk(result) {
   if (!result.ok) {
@@ -153,6 +155,8 @@ await checkServer(\"dev\");
 await checkServer(\"prod\");
 assertOk(await runDevBootstrap());
 assertOk(await runProdBootstrap());
+assertOk(await createReplicaBase());
+await createBranchFromBase({ name: \"dev\" });
 '
 systemctl restart velo-web
 "
@@ -162,12 +166,12 @@ check_servers() {
   local attempt
 
   for attempt in $(seq 1 30); do
-    if ssh_run "$APP_REMOTE" "set -a; . /etc/velo.env; set +a; curl -fsS -I -u \"\$VELO_BASIC_AUTH_USERNAME:\$VELO_BASIC_AUTH_PASSWORD\" http://127.0.0.1:$VELO_PORT >/dev/null"; then
+    if ssh_run "$APP_REMOTE" "curl -fsS -I http://127.0.0.1:$VELO_PORT >/dev/null"; then
       break
     fi
 
     if [ "$attempt" = 30 ]; then
-      ssh_run "$APP_REMOTE" "set -a; . /etc/velo.env; set +a; curl -fsS -I -u \"\$VELO_BASIC_AUTH_USERNAME:\$VELO_BASIC_AUTH_PASSWORD\" http://127.0.0.1:$VELO_PORT >/dev/null"
+      ssh_run "$APP_REMOTE" "curl -fsS -I http://127.0.0.1:$VELO_PORT >/dev/null"
     fi
 
     sleep 1
@@ -182,24 +186,19 @@ import { Database } from \"bun:sqlite\";
 
 const db = new Database(process.env.VELO_DB);
 const servers = db.query(\"select role, status from servers order by role\").all();
-const steps = db.query(\"select key, status from setup_steps where key in (?, ?, ?, ?) order by key\").all(
-  \"dev-check\",
-  \"prod-check\",
-  \"prod-setup\",
-  \"backups\"
-);
+const steps = db.query(\"select key, status from setup_steps order by key\").all();
 const branches = db.query(\"select slug, status from branches order by slug\").all();
 
 if (servers.length !== 2 || servers.some(function isBad(server) { return server.status !== \"ok\"; })) {
   throw new Error(\"bad servers: \" + JSON.stringify(servers));
 }
 
-if (steps.length !== 4 || steps.some(function isBad(step) { return step.status !== \"done\"; })) {
+if (steps.length !== 6 || steps.some(function isBad(step) { return step.status !== \"done\"; })) {
   throw new Error(\"bad setup steps: \" + JSON.stringify(steps));
 }
 
-if (branches.length !== 0) {
-  throw new Error(\"fresh deploy should not create dev branches: \" + JSON.stringify(branches));
+if (branches.length !== 1 || branches[0].slug !== \"dev\" || branches[0].status !== \"running\") {
+  throw new Error(\"fresh deploy should create one dev branch: \" + JSON.stringify(branches));
 }
 
 db.close();

--- a/scripts/deploy-main.sh
+++ b/scripts/deploy-main.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required."
+  exit 1
+fi
+
+VELO_REF="${VELO_REF:-$(gh api repos/elitan/velo/branches/main --jq '.commit.sha')}"
+export VELO_REF
+
+echo "Deploying latest main: $VELO_REF"
+exec scripts/deploy-hetzner.sh "$@"

--- a/scripts/e2e/hetzner-suite.ts
+++ b/scripts/e2e/hetzner-suite.ts
@@ -375,10 +375,7 @@ async function waitForProdArchive(): Promise<void> {
 async function appHead(path: string): Promise<void> {
   const command = [
     'set -e',
-    'set -a',
-    '. /etc/velo.env',
-    'set +a',
-    `curl -fsS -I -u "$VELO_BASIC_AUTH_USERNAME:$VELO_BASIC_AUTH_PASSWORD" ${shellQuote(`http://127.0.0.1:${PORT}${path}`)} >/dev/null`,
+    `curl -fsS -I ${shellQuote(`http://127.0.0.1:${PORT}${path}`)} >/dev/null`,
   ].join('\n');
 
   await assertCommandOk(await runCommand(['sh', '-lc', command], 30000), `HEAD ${path}`);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,8 +57,7 @@ if [ ! -f /etc/velo.env ]; then
 fi
 
 grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' "$VELO_PUBLIC_URL" >>/etc/velo.env
-grep -q '^VELO_BASIC_AUTH_USERNAME=' /etc/velo.env || printf 'VELO_BASIC_AUTH_USERNAME=%s\n' "${VELO_BASIC_AUTH_USERNAME:-velo}" >>/etc/velo.env
-grep -q '^VELO_BASIC_AUTH_PASSWORD=' /etc/velo.env || printf 'VELO_BASIC_AUTH_PASSWORD=%s\n' "${VELO_BASIC_AUTH_PASSWORD:-$(openssl rand -base64 32)}" >>/etc/velo.env
+sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
 
 cat >/etc/systemd/system/velo-web.service <<SERVICE
 [Unit]


### PR DESCRIPTION
## What changed

- Add `bun run deploy:main` to redeploy latest `main` fresh to the Hetzner test setup.
- Make fresh deploy remove the whole app checkout so stale remote edits cannot block install.
- Make fresh deploy complete all setup steps: checks, prod Postgres, backups, dev replica, and first `dev` branch.
- Stop creating or using basic auth for deploy, deploy-dev, and Hetzner e2e checks.
- Document the Hetzner test setup deploy flow in `AGENTS.md`.

## API routes, procedures, contracts

- No API routes added, updated, or deleted.
- No procedures added, updated, or deleted.
- Deploy contract changed: the Hetzner test setup must stay directly open, with no `VELO_BASIC_AUTH_*` gate, and fresh deploy should leave setup complete.

## Checks

- `bash -n scripts/*.sh`
- `bun run typecheck`
- Fresh redeploy to `157.180.22.136` and `89.167.89.255`
- Verified remote setup is 6/6 and `dev` branch is running
