### PR TITLE
fix(sql): run query with keyboard shortcut

### DIFF
--- a/src/web/routes/branch/$branchId/sql.tsx
+++ b/src/web/routes/branch/$branchId/sql.tsx
@@ -47,8 +47,11 @@ function SqlEditorPage() {
 
   const branch = getBranchView(state, params.branchId);
 
-  async function handleRunSql(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
+  async function runCurrentSql() {
+    if (runSql.isPending || !sql.trim() || branch.status === 'missing') {
+      return;
+    }
+
     const branchId = params.branchId;
     setError(null);
 
@@ -71,6 +74,11 @@ function SqlEditorPage() {
       setError(getErrorMessage(caught, 'SQL failed'));
       setResult(null);
     }
+  }
+
+  function handleRunSql(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void runCurrentSql();
   }
 
   return (
@@ -104,6 +112,14 @@ function SqlEditorPage() {
                 value={sql}
                 onChange={function updateSql(event) {
                   setSql(event.target.value);
+                }}
+                onKeyDown={function runSqlShortcut(event) {
+                  if (event.key !== 'Enter' || (!event.metaKey && !event.ctrlKey)) {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  void runCurrentSql();
                 }}
               />
             </form>


### PR DESCRIPTION
## Summary
- add Cmd+Enter and Ctrl+Enter handling in SQL editor textarea
- reuse existing run guards for empty SQL, missing branches, and pending runs

## API routes, procedures, contracts
- none

## Checks
- bun test src/server/control-plane.test.ts src/managers/docker.test.ts
- bun run typecheck (fails on existing src/web/routes/settings.tsx checked errors)