### PR TITLE
fix(wal): support postgres image ownership

### DIFF
--- a/src/managers/cert.ts
+++ b/src/managers/cert.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import { APP_SLUG } from '../config/constants';
 import { SystemError } from '../errors';
+import { DEFAULT_POSTGRES_OWNER, formatPostgresOwner, type PostgresOwner } from './postgres-owner';
 
 export interface CertPaths {
   certDir: string;
@@ -13,9 +14,14 @@ export interface CertPaths {
 
 export class CertManager {
   private baseDir: string;
+  private postgresOwner: PostgresOwner;
 
-  constructor(baseDir: string = join(process.env.HOME || '/root', `.${APP_SLUG}/certs`)) {
+  constructor(
+    baseDir: string = join(process.env.HOME || '/root', `.${APP_SLUG}/certs`),
+    postgresOwner: PostgresOwner = DEFAULT_POSTGRES_OWNER
+  ) {
     this.baseDir = baseDir;
+    this.postgresOwner = postgresOwner;
   }
 
   /**
@@ -33,7 +39,7 @@ export class CertManager {
   /**
    * Generate self-signed SSL certificates for a project
    */
-  async generateCerts(projectName: string): Promise<CertPaths> {
+  async generateCerts(projectName: string, postgresOwner = this.postgresOwner): Promise<CertPaths> {
     const paths = this.getCertPaths(projectName);
 
     // Check if valid certificates already exist
@@ -76,9 +82,8 @@ export class CertManager {
     }
 
     // Set ownership to match PostgreSQL user in container
-    // PostgreSQL alpine image runs as user 'postgres' with UID 70
     try {
-      await $`sudo chown 70:70 ${paths.serverKey} ${paths.serverCert}`;
+      await $`sudo chown ${formatPostgresOwner(postgresOwner)} ${paths.serverKey} ${paths.serverCert}`;
     } catch (error: any) {
       console.error('chown error:', error.message);
       throw error;
@@ -114,7 +119,7 @@ export class CertManager {
     const paths = this.getCertPaths(projectName);
 
     if (existsSync(paths.certDir)) {
-      // Use sudo to remove files that might be owned by postgres user (UID 70)
+      // Use sudo to remove files that might be owned by the container postgres user.
       try {
         await $`sudo rm -rf ${paths.certDir}`.quiet();
       } catch {

--- a/src/managers/postgres-owner.test.ts
+++ b/src/managers/postgres-owner.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { formatPostgresOwner, parsePostgresOwner, resolvePostgresOwner } from './postgres-owner';
+
+describe('parsePostgresOwner', function () {
+  test('parses postgres alpine owner', function () {
+    expect(parsePostgresOwner('70:70')).toEqual({ uid: '70', gid: '70' });
+  });
+
+  test('parses non-alpine postgres owner', function () {
+    expect(parsePostgresOwner('999:999')).toEqual({ uid: '999', gid: '999' });
+  });
+
+  test('rejects invalid owner output', function () {
+    expect(function parseBadOwner() {
+      parsePostgresOwner('postgres:postgres');
+    }).toThrow('Invalid postgres owner');
+  });
+});
+
+describe('formatPostgresOwner', function () {
+  test('formats chown owner spec', function () {
+    expect(formatPostgresOwner({ uid: '999', gid: '999' })).toBe('999:999');
+  });
+});
+
+describe('resolvePostgresOwner', function () {
+  test('resolves default postgres alpine image owner', async function () {
+    const owner = await resolvePostgresOwner('postgres:17-alpine', async function runOwnerProbe(image) {
+      expect(image).toBe('postgres:17-alpine');
+      return {
+        exitCode: 0,
+        stdout: '70:70',
+        stderr: '',
+      };
+    });
+
+    expect(owner).toEqual({ uid: '70', gid: '70' });
+  });
+
+  test('resolves non-70 image owner', async function () {
+    const owner = await resolvePostgresOwner('postgres:17', async function runOwnerProbe(image) {
+      expect(image).toBe('postgres:17');
+      return {
+        exitCode: 0,
+        stdout: '999:999',
+        stderr: '',
+      };
+    });
+
+    expect(owner).toEqual({ uid: '999', gid: '999' });
+  });
+});

--- a/src/managers/postgres-owner.ts
+++ b/src/managers/postgres-owner.ts
@@ -1,0 +1,79 @@
+export interface PostgresOwner {
+  uid: string;
+  gid: string;
+}
+
+export interface PostgresOwnerCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type PostgresOwnerRunner = (image: string) => Promise<PostgresOwnerCommandResult>;
+
+const ownerCache = new Map<string, PostgresOwner>();
+
+export const DEFAULT_POSTGRES_OWNER: PostgresOwner = {
+  uid: '70',
+  gid: '70',
+};
+
+export function formatPostgresOwner(owner: PostgresOwner): string {
+  return `${owner.uid}:${owner.gid}`;
+}
+
+export function parsePostgresOwner(output: string): PostgresOwner {
+  const [uid, gid] = output.trim().split(':');
+
+  if (!uid || !gid || !/^\d+$/.test(uid) || !/^\d+$/.test(gid)) {
+    throw new Error(`Invalid postgres owner: ${output.trim()}`);
+  }
+
+  return { uid, gid };
+}
+
+export async function resolvePostgresOwner(
+  image: string,
+  runner: PostgresOwnerRunner = runDockerOwnerProbe
+): Promise<PostgresOwner> {
+  const cached = ownerCache.get(image);
+  if (cached) {
+    return cached;
+  }
+
+  const result = await runner(image);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || `failed to resolve postgres owner for ${image}`);
+  }
+
+  const owner = parsePostgresOwner(result.stdout);
+  ownerCache.set(image, owner);
+  return owner;
+}
+
+async function runDockerOwnerProbe(image: string): Promise<PostgresOwnerCommandResult> {
+  const proc = Bun.spawn([
+    'docker',
+    'run',
+    '--rm',
+    '--entrypoint',
+    'sh',
+    image,
+    '-lc',
+    'printf "%s:%s\\n" "$(id -u postgres)" "$(id -g postgres)"',
+  ], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  return {
+    exitCode: await proc.exited,
+    stdout: stdout.trim(),
+    stderr: stderr.trim(),
+  };
+}

--- a/src/managers/wal.ts
+++ b/src/managers/wal.ts
@@ -1,5 +1,6 @@
 import { PATHS } from '../utils/paths';
 import { $ } from 'bun';
+import { DEFAULT_POSTGRES_OWNER, formatPostgresOwner, type PostgresOwner } from './postgres-owner';
 
 export interface WALArchiveInfo {
   datasetName: string;
@@ -14,13 +15,16 @@ export interface WALArchiveInfo {
 
 export interface WALManagerOptions {
   basePath?: string;
+  postgresOwner?: PostgresOwner;
 }
 
 export class WALManager {
   private basePath: string;
+  private postgresOwner: PostgresOwner;
 
   constructor(options: WALManagerOptions = {}) {
     this.basePath = options.basePath || PATHS.WAL_ARCHIVE;
+    this.postgresOwner = options.postgresOwner || DEFAULT_POSTGRES_OWNER;
   }
 
   /**
@@ -32,9 +36,8 @@ export class WALManager {
 
   /**
    * Ensure WAL archive directory exists for a dataset
-   * Sets permissions to allow Docker postgres user (UID 70/999) to write
    */
-  async ensureArchiveDir(datasetName: string): Promise<void> {
+  async ensureArchiveDir(datasetName: string, postgresOwner = this.postgresOwner): Promise<void> {
     const walArchivePath = this.getArchivePath(datasetName);
     await $`mkdir -p ${walArchivePath}`.quiet();
     // Create .keep file first while directory is still owned by current user
@@ -42,8 +45,8 @@ export class WALManager {
     // Set permissions before changing ownership (can't chmod after chown to different user)
     await $`chmod 770 ${walArchivePath}`.quiet();
     await $`chmod 660 ${walArchivePath}/.keep`.quiet();
-    // Set ownership to postgres user/group (UID/GID 70) - must be last
-    await $`sudo chown -R 70:70 ${walArchivePath}`.quiet();
+    // Set ownership to postgres user/group - must be last
+    await $`sudo chown -R ${formatPostgresOwner(postgresOwner)} ${walArchivePath}`.quiet();
   }
 
   /**

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -2,6 +2,7 @@ import { ZFSManager } from '../../managers/zfs';
 import { DockerManager } from '../../managers/docker';
 import { WALManager } from '../../managers/wal';
 import { CertManager } from '../../managers/cert';
+import { formatPostgresOwner, resolvePostgresOwner, type PostgresOwner } from '../../managers/postgres-owner';
 import { DEFAULTS } from '../../config/defaults';
 import { formatTimestamp, generatePassword } from '../../utils/helpers';
 import { getZFSPool } from '../../utils/zfs-pool';
@@ -171,10 +172,6 @@ async function createBranchClone(options: {
     const mountpoint = await zfs.getMountpoint(targetDataset);
     await prepareWritableClone(mountpoint);
 
-    const certPaths = await cert.generateCerts(PROJECT_NAME);
-    const walArchivePath = wal.getArchivePath(targetDataset);
-    await wal.ensureArchiveDir(targetDataset);
-
     const password = generatePassword();
     const pgVersion = await readPgVersion(`${mountpoint}/pgdata`);
     const image = `postgres:${pgVersion}-alpine`;
@@ -182,6 +179,13 @@ async function createBranchClone(options: {
     if (!(await docker.imageExists(image))) {
       await docker.pullImage(image);
     }
+
+    const postgresOwner = await resolvePostgresOwner(image);
+    await setPostgresDataOwner(`${mountpoint}/pgdata`, postgresOwner);
+
+    const certPaths = await cert.generateCerts(PROJECT_NAME, postgresOwner);
+    const walArchivePath = wal.getArchivePath(targetDataset);
+    await wal.ensureArchiveDir(targetDataset, postgresOwner);
 
     containerId = await docker.createContainer({
       name: targetContainer,
@@ -507,12 +511,23 @@ async function prepareWritableClone(mountpoint: string): Promise<void> {
       `if [ -f ${shellQuote(pgdata)}/postgresql.auto.conf ]; then`,
       `  sed -i.bak '/primary_conninfo/d;/primary_slot_name/d;/restore_command/d' ${shellQuote(pgdata)}/postgresql.auto.conf`,
       'fi',
-      `sudo chown -R 70:70 ${shellQuote(pgdata)}`,
     ].join('\n'),
   ]);
 
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || result.stdout || 'failed to prepare branch clone');
+  }
+}
+
+async function setPostgresDataOwner(pgdata: string, postgresOwner: PostgresOwner): Promise<void> {
+  const result = await runCommand([
+    'sh',
+    '-lc',
+    `sudo chown -R ${formatPostgresOwner(postgresOwner)} ${shellQuote(pgdata)}`,
+  ]);
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || 'failed to set Postgres data ownership');
   }
 }
 

--- a/src/server/services/pgbackrest-restore-service.ts
+++ b/src/server/services/pgbackrest-restore-service.ts
@@ -7,6 +7,7 @@ import { DockerManager } from '../../managers/docker';
 import { WALManager } from '../../managers/wal';
 import { ZFSManager } from '../../managers/zfs';
 import { CertManager } from '../../managers/cert';
+import { formatPostgresOwner, resolvePostgresOwner, type PostgresOwner } from '../../managers/postgres-owner';
 import { formatTimestamp } from '../../utils/helpers';
 import { getContainerName, getDatasetName } from '../../utils/naming';
 import { getZFSPool } from '../../utils/zfs-pool';
@@ -90,8 +91,7 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
 
     const mountpoint = await zfs.getMountpoint(dataset);
     const pgdata = `${mountpoint}/pgdata`;
-    await restorePgBackRestLocally(mountpoint, pgdata, restoreTime);
-    await ensurePortablePostgresConfig(pgdata);
+    await restorePgBackRestLocally(pgdata, restoreTime);
 
     const pgVersion = await readPgVersion(pgdata);
     const image = await ensurePgBackRestPostgresImage(pgVersion);
@@ -100,8 +100,13 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
       await docker.pullImage(image);
     }
 
-    const certPaths = await cert.generateCerts(PROJECT_NAME);
-    await wal.ensureArchiveDir(dataset);
+    const postgresOwner = await resolvePostgresOwner(image);
+    await setPostgresDataOwner(pgdata, postgresOwner);
+    await writeContainerPgBackRestConfig(mountpoint, pgdata, postgresOwner);
+    await ensurePortablePostgresConfig(pgdata, postgresOwner);
+
+    const certPaths = await cert.generateCerts(PROJECT_NAME, postgresOwner);
+    await wal.ensureArchiveDir(dataset, postgresOwner);
 
     containerId = await docker.createContainer({
       name: containerName,
@@ -266,7 +271,7 @@ async function getProdPassword(): Promise<string | null> {
   }
 }
 
-async function restorePgBackRestLocally(mountpoint: string, pgdata: string, restoreTime: Date): Promise<void> {
+async function restorePgBackRestLocally(pgdata: string, restoreTime: Date): Promise<void> {
   const tempDir = await mkdtemp(join(tmpdir(), 'velo-pgbackrest-'));
   const configPath = join(tempDir, 'pgbackrest.conf');
 
@@ -281,7 +286,6 @@ async function restorePgBackRestLocally(mountpoint: string, pgdata: string, rest
         `rm -rf ${shellQuote(pgdata)}`,
         `mkdir -p ${shellQuote(pgdata)}`,
         `pgbackrest --config=${shellQuote(configPath)} --stanza=main --pg1-path=${shellQuote(pgdata)} --type=time --target=${shellQuote(formatPgBackRestTime(restoreTime))} --target-action=promote restore`,
-        `sudo chown -R 70:70 ${shellQuote(pgdata)}`,
       ].join('\n'),
     ], 60 * 60 * 1000);
 
@@ -292,10 +296,13 @@ async function restorePgBackRestLocally(mountpoint: string, pgdata: string, rest
     await rm(tempDir, { force: true, recursive: true }).catch(function ignoreCleanupError() {});
   }
 
-  await writeContainerPgBackRestConfig(mountpoint, pgdata);
 }
 
-async function writeContainerPgBackRestConfig(mountpoint: string, pgdata: string): Promise<void> {
+async function writeContainerPgBackRestConfig(
+  mountpoint: string,
+  pgdata: string,
+  postgresOwner: PostgresOwner
+): Promise<void> {
   const hostConfig = await buildPgBackRestConfig();
   const containerConfigPath = `${mountpoint}/pgbackrest.conf`;
   const containerPgdata = '/var/lib/postgresql/data/pgdata';
@@ -314,7 +321,7 @@ async function writeContainerPgBackRestConfig(mountpoint: string, pgdata: string
       'else',
       `  printf '\\n%s\\n' ${shellQuote(restoreCommand)} >> ${shellQuote(autoConfPath)}`,
       'fi',
-      `sudo chown 70:70 ${shellQuote(containerConfigPath)} ${shellQuote(autoConfPath)}`,
+      `sudo chown ${formatPostgresOwner(postgresOwner)} ${shellQuote(containerConfigPath)} ${shellQuote(autoConfPath)}`,
       `sudo chmod 600 ${shellQuote(containerConfigPath)} ${shellQuote(autoConfPath)}`,
     ].join('\n'),
   ]);
@@ -351,7 +358,7 @@ async function ensurePgBackRestPostgresImage(pgVersion: string): Promise<string>
   return tag;
 }
 
-async function ensurePortablePostgresConfig(pgdata: string): Promise<void> {
+async function ensurePortablePostgresConfig(pgdata: string, postgresOwner: PostgresOwner): Promise<void> {
   const result = await runCommand([
     'sh',
     '-lc',
@@ -369,13 +376,25 @@ async function ensurePortablePostgresConfig(pgdata: string): Promise<void> {
       'host replication all ::/0 scram-sha-256',
       'HBA',
       `touch ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
-      `sudo chown 70:70 ${shellQuote(`${pgdata}/postgresql.conf`)} ${shellQuote(`${pgdata}/pg_hba.conf`)} ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
+      `sudo chown ${formatPostgresOwner(postgresOwner)} ${shellQuote(`${pgdata}/postgresql.conf`)} ${shellQuote(`${pgdata}/pg_hba.conf`)} ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
       `sudo chmod 600 ${shellQuote(`${pgdata}/postgresql.conf`)} ${shellQuote(`${pgdata}/pg_hba.conf`)} ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
     ].join('\n'),
   ]);
 
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || result.stdout || 'failed to write portable Postgres config');
+  }
+}
+
+async function setPostgresDataOwner(pgdata: string, postgresOwner: PostgresOwner): Promise<void> {
+  const result = await runCommand([
+    'sh',
+    '-lc',
+    `sudo chown -R ${formatPostgresOwner(postgresOwner)} ${shellQuote(pgdata)}`,
+  ]);
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || 'failed to set Postgres data ownership');
   }
 }
 

--- a/src/server/services/replica-service.ts
+++ b/src/server/services/replica-service.ts
@@ -2,6 +2,7 @@ import { ZFSManager } from '../../managers/zfs';
 import { DockerManager } from '../../managers/docker';
 import { WALManager } from '../../managers/wal';
 import { CertManager } from '../../managers/cert';
+import { formatPostgresOwner, resolvePostgresOwner, type PostgresOwner } from '../../managers/postgres-owner';
 import { DEFAULTS } from '../../config/defaults';
 import { generatePassword } from '../../utils/helpers';
 import { getZFSPool } from '../../utils/zfs-pool';
@@ -80,8 +81,8 @@ export async function createReplicaBase(): Promise<ReplicaResult> {
   }
 
   const mountpoint = await zfs.getMountpoint(baseDataset);
-  await ensurePortablePostgresConfig(`${mountpoint}/pgdata`);
-  const pgVersion = await readPgVersion(`${mountpoint}/pgdata`);
+  const pgdata = `${mountpoint}/pgdata`;
+  const pgVersion = await readPgVersion(pgdata);
   const image = `postgres:${pgVersion}-alpine`;
   const containerName = getContainerName(PROJECT_NAME, BASE_BRANCH_NAME);
 
@@ -90,12 +91,16 @@ export async function createReplicaBase(): Promise<ReplicaResult> {
     await docker.removeContainer(existingContainerId);
   }
 
-  const certPaths = await cert.generateCerts(PROJECT_NAME);
-  await wal.ensureArchiveDir(baseDataset);
-
   if (!(await docker.imageExists(image))) {
     await docker.pullImage(image);
   }
+
+  const postgresOwner = await resolvePostgresOwner(image);
+  await setPostgresDataOwner(pgdata, postgresOwner);
+  await ensurePortablePostgresConfig(pgdata, postgresOwner);
+
+  const certPaths = await cert.generateCerts(PROJECT_NAME, postgresOwner);
+  await wal.ensureArchiveDir(baseDataset, postgresOwner);
 
   const containerId = await docker.createContainer({
     name: containerName,
@@ -173,7 +178,6 @@ async function runBaseBackup(options: {
       `rm -rf ${shellQuote(options.targetDir)}`,
       `mkdir -p ${shellQuote(options.targetDir)}`,
       `PGPASSWORD=${shellQuote(options.replicationPassword)} pg_basebackup -h ${shellQuote(options.prodHost)} -U ${REPLICATION_USER} -D ${shellQuote(options.targetDir)} -R -X stream --checkpoint=fast`,
-      `sudo chown -R 70:70 ${shellQuote(options.targetDir)}`,
     ].join('\n'),
   ], 60 * 60 * 1000);
 
@@ -183,7 +187,7 @@ async function runBaseBackup(options: {
   }
 }
 
-async function ensurePortablePostgresConfig(pgdata: string): Promise<void> {
+async function ensurePortablePostgresConfig(pgdata: string, postgresOwner: PostgresOwner): Promise<void> {
   const result = await runCommand([
     'sh',
     '-lc',
@@ -201,13 +205,25 @@ async function ensurePortablePostgresConfig(pgdata: string): Promise<void> {
       'host replication all ::/0 scram-sha-256',
       'HBA',
       `touch ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
-      `sudo chown 70:70 ${shellQuote(`${pgdata}/postgresql.conf`)} ${shellQuote(`${pgdata}/pg_hba.conf`)} ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
+      `sudo chown ${formatPostgresOwner(postgresOwner)} ${shellQuote(`${pgdata}/postgresql.conf`)} ${shellQuote(`${pgdata}/pg_hba.conf`)} ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
       `sudo chmod 600 ${shellQuote(`${pgdata}/postgresql.conf`)} ${shellQuote(`${pgdata}/pg_hba.conf`)} ${shellQuote(`${pgdata}/pg_ident.conf`)}`,
     ].join('\n'),
   ]);
 
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || result.stdout || 'failed to write portable Postgres config');
+  }
+}
+
+async function setPostgresDataOwner(pgdata: string, postgresOwner: PostgresOwner): Promise<void> {
+  const result = await runCommand([
+    'sh',
+    '-lc',
+    `sudo chown -R ${formatPostgresOwner(postgresOwner)} ${shellQuote(pgdata)}`,
+  ]);
+
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || result.stdout || 'failed to set Postgres data ownership');
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve the postgres UID/GID from the selected Docker image
- use resolved ownership for WAL archives, SSL certs, branch clones, replica base data, and PITR restore files
- add coverage for default postgres:17-alpine and a non-70 owner image path

## API routes / procedures / contracts
- No API routes, procedures, or external contracts changed.

## Tests
- bun run typecheck
- bun test

Closes #42