### PR TITLE
feat(branches): add branch ttl cleanup

### DIFF
--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -3,17 +3,24 @@ import { getDb } from '#db/client';
 import { publicProcedure } from './context';
 import { userFacingError } from './errors';
 import { createJob, runJob } from '#server/services/job-service';
-import { createBranchFromBase, createPreviewBranch, deleteBranch, normalizeBranchSlug, resetBranchFromParent } from '#server/services/branch-service';
+import { createBranchFromBase, createPreviewBranch, deleteBranch, normalizeBranchSlug, resetBranchFromParent, updateBranchExpiry } from '#server/services/branch-service';
 import { restoreDevelopmentBranchFromPgBackRest, restoreProductionFromPgBackRest } from '#server/services/pgbackrest-restore-service';
 import { runBranchSql } from '#server/services/sql-editor-service';
 
 const branchInput = z.object({
   name: z.string().min(1),
   parentBranchId: z.number().int().positive().nullable().optional(),
+  ttlHours: z.number().positive().nullable().optional(),
+  expiresAt: z.string().nullable().optional(),
 });
 
 const branchIdInput = z.object({
   id: z.number().int().positive(),
+});
+
+const branchExpiryInput = z.object({
+  id: z.number().int().positive(),
+  expiresAt: z.string().nullable(),
 });
 
 const previewBranchInput = z.object({
@@ -58,6 +65,13 @@ export const branchesRouter = {
       });
       return job;
     }),
+  expiry: {
+    update: publicProcedure
+      .input(branchExpiryInput)
+      .handler(async function updateExpiry({ input }) {
+        return updateBranchExpiry(input);
+      }),
+  },
   preview: {
     create: publicProcedure
       .input(previewBranchInput)

--- a/src/db/generated.ts
+++ b/src/db/generated.ts
@@ -20,6 +20,7 @@ export interface Branches {
   projectId: number;
   slug: string;
   sourceReplayAt: string | null;
+  expiresAt: string | null;
   status: Generated<string>;
   updatedAt: Generated<string>;
 }

--- a/src/db/migrations/005_branch_expiry.sql
+++ b/src/db/migrations/005_branch_expiry.sql
@@ -1,0 +1,1 @@
+alter table branches add column expires_at text;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -51,6 +51,7 @@ export interface BranchesTable {
   status: 'creating' | 'running' | 'stopped' | 'error';
   parentBranchId: number | null;
   sourceReplayAt: string | null;
+  expiresAt: string | null;
   connectionUrl: string | null;
   createdAt: Timestamp;
   updatedAt: Timestamp;

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { closeDb, getDb } from '../db/client';
 import { migrateDatabase } from '../db/migrate';
 import { createJob, getActiveJob, getJob, listJobs, runJob } from './services/job-service';
-import { createBranchFromBase } from './services/branch-service';
+import { createBranchFromBase, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, saveServer } from './services/setup-state-service';
@@ -156,6 +156,57 @@ describe('control plane database', function controlPlaneDatabase() {
       .executeTakeFirstOrThrow();
 
     expect(firstBranchStep.status).toBe('pending');
+  });
+
+  test('tracks branch expiry and skips active cleanup targets', async function testBranchExpiry() {
+    const db = getDb();
+    await db
+      .insertInto('projects')
+      .values({
+        name: 'prod',
+        postgresVersion: '17',
+        databaseName: 'postgres',
+        appUser: 'postgres',
+      })
+      .execute();
+    const project = await db
+      .selectFrom('projects')
+      .select('id')
+      .where('name', '=', 'prod')
+      .executeTakeFirstOrThrow();
+
+    await db
+      .insertInto('branches')
+      .values({
+        projectId: project.id,
+        slug: 'preview-1',
+        displayName: 'preview-1',
+        dataset: 'prod_preview_1',
+        status: 'running',
+        expiresAt: '2026-05-01T00:00:00.000Z',
+      })
+      .execute();
+
+    const branch = await db
+      .selectFrom('branches')
+      .select(['id'])
+      .where('slug', '=', 'preview-1')
+      .executeTakeFirstOrThrow();
+    const activeJob = await createJob('reset-branch', { id: branch.id });
+
+    await updateBranchExpiry({ id: branch.id, expiresAt: '2026-05-02T00:00:00.000Z' });
+    await runExpiredBranchCleanup();
+
+    const updated = await db
+      .selectFrom('branches')
+      .select(['expiresAt'])
+      .where('id', '=', branch.id)
+      .executeTakeFirstOrThrow();
+    const cleanupJob = await getActiveJob('branch-cleanup');
+
+    expect(activeJob.status).toBe('queued');
+    expect(updated.expiresAt).toBe('2026-05-02T00:00:00.000Z');
+    expect(cleanupJob).toBeUndefined();
   });
 });
 

--- a/src/server/services/branch-cleanup-scheduler.ts
+++ b/src/server/services/branch-cleanup-scheduler.ts
@@ -1,0 +1,42 @@
+import { runExpiredBranchCleanup } from './branch-service';
+
+const CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+let interval: ReturnType<typeof setInterval> | null = null;
+let running = false;
+
+export function startBranchCleanupScheduler(): void {
+  if (interval || process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  void checkExpiredBranches();
+  interval = setInterval(function checkBranches() {
+    void checkExpiredBranches();
+  }, CHECK_INTERVAL_MS);
+}
+
+export function stopBranchCleanupScheduler(): void {
+  if (!interval) {
+    return;
+  }
+
+  clearInterval(interval);
+  interval = null;
+}
+
+async function checkExpiredBranches(): Promise<void> {
+  if (running) {
+    return;
+  }
+
+  running = true;
+
+  try {
+    await runExpiredBranchCleanup();
+  } catch (error) {
+    console.error('[branches] cleanup failed', error);
+  } finally {
+    running = false;
+  }
+}

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -11,6 +11,7 @@ import { runCommand } from './command-service';
 import { setStepStatus } from './setup-state-service';
 import { createBranchFromPgBackRest } from './pgbackrest-restore-service';
 import { createLocalDockerBranch, deleteLocalDockerBranch, isLocalDockerMode } from './local-docker-service';
+import { createJob, getActiveJobs, runJob } from './job-service';
 
 const PROJECT_NAME = 'prod';
 const BASE_BRANCH_NAME = 'base';
@@ -19,6 +20,8 @@ export interface CreateBranchInput {
   name: string;
   parentBranchId?: number | null;
   slug?: string;
+  expiresAt?: string | null;
+  ttlHours?: number | null;
 }
 
 export interface CreatePreviewBranchInput {
@@ -43,10 +46,16 @@ export interface DeleteBranchResult {
   displayName: string;
 }
 
+export interface UpdateBranchExpiryInput {
+  id: number;
+  expiresAt: string | null;
+}
+
 export async function createBranchFromBase(input: CreateBranchInput): Promise<CreateBranchResult> {
   const displayName = normalizeDisplayName(input.name);
   const branchSlug = normalizeBranchSlug(input.slug || input.name);
   const source = await resolveBranchSource(input.parentBranchId);
+  const expiresAt = resolveExpiresAt(input);
 
   if (source.slug === branchSlug) {
     throw new Error('A branch cannot be created from itself');
@@ -64,6 +73,7 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
         sourceDatabase: source.dataset,
         sourceReplayAt: new Date().toISOString(),
         parentBranchId: source.id,
+        expiresAt,
       });
 
       await setStepStatus('first-branch', 'done', `${displayName} ready`);
@@ -78,6 +88,7 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
       sourceDataset: source.dataset,
       sourceReplayAt: new Date().toISOString(),
       parentBranchId: source.id,
+      expiresAt,
       publicAccess: true,
       readOnly: false,
     });
@@ -116,6 +127,7 @@ async function createBranchClone(options: {
   sourceDataset: string;
   sourceReplayAt: string;
   parentBranchId: number | null;
+  expiresAt: string | null;
   publicAccess: boolean;
   readOnly: boolean;
 }): Promise<CreateBranchResult> {
@@ -208,6 +220,7 @@ async function createBranchClone(options: {
         parentBranchId: options.parentBranchId,
         connectionUrl: connectionUrl,
         sourceReplayAt: options.sourceReplayAt,
+        expiresAt: options.expiresAt,
       })
       .execute();
 
@@ -253,6 +266,65 @@ export async function resetBranchFromParent(input: DeleteBranchInput): Promise<C
     slug: branch.slug,
     parentBranchId: branch.parentBranchId,
   });
+}
+
+export async function updateBranchExpiry(input: UpdateBranchExpiryInput): Promise<void> {
+  const branch = await getDb()
+    .selectFrom('branches')
+    .select(['id'])
+    .where('id', '=', input.id)
+    .executeTakeFirst();
+
+  if (!branch) {
+    throw new Error('Branch not found');
+  }
+
+  await getDb()
+    .updateTable('branches')
+    .set({
+      expiresAt: parseOptionalExpiry(input.expiresAt),
+    })
+    .where('id', '=', input.id)
+    .execute();
+}
+
+export async function runExpiredBranchCleanup(): Promise<void> {
+  const active = await getActiveJobs();
+  const expired = await getDb()
+    .selectFrom('branches')
+    .select(['id', 'slug', 'displayName', 'expiresAt'])
+    .where('expiresAt', 'is not', null)
+    .where('expiresAt', '<=', new Date().toISOString())
+    .orderBy('expiresAt', 'asc')
+    .execute();
+
+  for (const branch of expired) {
+    if (hasActiveBranchJob(branch.id, branch.slug, active)) {
+      continue;
+    }
+
+    const child = await getDb()
+      .selectFrom('branches')
+      .select(['id'])
+      .where('parentBranchId', '=', branch.id)
+      .executeTakeFirst();
+
+    if (child) {
+      continue;
+    }
+
+    const job = await createJob('branch-cleanup', {
+      branchId: branch.id,
+      branchSlug: branch.slug,
+      expiresAt: branch.expiresAt,
+    });
+
+    runJob(job, async function runBranchCleanupJob(context) {
+      await context.log(`deleting expired branch ${branch.displayName}`);
+      const result = await deleteBranch({ id: branch.id });
+      await context.log(`deleted expired branch ${result.displayName}`);
+    });
+  }
 }
 
 async function resolveBranchSource(parentBranchId: number | null | undefined): Promise<{ id: number | null; slug: string; dataset: string }> {
@@ -522,6 +594,55 @@ function parseRestoreTime(value: string): Date {
   }
 
   return date;
+}
+
+function resolveExpiresAt(input: CreateBranchInput): string | null {
+  if (input.expiresAt !== undefined) {
+    return parseOptionalExpiry(input.expiresAt);
+  }
+
+  if (!input.ttlHours) {
+    return null;
+  }
+
+  if (!Number.isFinite(input.ttlHours) || input.ttlHours <= 0) {
+    throw new Error('TTL must be greater than zero');
+  }
+
+  return new Date(Date.now() + input.ttlHours * 60 * 60 * 1000).toISOString();
+}
+
+function parseOptionalExpiry(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const expiresAt = new Date(value);
+
+  if (Number.isNaN(expiresAt.getTime())) {
+    throw new Error('Expiry time is invalid');
+  }
+
+  return expiresAt.toISOString();
+}
+
+function hasActiveBranchJob(branchId: number, branchSlug: string, jobs: Awaited<ReturnType<typeof getActiveJobs>>): boolean {
+  return jobs.some(function isBranchJob(job) {
+    if (job.type === 'branch-cleanup') {
+      return true;
+    }
+
+    if (!job.inputJson) {
+      return false;
+    }
+
+    try {
+      const input = JSON.parse(job.inputJson) as Record<string, unknown>;
+      return input.id === branchId || input.branchId === branchId || input.targetBranch === branchSlug;
+    } catch {
+      return false;
+    }
+  });
 }
 
 function shellQuote(value: string): string {

--- a/src/server/services/job-service.ts
+++ b/src/server/services/job-service.ts
@@ -87,6 +87,15 @@ export async function getActiveJob(type: string): Promise<Job | undefined> {
     .executeTakeFirst();
 }
 
+export async function getActiveJobs(): Promise<Job[]> {
+  return getDb()
+    .selectFrom('jobs')
+    .selectAll()
+    .where('status', 'in', ['queued', 'running'])
+    .orderBy('id', 'desc')
+    .execute();
+}
+
 async function runJobInternal(job: Job, handler: (context: JobContext) => Promise<void>): Promise<void> {
   await updateJob(job.id, 'running', null, {
     startedAt: new Date().toISOString(),

--- a/src/server/services/local-docker-service.ts
+++ b/src/server/services/local-docker-service.ts
@@ -14,6 +14,7 @@ export interface LocalDockerBranchInput {
   sourceDatabase: string;
   sourceReplayAt: string;
   parentBranchId: number | null;
+  expiresAt: string | null;
 }
 
 export interface LocalDockerBranchResult {
@@ -157,6 +158,7 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
       parentBranchId: input.parentBranchId,
       connectionUrl: connectionUrl,
       sourceReplayAt: input.sourceReplayAt,
+      expiresAt: input.expiresAt,
     })
     .execute();
 

--- a/src/server/services/setup-state-service.ts
+++ b/src/server/services/setup-state-service.ts
@@ -33,6 +33,7 @@ export interface ControlPlaneState {
     parentSlug: string | null;
     port: number | null;
     connectionUrl: string | null;
+    expiresAt: string | null;
     createdAt: string;
   }>;
   jobs: JobRecord[];
@@ -63,6 +64,7 @@ export async function getControlPlaneState(): Promise<ControlPlaneState> {
         'parent.slug as parentSlug',
         'branches.port',
         'branches.connectionUrl',
+        'branches.expiresAt',
         'branches.createdAt',
       ])
       .where('branches.slug', 'not like', 'preview-%')

--- a/src/server/web-runtime.ts
+++ b/src/server/web-runtime.ts
@@ -3,6 +3,7 @@ import { join, normalize, relative } from 'node:path';
 import { migrateDatabase } from '#db/migrate';
 import { persistUpdateResult } from '#server/services/update-service';
 import { startUpdateScheduler } from '#server/services/update-scheduler';
+import { startBranchCleanupScheduler } from '#server/services/branch-cleanup-scheduler';
 
 const host = process.env.HOST || '0.0.0.0';
 const port = Number(process.env.PORT || 3000);
@@ -11,6 +12,7 @@ const clientDir = join(process.cwd(), 'dist/client');
 migrateDatabase();
 await persistUpdateResult();
 startUpdateScheduler();
+startBranchCleanupScheduler();
 
 const serverEntryPath = new URL('../../dist/server/server.js', import.meta.url).href;
 const serverEntry = (await import(serverEntryPath)) as {

--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -426,6 +426,7 @@ export interface BranchesPanelProps {
     status: string;
     port: number | null;
     connectionUrl: string | null;
+    expiresAt: string | null;
   }>;
   busy: string | null;
   onCreate: (formData: FormData) => Promise<void>;
@@ -441,6 +442,7 @@ interface BranchTreePanelProps {
     parentBranchId: number | null;
     parentName: string | null;
     parentSlug: string | null;
+    expiresAt: string | null;
   }>;
   prodReady: boolean;
 }
@@ -521,7 +523,7 @@ function BranchTreeItem(props: { node: BranchTreeNode }) {
             <p className="truncate font-medium">{branch.displayName}</p>
           </div>
           <p className="mt-1 truncate text-xs text-muted-foreground">
-            from {branch.parentName || branch.parentSlug || 'prod'}
+            {formatBranchLine(branch.parentName || branch.parentSlug || 'prod', branch.expiresAt)}
           </p>
         </div>
         <StatusBadge status={branch.status} />
@@ -591,7 +593,7 @@ export function BranchesPanel(props: BranchesPanelProps) {
           <CardTitle>Branches</CardTitle>
           <CardDescription>Writable ZFS clones from the dev base.</CardDescription>
         </div>
-        <BranchCreateForm busy={props.busy === 'create-branch'} onCreate={props.onCreate} />
+        <BranchCreateForm branches={props.branches} busy={props.busy === 'create-branch'} onCreate={props.onCreate} />
       </CardHeader>
       <CardContent className="p-0">
         {props.branches.length === 0 ? (
@@ -610,7 +612,7 @@ export function BranchesPanel(props: BranchesPanelProps) {
               }
 
               return (
-                <div className="grid gap-3 px-5 py-4 md:grid-cols-[1fr_120px_80px_auto] md:items-center" key={branch.id}>
+                <div className="grid gap-3 px-5 py-4 md:grid-cols-[1fr_120px_150px_80px_auto] md:items-center" key={branch.id}>
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       <GitBranch className="size-4 text-muted-foreground" />
@@ -621,6 +623,7 @@ export function BranchesPanel(props: BranchesPanelProps) {
                     </div>
                   </div>
                   <StatusBadge status={branch.status} />
+                  <div className="text-sm text-muted-foreground">{formatExpiry(branch.expiresAt)}</div>
                   <div className="text-sm text-muted-foreground">{branch.port || '-'}</div>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
@@ -655,7 +658,7 @@ export function BranchesPanel(props: BranchesPanelProps) {
                       </AlertDialogFooter>
                     </AlertDialogContent>
                   </AlertDialog>
-                  <div className="hidden md:col-span-4 md:block">
+                  <div className="hidden md:col-span-5 md:block">
                     <ConnectionString value={branch.connectionUrl} />
                   </div>
                 </div>
@@ -669,6 +672,7 @@ export function BranchesPanel(props: BranchesPanelProps) {
 }
 
 interface BranchCreateFormProps {
+  branches: BranchesPanelProps['branches'];
   busy: boolean;
   onCreate: (formData: FormData) => Promise<void>;
 }
@@ -682,14 +686,73 @@ function BranchCreateForm(props: BranchCreateFormProps) {
   }
 
   return (
-    <form className="grid grid-cols-[minmax(0,180px)_auto] gap-2" onSubmit={submitForm}>
+    <form className="grid grid-cols-[minmax(0,180px)_140px_120px_auto] gap-2" onSubmit={submitForm}>
       <Input name="name" placeholder="preview-1" />
+      <Select name="parentBranchId" defaultValue="prod">
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="prod">production</SelectItem>
+          {props.branches.map(function renderParentOption(branch) {
+            return (
+              <SelectItem key={branch.id} value={String(branch.id)}>
+                {branch.displayName}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+      <Select name="ttlHours" defaultValue="none">
+        <SelectTrigger>
+          <SelectValue placeholder="no expiry" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="none">no expiry</SelectItem>
+          <SelectItem value="1">1h</SelectItem>
+          <SelectItem value="24">1 day</SelectItem>
+          <SelectItem value="168">7 days</SelectItem>
+        </SelectContent>
+      </Select>
       <Button type="submit" variant="secondary" disabled={props.busy}>
         {props.busy ? <Loader2 className="animate-spin" /> : <GitBranch />}
         Create
       </Button>
     </form>
   );
+}
+
+function formatBranchLine(parent: string, expiresAt: string | null): string {
+  const expiry = formatExpiry(expiresAt);
+
+  if (expiry === 'no expiry') {
+    return `from ${parent}`;
+  }
+
+  return `from ${parent} · ${expiry}`;
+}
+
+export function formatExpiry(expiresAt: string | null): string {
+  if (!expiresAt) {
+    return 'no expiry';
+  }
+
+  const time = new Date(expiresAt).getTime();
+
+  if (Number.isNaN(time)) {
+    return 'invalid expiry';
+  }
+
+  const diffMs = time - Date.now();
+  const suffix = diffMs < 0 ? 'expired' : 'expires';
+  const absMs = Math.abs(diffMs);
+  const hours = Math.ceil(absMs / (60 * 60 * 1000));
+
+  if (hours < 48) {
+    return `${suffix} in ${hours}h`;
+  }
+
+  return `${suffix} in ${Math.ceil(hours / 24)}d`;
 }
 
 export interface ServerPanelProps {

--- a/src/web/routes/branch/$branchId/overview.tsx
+++ b/src/web/routes/branch/$branchId/overview.tsx
@@ -4,6 +4,7 @@ import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
 import {
   ChevronDown,
+  Clock3,
   GitBranch,
   Loader2,
   Pencil,
@@ -38,10 +39,18 @@ import {
 } from '#web/components/ui/dropdown-menu';
 import { Input } from '#web/components/ui/input';
 import { Label } from '#web/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '#web/components/ui/select';
 import { orpc, type ControlPlaneState } from '#web/lib/api-client';
 import {
   AppSidebar,
   BranchOverviewPanel,
+  formatExpiry,
   StatusBadge,
 } from '#web/components/control-plane';
 import { isSetupComplete, OnboardingWizard } from '#web/components/onboarding-wizard';
@@ -57,11 +66,14 @@ function BranchOverviewPage() {
   const createBranch = useMutation(orpc.branches.create.mutationOptions({ onSuccess: refreshDashboard }));
   const deleteBranch = useMutation(orpc.branches.delete.mutationOptions({ onSuccess: refreshDashboard }));
   const resetBranch = useMutation(orpc.branches.reset.mutationOptions({ onSuccess: refreshDashboard }));
+  const updateExpiry = useMutation(orpc.branches.expiry.update.mutationOptions({ onSuccess: refreshDashboard }));
   const params = Route.useParams();
   const busy = getBusyKey();
   const [message, setMessage] = useState<string | null>(null);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [childBranchName, setChildBranchName] = useState('');
+  const [childParentBranchId, setChildParentBranchId] = useState('prod');
+  const [childTtlHours, setChildTtlHours] = useState('none');
   const [confirmAction, setConfirmAction] = useState<'reset' | 'delete' | null>(null);
   const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
     return job.status === 'queued' || job.status === 'running';
@@ -115,6 +127,8 @@ function BranchOverviewPage() {
 
   function openCreateChildModal() {
     setChildBranchName(`${branch.id}-child`);
+    setChildParentBranchId(branch.rowId ? String(branch.rowId) : 'prod');
+    setChildTtlHours('none');
     setCreateModalOpen(true);
   }
 
@@ -128,8 +142,12 @@ function BranchOverviewPage() {
     }
 
     setMessage(null);
-    const result = await createBranch.mutateAsync({ name, parentBranchId: branch.rowId });
-    setMessage(`Creating child branch ${name} from ${branch.name}.`);
+    const result = await createBranch.mutateAsync({
+      name,
+      parentBranchId: childParentBranchId !== 'prod' ? Number(childParentBranchId) : null,
+      ttlHours: childTtlHours !== 'none' ? Number(childTtlHours) : null,
+    });
+    setMessage(`Creating branch ${name}.`);
     setCreateModalOpen(false);
 
     if (result.branchSlug) {
@@ -169,6 +187,17 @@ function BranchOverviewPage() {
     if (action === 'delete') {
       void handleDelete();
     }
+  }
+
+  async function handleExpiry(value: string) {
+    if (!branch.rowId) {
+      return;
+    }
+
+    const expiresAt = value === 'none' ? null : new Date(Date.now() + Number(value) * 60 * 60 * 1000).toISOString();
+    setMessage(null);
+    await updateExpiry.mutateAsync({ id: branch.rowId, expiresAt });
+    setMessage(expiresAt ? `Expiry set for ${branch.name}.` : `Expiry disabled for ${branch.name}.`);
   }
 
   return (
@@ -224,6 +253,33 @@ function BranchOverviewPage() {
                       Edit name
                     </DropdownMenuItem>
                     <DropdownMenuItem
+                      disabled={branch.id === 'prod' || updateExpiry.isPending}
+                      onSelect={function extendOneDay() {
+                        void handleExpiry('24');
+                      }}
+                    >
+                      <Clock3 />
+                      Expire in 1 day
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={branch.id === 'prod' || updateExpiry.isPending}
+                      onSelect={function extendSevenDays() {
+                        void handleExpiry('168');
+                      }}
+                    >
+                      <Clock3 />
+                      Expire in 7 days
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={branch.id === 'prod' || updateExpiry.isPending}
+                      onSelect={function disableExpiry() {
+                        void handleExpiry('none');
+                      }}
+                    >
+                      <Clock3 />
+                      Disable expiry
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
                       variant="destructive"
                       disabled={branch.id === 'prod' || busy === 'delete'}
                       onSelect={function selectDelete() {
@@ -249,6 +305,11 @@ function BranchOverviewPage() {
               connectionLabel={`${branch.name} connection string`}
               connectionUrl={branch.connectionUrl}
             />
+
+            <div className="rounded-lg border border-border bg-muted/20 p-4">
+              <p className="text-sm font-medium">Expiry</p>
+              <p className="mt-1 text-sm text-muted-foreground">{branch.id === 'prod' ? 'production never expires' : formatExpiry(branch.expiresAt)}</p>
+            </div>
           </div>
         </section>
       </div>
@@ -266,6 +327,25 @@ function BranchOverviewPage() {
             </DialogHeader>
 
             <div className="mt-5 grid gap-2">
+              <Label>Parent branch</Label>
+              <Select value={childParentBranchId} onValueChange={setChildParentBranchId}>
+                <SelectTrigger className="h-9 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="prod">production</SelectItem>
+                  {state.branches.map(function renderParentOption(item) {
+                    return (
+                      <SelectItem key={item.id} value={String(item.id)}>
+                        {item.displayName}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="mt-4 grid gap-2">
               <Label htmlFor="child-branch-name">Branch name</Label>
               <Input
                 id="child-branch-name"
@@ -275,6 +355,21 @@ function BranchOverviewPage() {
                   setChildBranchName(event.target.value);
                 }}
               />
+            </div>
+
+            <div className="mt-4 grid gap-2">
+              <Label>Expiry</Label>
+              <Select value={childTtlHours} onValueChange={setChildTtlHours}>
+                <SelectTrigger className="h-9 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">no expiry</SelectItem>
+                  <SelectItem value="1">1h</SelectItem>
+                  <SelectItem value="24">1 day</SelectItem>
+                  <SelectItem value="168">7 days</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
             <DialogFooter className="mt-6">
@@ -343,6 +438,7 @@ function getBranchView(state: ControlPlaneState, branchId: string) {
       badge: 'Production',
       status: state.prodConnectionUrl ? 'ready' : 'pending',
       connectionUrl: state.prodConnectionUrl,
+      expiresAt: null,
     };
   }
 
@@ -361,6 +457,7 @@ function getBranchView(state: ControlPlaneState, branchId: string) {
     badge: 'Development',
     status: branch?.status || 'missing',
     connectionUrl: branch?.connectionUrl || null,
+    expiresAt: branch?.expiresAt || null,
   };
 }
 

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -167,7 +167,13 @@ function SettingsPage() {
 
   async function handleCreateBranch(formData: FormData) {
     const name = String(formData.get('name') || '');
-    await createBranch.mutateAsync({ name });
+    const ttlHours = formData.get('ttlHours');
+    const parentBranchId = formData.get('parentBranchId');
+    await createBranch.mutateAsync({
+      name,
+      parentBranchId: parentBranchId && parentBranchId !== 'prod' ? Number(parentBranchId) : null,
+      ttlHours: ttlHours && ttlHours !== 'none' ? Number(ttlHours) : null,
+    });
   }
 
   async function handleDeleteBranch(id: number) {
@@ -419,15 +425,15 @@ function UpdatePanel() {
 
         <div className="grid gap-3 rounded-lg border border-border bg-muted/20 p-4">
           <Label className="flex items-center gap-2">
-            <Checkbox checked={autoSettings?.enabled ?? true} onChange={function changeEnabled(event) { updateAutoEnabled(event.currentTarget.checked); }} />
+            <Checkbox checked={autoSettings?.enabled ?? true} onCheckedChange={function changeEnabled(checked) { updateAutoEnabled(checked === true); }} />
             Auto check
           </Label>
           <Label className="flex items-center gap-2">
-            <Checkbox checked={autoSettings?.applyPatches ?? false} onChange={function changePatches(event) { updateAutoPatches(event.currentTarget.checked); }} />
+            <Checkbox checked={autoSettings?.applyPatches ?? false} onCheckedChange={function changePatches(checked) { updateAutoPatches(checked === true); }} />
             Auto apply patch releases
           </Label>
           <Label className="flex items-center gap-2">
-            <Checkbox checked={autoSettings?.applyMigrations ?? false} onChange={function changeMigrations(event) { updateAutoMigrations(event.currentTarget.checked); }} />
+            <Checkbox checked={autoSettings?.applyMigrations ?? false} onCheckedChange={function changeMigrations(checked) { updateAutoMigrations(checked === true); }} />
             Allow migration updates
           </Label>
           <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
## Summary
- add optional branch expiry metadata and create-form TTL presets
- show and edit branch expiry from branch lists and overview
- add a production cleanup scheduler that records `branch-cleanup` jobs and skips active branch work

## Contracts
- adds `branches.expires_at`
- updates `branches.create` to accept `ttlHours` or `expiresAt`
- adds `branches.expiry.update`
- dashboard branch payload now includes `expiresAt`

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`

Closes #82
