### PR TITLE
feat(jobs): add retryable sqlite queue

### DIFF
--- a/src/api/bootstrap.ts
+++ b/src/api/bootstrap.ts
@@ -1,12 +1,6 @@
 import { z } from 'zod';
-import { getDb } from '#db/client';
-import { assertOk } from './helpers';
 import { publicProcedure } from './context';
-import { runDevBootstrap, runProdBootstrap } from '#server/services/bootstrap-service';
-import { createJob, getActiveJob, runJob } from '#server/services/job-service';
-import { createBranchFromBase } from '#server/services/branch-service';
-import { createReplicaBase } from '#server/services/replica-service';
-import { checkServer } from '#server/services/setup-state-service';
+import { createJob, getActiveJob } from '#server/services/job-service';
 
 const bootstrapInput = z.object({
   target: z.enum(['prod', 'dev']),
@@ -21,16 +15,6 @@ export const bootstrapRouter = {
     }
 
     const job = await createJob(jobType);
-    runJob(job, async function runBootstrapJob(context) {
-      if (input.target === 'prod') {
-        await context.log('installing prod Postgres and backups');
-        assertOk(await runProdBootstrap());
-        return;
-      }
-
-      await context.log('installing dev prerequisites');
-      assertOk(await runDevBootstrap());
-    });
     return job;
   }),
   complete: publicProcedure.handler(async function completeSetup() {
@@ -40,42 +24,6 @@ export const bootstrapRouter = {
     }
 
     const job = await createJob('setup');
-    runJob(job, async function runSetupJob(context) {
-      if (!(await isStepDone('dev-check'))) {
-        await context.log('setting up dev server');
-        assertOk(await runDevBootstrap());
-      }
-
-      if (!(await isStepDone('prod-check'))) {
-        await context.log('checking prod server');
-        await checkServer('prod');
-      }
-
-      if (!(await isStepDone('prod-setup')) || !(await isStepDone('backups'))) {
-        await context.log('setting up prod Postgres and backups');
-        assertOk(await runProdBootstrap());
-      }
-
-      if (!(await isStepDone('replica'))) {
-        await context.log('creating dev replica base');
-        assertOk(await createReplicaBase());
-      }
-
-      if (!(await isStepDone('first-branch'))) {
-        await context.log('creating first dev branch');
-        await createBranchFromBase({ name: 'dev' });
-      }
-    });
     return job;
   }),
 };
-
-async function isStepDone(key: string): Promise<boolean> {
-  const step = await getDb()
-    .selectFrom('setupSteps')
-    .select(['status'])
-    .where('key', '=', key)
-    .executeTakeFirst();
-
-  return step?.status === 'done';
-}

--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod';
-import { getDb } from '#db/client';
 import { publicProcedure } from './context';
 import { userFacingError } from './errors';
-import { createJob, runJob } from '#server/services/job-service';
-import { createBranchFromBase, createPreviewBranch, deleteBranch, normalizeBranchSlug, resetBranchFromParent } from '#server/services/branch-service';
-import { restoreDevelopmentBranchFromPgBackRest, restoreProductionFromPgBackRest } from '#server/services/pgbackrest-restore-service';
+import { createJob } from '#server/services/job-service';
+import { createPreviewBranch, normalizeBranchSlug } from '#server/services/branch-service';
 import { runBranchSql } from '#server/services/sql-editor-service';
 
 const branchInput = z.object({
@@ -38,10 +36,6 @@ export const branchesRouter = {
     .handler(async function createBranch({ input }) {
       const branchSlug = normalizeBranchSlug(input.name);
       const job = await createJob('create-branch', input);
-      runJob(job, async function runCreateBranchJob(context) {
-        await context.log(`creating branch ${input.name}`);
-        await createBranchFromBase(input);
-      });
       return {
         ...job,
         branchSlug,
@@ -51,11 +45,6 @@ export const branchesRouter = {
     .input(branchIdInput)
     .handler(async function deleteBranchById({ input }) {
       const job = await createJob('delete-branch', input);
-      runJob(job, async function runDeleteBranchJob(context) {
-        await context.log(`deleting branch ${input.id}`);
-        const result = await deleteBranch(input);
-        await context.log(`deleted branch ${result.displayName}`);
-      });
       return job;
     }),
   preview: {
@@ -67,7 +56,7 @@ export const branchesRouter = {
     delete: publicProcedure
       .input(branchIdInput)
       .handler(async function deleteBranchPreview({ input }) {
-        return deleteBranch(input);
+        return createJob('delete-branch', input);
       }),
   },
   sql: {
@@ -85,48 +74,12 @@ export const branchesRouter = {
     .input(restoreBranchInput)
     .handler(async function restoreBranch({ input }) {
       const job = await createJob('restore-branch', input);
-      runJob(job, async function runRestoreBranchJob(context) {
-        await context.log(`restoring ${input.targetBranch} from ${input.sourceBranch}`);
-
-        if (input.targetBranch === 'prod') {
-          await restoreProductionFromPgBackRest(input);
-          await context.log('production restore completed');
-          return;
-        }
-
-        const existing = await findBranchBySlug(normalizeBranchLookup(input.targetBranch));
-
-        if (existing) {
-          await context.log(`replacing existing branch ${input.targetBranch}`);
-          await deleteBranch({ id: existing.id });
-        }
-
-        const result = await restoreDevelopmentBranchFromPgBackRest(input);
-        await context.log(`branch restored: ${result.displayName}`);
-      });
       return job;
     }),
   reset: publicProcedure
     .input(branchIdInput)
     .handler(async function resetBranch({ input }) {
       const job = await createJob('reset-branch', input);
-      runJob(job, async function runResetBranchJob(context) {
-        await context.log(`resetting branch ${input.id} from parent`);
-        const result = await resetBranchFromParent(input);
-        await context.log(`reset branch ${result.displayName}`);
-      });
       return job;
     }),
 };
-
-async function findBranchBySlug(slug: string): Promise<{ id: number } | undefined> {
-  return getDb()
-    .selectFrom('branches')
-    .select(['id'])
-    .where('slug', '=', slug)
-    .executeTakeFirst();
-}
-
-function normalizeBranchLookup(name: string): string {
-  return name.trim().toLowerCase();
-}

--- a/src/api/replica-base.ts
+++ b/src/api/replica-base.ts
@@ -1,7 +1,5 @@
-import { assertOk } from './helpers';
 import { publicProcedure } from './context';
-import { createJob, getActiveJob, runJob } from '#server/services/job-service';
-import { createReplicaBase } from '#server/services/replica-service';
+import { createJob, getActiveJob } from '#server/services/job-service';
 
 export const replicaBaseRouter = {
   create: publicProcedure.handler(async function createReplicaBaseJob() {
@@ -11,10 +9,6 @@ export const replicaBaseRouter = {
     }
 
     const job = await createJob('replica-base');
-    runJob(job, async function runReplicaBaseJob(context) {
-      await context.log('creating dev replica base');
-      assertOk(await createReplicaBase());
-    });
     return job;
   }),
 };

--- a/src/db/bun-sqlite.ts
+++ b/src/db/bun-sqlite.ts
@@ -45,5 +45,5 @@ class BunSqliteStatement {
 
 function isReadStatement(sql: string): boolean {
   const firstWord = sql.trimStart().split(/\s+/, 1)[0]?.toLowerCase();
-  return firstWord === 'select' || firstWord === 'pragma' || firstWord === 'with';
+  return firstWord === 'select' || firstWord === 'pragma' || firstWord === 'with' || /\breturning\b/i.test(sql);
 }

--- a/src/db/generated.ts
+++ b/src/db/generated.ts
@@ -33,11 +33,17 @@ export interface JobLogs {
 }
 
 export interface Jobs {
+  attempts: Generated<number>;
   createdAt: Generated<string>;
   error: string | null;
   finishedAt: string | null;
+  heartbeatAt: string | null;
   id: Generated<number | null>;
   inputJson: string | null;
+  lockedAt: string | null;
+  lockedBy: string | null;
+  maxAttempts: Generated<number>;
+  runAfter: string | null;
   startedAt: string | null;
   status: Generated<string>;
   type: string;

--- a/src/db/migrations/005_job_queue.sql
+++ b/src/db/migrations/005_job_queue.sql
@@ -1,0 +1,11 @@
+alter table jobs add column attempts integer not null default 0;
+alter table jobs add column max_attempts integer not null default 1;
+alter table jobs add column run_after text;
+alter table jobs add column locked_at text;
+alter table jobs add column locked_by text;
+alter table jobs add column heartbeat_at text;
+
+update jobs set run_after = datetime('now') where run_after is null;
+
+create index if not exists jobs_queue_idx on jobs(status, run_after, id);
+create index if not exists jobs_running_heartbeat_idx on jobs(status, heartbeat_at);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -62,6 +62,12 @@ export interface JobsTable {
   status: 'queued' | 'running' | 'done' | 'error';
   inputJson: string | null;
   error: string | null;
+  attempts: Generated<number>;
+  maxAttempts: Generated<number>;
+  runAfter: string | null;
+  lockedAt: string | null;
+  lockedBy: string | null;
+  heartbeatAt: string | null;
   createdAt: Timestamp;
   startedAt: string | null;
   finishedAt: string | null;

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
+import { sql } from 'kysely';
 import { closeDb, getDb } from '../db/client';
 import { migrateDatabase } from '../db/migrate';
-import { createJob, getActiveJob, getJob, listJobs, runJob } from './services/job-service';
+import { createJob, getActiveJob, getJob, listJobs, startJobWorker, type JobHandlers } from './services/job-service';
 import { createBranchFromBase } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
@@ -76,6 +78,37 @@ describe('control plane database', function controlPlaneDatabase() {
     expect(steps.every(function isPending(step) {
       return step.status === 'pending';
     })).toBe(true);
+  });
+
+  test('migrates job queue columns on existing databases', async function testExistingJobMigration() {
+    const originalDb = process.env.VELO_DB;
+    const existingDir = mkdtempSync(join(tmpdir(), 'velo-existing-jobs-'));
+    const existingDbPath = join(existingDir, 'velo.sqlite');
+
+    await closeDb();
+
+    try {
+      createPreQueueDatabase(existingDbPath);
+      process.env.VELO_DB = existingDbPath;
+      migrateDatabase();
+
+      const db = new Database(existingDbPath);
+      const job = db
+        .query('select type, attempts, max_attempts, run_after from jobs where type = ?')
+        .get('old-job') as { type: string; attempts: number; max_attempts: number; run_after: string | null };
+      db.close();
+
+      expect(job).toMatchObject({
+        type: 'old-job',
+        attempts: 0,
+        max_attempts: 1,
+      });
+      expect(job.run_after).toBeTruthy();
+    } finally {
+      await closeDb();
+      process.env.VELO_DB = originalDb;
+      rmSync(existingDir, { recursive: true, force: true });
+    }
   });
 
   test('returns dashboard state without leaking backup secrets', async function testControlPlaneState() {
@@ -159,15 +192,36 @@ describe('control plane database', function controlPlaneDatabase() {
   });
 });
 
+function createPreQueueDatabase(databasePath: string): void {
+  const db = new Database(databasePath);
+  db.exec(`
+    create table schema_migrations (
+      id text primary key,
+      applied_at text not null default (datetime('now'))
+    );
+  `);
+
+  for (const id of ['001_initial', '002_jobs', '003_branch_parent', '004_branch_identity']) {
+    db.exec(readFileSync(join(process.cwd(), 'src/db/migrations', `${id}.sql`), 'utf8'));
+    db.prepare('insert into schema_migrations (id) values (?)').run(id);
+  }
+
+  db.prepare('insert into jobs (type, status) values (?, ?)').run('old-job', 'running');
+  db.close();
+}
+
 describe('control plane jobs', function controlPlaneJobs() {
   test('runs jobs, stores logs, and sanitizes secrets', async function testSuccessfulJob() {
     const job = await createJob('test-job', { branch: 'preview-1' });
-
-    runJob(job, async function handleJob(context) {
-      await context.log('using password=secret-value and secret access key abc');
+    const worker = startTestWorker({
+      'test-job': async function handleJob(_input, context) {
+        await context.log('using password=secret-value and secret access key abc');
+      },
     });
 
+    await worker.tick();
     const record = await waitForJob(job.id);
+    worker.stop();
 
     expect(record.status).toBe('done');
     expect(record.logs.some(function hasSanitizedLog(log) {
@@ -179,13 +233,16 @@ describe('control plane jobs', function controlPlaneJobs() {
 
   test('stores sanitized job failures', async function testFailedJob() {
     const job = await createJob('failing-job');
-
-    runJob(job, async function handleJob() {
-      throw new Error('failed with access key id abc123 and password=bad');
+    const worker = startTestWorker({
+      'failing-job': async function handleJob() {
+        throw new Error('failed with access key id abc123 and password=bad');
+      },
     });
 
+    await worker.tick();
     const record = await waitForJob(job.id);
     const jobs = await listJobs();
+    worker.stop();
 
     expect(record.status).toBe('error');
     expect(record.error).toContain('access_key_id=***');
@@ -195,8 +252,12 @@ describe('control plane jobs', function controlPlaneJobs() {
 
   test('finds only queued or running jobs by type', async function testActiveJob() {
     const finished = await createJob('prod-bootstrap');
-    runJob(finished, async function handleJob() {});
+    const worker = startTestWorker({
+      'prod-bootstrap': async function handleJob() {},
+    });
+    await worker.tick();
     await waitForJob(finished.id);
+    worker.stop();
 
     const active = await createJob('prod-bootstrap');
     const ignored = await createJob('dev-bootstrap');
@@ -205,7 +266,126 @@ describe('control plane jobs', function controlPlaneJobs() {
     expect(await getActiveJob('dev-bootstrap')).toMatchObject({ id: ignored.id });
     expect(await getActiveJob('missing-job')).toBeUndefined();
   });
+
+  test('retries failed jobs with backoff', async function testRetryJob() {
+    const job = await createJob('retry-job', undefined, { maxAttempts: 2 });
+    let runs = 0;
+    const worker = startTestWorker({
+      'retry-job': async function handleJob() {
+        runs += 1;
+
+        if (runs === 1) {
+          throw new Error('ssh failed');
+        }
+      },
+    });
+
+    await worker.tick();
+    const queued = await getJob(job.id);
+
+    expect(queued.status).toBe('queued');
+    expect(queued.attempts).toBe(1);
+    expect(queued.error).toBe('ssh failed');
+    expect(queued.logs.some(function hasRetryLog(log) {
+      return log.message.includes('retrying retry-job');
+    })).toBe(true);
+
+    await getDb()
+      .updateTable('jobs')
+      .set({ runAfter: sql<string>`datetime('now')` })
+      .where('id', '=', job.id)
+      .execute();
+
+    await worker.tick();
+    const done = await waitForJob(job.id);
+    worker.stop();
+
+    expect(done.status).toBe('done');
+    expect(done.attempts).toBe(2);
+  });
+
+  test('recovers stale running jobs', async function testRecoverStaleJob() {
+    const job = await createJob('stale-job', undefined, { maxAttempts: 2 });
+    const worker = startTestWorker({
+      'stale-job': async function handleJob(_input, context) {
+        await context.log('recovered');
+      },
+    });
+
+    await markRunningStale(job.id, 1);
+    await worker.tick();
+    const record = await waitForJob(job.id);
+    worker.stop();
+
+    expect(record.status).toBe('done');
+    expect(record.attempts).toBe(2);
+    expect(record.logs.some(function hasLostHeartbeatLog(log) {
+      return log.message.includes('lost heartbeat');
+    })).toBe(true);
+  });
+
+  test('marks exhausted stale jobs as error', async function testExhaustedStaleJob() {
+    const job = await createJob('stale-job', undefined, { maxAttempts: 1 });
+    const worker = startTestWorker({
+      'stale-job': async function handleJob() {},
+    });
+
+    await markRunningStale(job.id, 1);
+    await worker.tick();
+    const record = await waitForJob(job.id);
+    worker.stop();
+
+    expect(record.status).toBe('error');
+    expect(record.error).toContain('lost heartbeat');
+  });
+
+  test('does not let duplicate workers claim the same job', async function testDuplicateWorkerClaim() {
+    const job = await createJob('slow-job', undefined, { maxAttempts: 1 });
+    let runs = 0;
+    const handlers: JobHandlers = {
+      'slow-job': async function handleJob() {
+        runs += 1;
+        await Bun.sleep(50);
+      },
+    };
+    const firstWorker = startTestWorker(handlers, 'first-worker');
+    const secondWorker = startTestWorker(handlers, 'second-worker');
+
+    await Promise.all([
+      firstWorker.tick(),
+      secondWorker.tick(),
+    ]);
+    const record = await waitForJob(job.id);
+    firstWorker.stop();
+    secondWorker.stop();
+
+    expect(record.status).toBe('done');
+    expect(runs).toBe(1);
+  });
 });
+
+function startTestWorker(handlers: JobHandlers, workerId = 'test-worker') {
+  return startJobWorker(handlers, {
+    autoStart: false,
+    staleTimeoutSeconds: 1,
+    workerId,
+  });
+}
+
+async function markRunningStale(jobId: number, attempts: number): Promise<void> {
+  await getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'running',
+      attempts,
+      lockedAt: sql<string>`datetime('now', '-10 seconds')`,
+      lockedBy: 'dead-worker',
+      heartbeatAt: sql<string>`datetime('now', '-10 seconds')`,
+      updatedAt: sql<string>`datetime('now', '-10 seconds')`,
+    })
+    .where('id', '=', jobId)
+    .execute();
+}
 
 async function waitForJob(jobId: number) {
   const startedAt = Date.now();

--- a/src/server/services/job-handlers.ts
+++ b/src/server/services/job-handlers.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+import { getDb } from '#db/client';
+import { createBranchFromBase, deleteBranch, normalizeBranchSlug, resetBranchFromParent } from '#server/services/branch-service';
+import { restoreDevelopmentBranchFromPgBackRest, restoreProductionFromPgBackRest } from '#server/services/pgbackrest-restore-service';
+import { runDevBootstrap, runProdBootstrap, type BootstrapResult } from '#server/services/bootstrap-service';
+import { createReplicaBase, type ReplicaResult } from '#server/services/replica-service';
+import { checkServer } from '#server/services/setup-state-service';
+import type { JobContext, JobHandlers } from './job-service';
+
+const branchInput = z.object({
+  name: z.string().min(1),
+  parentBranchId: z.number().int().positive().nullable().optional(),
+});
+
+const branchIdInput = z.object({
+  id: z.number().int().positive(),
+});
+
+const restoreBranchInput = z.object({
+  targetBranch: z.string().min(1),
+  sourceBranch: z.string().min(1),
+  restoreTime: z.string().min(1),
+});
+
+export const jobHandlers: JobHandlers = {
+  'create-branch': async function createBranchJob(input, context) {
+    const parsed = branchInput.parse(input);
+    await context.log(`creating branch ${parsed.name}`);
+    await createBranchFromBase(parsed);
+  },
+  'delete-branch': async function deleteBranchJob(input, context) {
+    const parsed = branchIdInput.parse(input);
+    await context.log(`deleting branch ${parsed.id}`);
+
+    if (!(await branchExists(parsed.id))) {
+      await context.log(`branch ${parsed.id} already deleted`);
+      return;
+    }
+
+    const result = await deleteBranch(parsed);
+    await context.log(`deleted branch ${result.displayName}`);
+  },
+  'restore-branch': async function restoreBranchJob(input, context) {
+    const parsed = restoreBranchInput.parse(input);
+    await context.log(`restoring ${parsed.targetBranch} from ${parsed.sourceBranch}`);
+
+    if (parsed.targetBranch.trim().toLowerCase() === 'prod') {
+      context.disableRetry();
+      await restoreProductionFromPgBackRest(parsed);
+      await context.log('production restore completed');
+      return;
+    }
+
+    const existing = await findBranchBySlug(normalizeBranchLookup(parsed.targetBranch));
+
+    if (existing) {
+      await context.log(`replacing existing branch ${parsed.targetBranch}`);
+      await deleteBranch({ id: existing.id });
+    }
+
+    const result = await restoreDevelopmentBranchFromPgBackRest(parsed);
+    await context.log(`branch restored: ${result.displayName}`);
+  },
+  'reset-branch': async function resetBranchJob(input, context) {
+    const parsed = branchIdInput.parse(input);
+    await context.log(`resetting branch ${parsed.id} from parent`);
+    const result = await resetBranchFromParent(parsed);
+    await context.log(`reset branch ${result.displayName}`);
+  },
+  'dev-bootstrap': async function devBootstrapJob(_input, context) {
+    await context.log('installing dev prerequisites');
+    assertOk(await runDevBootstrap());
+  },
+  'prod-bootstrap': async function prodBootstrapJob(_input, context) {
+    await context.log('installing prod Postgres and backups');
+    assertOk(await runProdBootstrap());
+  },
+  setup: async function setupJob(_input, context) {
+    await runSetupJob(context);
+  },
+  'replica-base': async function replicaBaseJob(_input, context) {
+    await context.log('creating dev replica base');
+    assertOk(await createReplicaBase());
+  },
+};
+
+async function runSetupJob(context: JobContext): Promise<void> {
+  if (!(await isStepDone('dev-check'))) {
+    await context.log('setting up dev server');
+    assertOk(await runDevBootstrap());
+  }
+
+  if (!(await isStepDone('prod-check'))) {
+    await context.log('checking prod server');
+    await checkServer('prod');
+  }
+
+  if (!(await isStepDone('prod-setup')) || !(await isStepDone('backups'))) {
+    await context.log('setting up prod Postgres and backups');
+    assertOk(await runProdBootstrap());
+  }
+
+  if (!(await isStepDone('replica'))) {
+    await context.log('creating dev replica base');
+    assertOk(await createReplicaBase());
+  }
+
+  if (!(await isStepDone('first-branch'))) {
+    await context.log('creating first dev branch');
+    await createBranchFromBase({ name: 'dev' });
+  }
+}
+
+async function isStepDone(key: string): Promise<boolean> {
+  const step = await getDb()
+    .selectFrom('setupSteps')
+    .select(['status'])
+    .where('key', '=', key)
+    .executeTakeFirst();
+
+  return step?.status === 'done';
+}
+
+async function branchExists(id: number): Promise<boolean> {
+  const branch = await getDb()
+    .selectFrom('branches')
+    .select(['id'])
+    .where('id', '=', id)
+    .executeTakeFirst();
+
+  return Boolean(branch);
+}
+
+async function findBranchBySlug(slug: string): Promise<{ id: number } | undefined> {
+  return getDb()
+    .selectFrom('branches')
+    .select(['id'])
+    .where('slug', '=', slug)
+    .executeTakeFirst();
+}
+
+function normalizeBranchLookup(name: string): string {
+  return normalizeBranchSlug(name.trim().toLowerCase());
+}
+
+function assertOk(result: BootstrapResult | ReplicaResult): void {
+  if (!result.ok) {
+    throw new Error(result.message);
+  }
+}

--- a/src/server/services/job-service.ts
+++ b/src/server/services/job-service.ts
@@ -3,12 +3,23 @@ import { getDb } from '../../db/client';
 import type { Job, JobLog } from '../../db/schema';
 
 export type JobStatus = 'queued' | 'running' | 'done' | 'error';
+export type JobHandler = (input: unknown, context: JobContext) => Promise<void>;
+export type JobHandlers = Record<string, JobHandler>;
+
+const DEFAULT_STALE_TIMEOUT_SECONDS = 5 * 60;
+const DEFAULT_POLL_INTERVAL_MS = 1000;
 
 export interface JobRecord {
   id: number;
   type: string;
   status: JobStatus;
   error: string | null;
+  attempts: number;
+  maxAttempts: number;
+  runAfter: string | null;
+  lockedAt: string | null;
+  lockedBy: string | null;
+  heartbeatAt: string | null;
   createdAt: string;
   startedAt: string | null;
   finishedAt: string | null;
@@ -23,29 +34,88 @@ export interface JobRecord {
 
 export interface JobContext {
   jobId: number;
+  attempt: number;
   log(message: string): Promise<void>;
+  disableRetry(): void;
 }
 
-export async function createJob(type: string, input?: unknown): Promise<Job> {
-  await getDb()
+export interface CreateJobOptions {
+  maxAttempts?: number;
+}
+
+export interface JobWorker {
+  tick(): Promise<void>;
+  stop(): void;
+}
+
+export interface StartJobWorkerOptions {
+  pollIntervalMs?: number;
+  staleTimeoutSeconds?: number;
+  workerId?: string;
+  autoStart?: boolean;
+}
+
+export async function createJob(type: string, input?: unknown, options: CreateJobOptions = {}): Promise<Job> {
+  return getDb()
     .insertInto('jobs')
     .values({
       type,
       status: 'queued',
       inputJson: input === undefined ? null : JSON.stringify(input),
       error: null,
+      attempts: 0,
+      maxAttempts: options.maxAttempts ?? getDefaultMaxAttempts(type, input),
+      runAfter: sql<string>`datetime('now')`,
     })
-    .execute();
-
-  return getDb()
-    .selectFrom('jobs')
-    .selectAll()
-    .orderBy('id', 'desc')
+    .returningAll()
     .executeTakeFirstOrThrow();
 }
 
-export function runJob(job: Job, handler: (context: JobContext) => Promise<void>): void {
-  void runJobInternal(job, handler);
+export function startJobWorker(handlers: JobHandlers, options: StartJobWorkerOptions = {}): JobWorker {
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const staleTimeoutSeconds = options.staleTimeoutSeconds ?? DEFAULT_STALE_TIMEOUT_SECONDS;
+  const workerId = options.workerId ?? `worker-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  let stopped = false;
+  let running = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  async function tick(): Promise<void> {
+    if (running || stopped) {
+      return;
+    }
+
+    running = true;
+
+    try {
+      await recoverStaleJobs(staleTimeoutSeconds);
+      const job = await claimNextJob(workerId);
+
+      if (job) {
+        await runClaimedJob(job, handlers, workerId, staleTimeoutSeconds);
+      }
+    } finally {
+      running = false;
+    }
+  }
+
+  function stop(): void {
+    stopped = true;
+
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  if (options.autoStart !== false) {
+    void tick();
+    timer = setInterval(function runWorkerTick() {
+      void tick();
+    }, pollIntervalMs);
+    (timer as { unref?: () => void }).unref?.();
+  }
+
+  return { tick, stop };
 }
 
 export async function listJobs(limit = 20): Promise<JobRecord[]> {
@@ -87,51 +157,196 @@ export async function getActiveJob(type: string): Promise<Job | undefined> {
     .executeTakeFirst();
 }
 
-async function runJobInternal(job: Job, handler: (context: JobContext) => Promise<void>): Promise<void> {
-  await updateJob(job.id, 'running', null, {
-    startedAt: new Date().toISOString(),
-  });
-  await appendJobLog(job.id, 'info', `started ${job.type}`);
+async function claimNextJob(workerId: string): Promise<Job | undefined> {
+  return getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'running',
+      attempts: sql<number>`attempts + 1`,
+      error: null,
+      lockedAt: sql<string>`datetime('now')`,
+      lockedBy: workerId,
+      heartbeatAt: sql<string>`datetime('now')`,
+      startedAt: sql<string>`datetime('now')`,
+      finishedAt: null,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .where('id', '=', function selectNextQueuedJob(eb) {
+      return eb
+        .selectFrom('jobs')
+        .select('id')
+        .where('status', '=', 'queued')
+        .where('runAfter', '<=', sql<string>`datetime('now')`)
+        .orderBy('id')
+        .limit(1);
+    })
+    .where('status', '=', 'queued')
+    .returningAll()
+    .executeTakeFirst();
+}
+
+async function runClaimedJob(
+  job: Job,
+  handlers: JobHandlers,
+  workerId: string,
+  staleTimeoutSeconds: number
+): Promise<void> {
+  let retryEnabled = true;
+  const heartbeatMs = Math.max(1000, Math.floor(staleTimeoutSeconds * 500));
+  const heartbeat = setInterval(function updateHeartbeat() {
+    void touchJobHeartbeat(job.id, workerId);
+  }, heartbeatMs);
+  (heartbeat as { unref?: () => void }).unref?.();
 
   const context: JobContext = {
     jobId: job.id,
+    attempt: job.attempts,
     async log(message: string) {
       await appendJobLog(job.id, 'info', message);
+    },
+    disableRetry() {
+      retryEnabled = false;
     },
   };
 
   try {
-    await handler(context);
-    await appendJobLog(job.id, 'info', `finished ${job.type}`);
-    await updateJob(job.id, 'done', null, {
-      finishedAt: new Date().toISOString(),
-    });
+    const handler = handlers[job.type];
+
+    if (!handler) {
+      throw new Error(`No job handler registered for ${job.type}`);
+    }
+
+    await appendJobLog(job.id, 'info', `attempt ${job.attempts} started ${job.type}`);
+    await handler(parseJobInput(job), context);
+    await appendJobLog(job.id, 'info', `attempt ${job.attempts} finished ${job.type}`);
+    await finishJob(job.id, workerId);
   } catch (error: any) {
     const message = sanitizeLogMessage(error?.message || String(error));
     await appendJobLog(job.id, 'error', message);
-    await updateJob(job.id, 'error', message, {
-      finishedAt: new Date().toISOString(),
-    });
+
+    if (retryEnabled && job.attempts < job.maxAttempts) {
+      const backoffSeconds = getBackoffSeconds(job.attempts);
+      await appendJobLog(job.id, 'info', `retrying ${job.type} in ${backoffSeconds}s`);
+      await retryJob(job.id, message, backoffSeconds, workerId);
+      return;
+    }
+
+    await errorJob(job.id, message, workerId);
+  } finally {
+    clearInterval(heartbeat);
   }
 }
 
-async function updateJob(
-  jobId: number,
-  status: JobStatus,
-  error: string | null,
-  options: { startedAt?: string; finishedAt?: string } = {}
-): Promise<void> {
+async function recoverStaleJobs(staleTimeoutSeconds: number): Promise<void> {
+  const staleBefore = sql<string>`datetime('now', ${`-${staleTimeoutSeconds} seconds`})`;
+  const staleJobs = await getDb()
+    .selectFrom('jobs')
+    .selectAll()
+    .where('status', '=', 'running')
+    .where(function findStaleJobs(eb) {
+      return eb.or([
+        eb('heartbeatAt', 'is', null),
+        eb('heartbeatAt', '<', staleBefore),
+      ]);
+    })
+    .execute();
+
+  for (const job of staleJobs) {
+    if (job.attempts < job.maxAttempts) {
+      await appendJobLog(job.id, 'error', `attempt ${job.attempts} lost heartbeat`);
+      await getDb()
+        .updateTable('jobs')
+        .set({
+          status: 'queued',
+          runAfter: sql<string>`datetime('now')`,
+          lockedAt: null,
+          lockedBy: null,
+          heartbeatAt: null,
+          updatedAt: sql<string>`datetime('now')`,
+        })
+        .where('id', '=', job.id)
+        .where('status', '=', 'running')
+        .execute();
+      continue;
+    }
+
+    const message = `attempt ${job.attempts} lost heartbeat`;
+    await appendJobLog(job.id, 'error', message);
+    await errorJob(job.id, message);
+  }
+}
+
+async function touchJobHeartbeat(jobId: number, workerId: string): Promise<void> {
   await getDb()
     .updateTable('jobs')
     .set({
-      status,
-      error,
-      startedAt: options.startedAt,
-      finishedAt: options.finishedAt,
-      updatedAt: sql`datetime('now')`,
+      heartbeatAt: sql<string>`datetime('now')`,
+      updatedAt: sql<string>`datetime('now')`,
     })
     .where('id', '=', jobId)
+    .where('status', '=', 'running')
+    .where('lockedBy', '=', workerId)
     .execute();
+}
+
+async function finishJob(jobId: number, workerId: string): Promise<void> {
+  await getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'done',
+      error: null,
+      lockedAt: null,
+      lockedBy: null,
+      heartbeatAt: null,
+      finishedAt: sql<string>`datetime('now')`,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .where('id', '=', jobId)
+    .where('status', '=', 'running')
+    .where('lockedBy', '=', workerId)
+    .execute();
+}
+
+async function retryJob(jobId: number, error: string, backoffSeconds: number, workerId: string): Promise<void> {
+  await getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'queued',
+      error,
+      runAfter: sql<string>`datetime('now', ${`+${backoffSeconds} seconds`})`,
+      lockedAt: null,
+      lockedBy: null,
+      heartbeatAt: null,
+      finishedAt: null,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .where('id', '=', jobId)
+    .where('status', '=', 'running')
+    .where('lockedBy', '=', workerId)
+    .execute();
+}
+
+async function errorJob(jobId: number, error: string, workerId?: string): Promise<void> {
+  let query = getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'error',
+      error,
+      lockedAt: null,
+      lockedBy: null,
+      heartbeatAt: null,
+      finishedAt: sql<string>`datetime('now')`,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .where('id', '=', jobId);
+
+  if (workerId) {
+    query = query
+      .where('status', '=', 'running')
+      .where('lockedBy', '=', workerId);
+  }
+
+  await query.execute();
 }
 
 export async function appendJobLog(jobId: number, level: 'info' | 'error', message: string): Promise<void> {
@@ -162,6 +377,12 @@ function mapJob(job: Job, logs: JobLog[]): JobRecord {
     type: job.type,
     status: job.status,
     error: job.error,
+    attempts: job.attempts,
+    maxAttempts: job.maxAttempts,
+    runAfter: job.runAfter,
+    lockedAt: job.lockedAt,
+    lockedBy: job.lockedBy,
+    heartbeatAt: job.heartbeatAt,
     createdAt: job.createdAt,
     startedAt: job.startedAt,
     finishedAt: job.finishedAt,
@@ -175,6 +396,45 @@ function mapJob(job: Job, logs: JobLog[]): JobRecord {
       };
     }),
   };
+}
+
+function parseJobInput(job: Job): unknown {
+  if (job.inputJson === null) {
+    return undefined;
+  }
+
+  return JSON.parse(job.inputJson);
+}
+
+function getDefaultMaxAttempts(type: string, input: unknown): number {
+  if (type === 'restore-branch' && isProductionRestore(input)) {
+    return 1;
+  }
+
+  if ([
+    'dev-bootstrap',
+    'prod-bootstrap',
+    'setup',
+    'replica-base',
+    'create-branch',
+    'delete-branch',
+    'restore-branch',
+  ].includes(type)) {
+    return 3;
+  }
+
+  return 1;
+}
+
+function isProductionRestore(input: unknown): boolean {
+  return typeof input === 'object'
+    && input !== null
+    && 'targetBranch' in input
+    && String(input.targetBranch).trim().toLowerCase() === 'prod';
+}
+
+function getBackoffSeconds(attempt: number): number {
+  return Math.min(60, 5 * (2 ** Math.max(0, attempt - 1)));
 }
 
 function sanitizeLogMessage(message: string): string {

--- a/src/server/web-runtime.ts
+++ b/src/server/web-runtime.ts
@@ -3,6 +3,8 @@ import { join, normalize, relative } from 'node:path';
 import { migrateDatabase } from '#db/migrate';
 import { persistUpdateResult } from '#server/services/update-service';
 import { startUpdateScheduler } from '#server/services/update-scheduler';
+import { jobHandlers } from '#server/services/job-handlers';
+import { startJobWorker } from '#server/services/job-service';
 
 const host = process.env.HOST || '0.0.0.0';
 const port = Number(process.env.PORT || 3000);
@@ -11,6 +13,7 @@ const clientDir = join(process.cwd(), 'dist/client');
 migrateDatabase();
 await persistUpdateResult();
 startUpdateScheduler();
+startJobWorker(jobHandlers);
 
 const serverEntryPath = new URL('../../dist/server/server.js', import.meta.url).href;
 const serverEntry = (await import(serverEntryPath)) as {

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -417,19 +417,19 @@ function UpdatePanel() {
           </div>
         ) : null}
 
-        <div className="grid gap-3 rounded-lg border border-border bg-muted/20 p-4">
-          <Label className="flex items-center gap-2">
-            <Checkbox checked={autoSettings?.enabled ?? true} onChange={function changeEnabled(event) { updateAutoEnabled(event.currentTarget.checked); }} />
-            Auto check
-          </Label>
-          <Label className="flex items-center gap-2">
-            <Checkbox checked={autoSettings?.applyPatches ?? false} onChange={function changePatches(event) { updateAutoPatches(event.currentTarget.checked); }} />
-            Auto apply patch releases
-          </Label>
-          <Label className="flex items-center gap-2">
-            <Checkbox checked={autoSettings?.applyMigrations ?? false} onChange={function changeMigrations(event) { updateAutoMigrations(event.currentTarget.checked); }} />
-            Allow migration updates
-          </Label>
+	        <div className="grid gap-3 rounded-lg border border-border bg-muted/20 p-4">
+	          <Label className="flex items-center gap-2">
+	            <Checkbox checked={autoSettings?.enabled ?? true} onCheckedChange={function changeEnabled(checked) { updateAutoEnabled(checked === true); }} />
+	            Auto check
+	          </Label>
+	          <Label className="flex items-center gap-2">
+	            <Checkbox checked={autoSettings?.applyPatches ?? false} onCheckedChange={function changePatches(checked) { updateAutoPatches(checked === true); }} />
+	            Auto apply patch releases
+	          </Label>
+	          <Label className="flex items-center gap-2">
+	            <Checkbox checked={autoSettings?.applyMigrations ?? false} onCheckedChange={function changeMigrations(checked) { updateAutoMigrations(checked === true); }} />
+	            Allow migration updates
+	          </Label>
           <div className="flex items-center justify-between gap-3">
             <Label htmlFor="update-hour">Hour</Label>
             <Select value={String(utcToLocalHour(autoSettings?.hour ?? 4))} onValueChange={updateAutoHour}>


### PR DESCRIPTION
Closes #51

## Summary
- add durable SQLite job queue fields for attempts, backoff, locks, and heartbeat recovery
- add a worker loop that claims queued jobs atomically, retries transient failures, and recovers stale running jobs
- move job execution into registered handlers so jobs can resume after restart
- fix settings checkboxes to use the Radix checked-change contract

## API routes, procedures, and contracts
- Updated `bootstrap.start`, `bootstrap.complete`, `replicaBase.create`, `branches.create`, `branches.delete`, `branches.restore`, and `branches.reset` to enqueue jobs instead of running work inline.
- Updated `branches.preview.delete` to enqueue the same durable `delete-branch` job.
- Updated job records with queue metadata: `attempts`, `maxAttempts`, `runAfter`, `lockedAt`, `lockedBy`, and `heartbeatAt`.
- No procedures were deleted.

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`