### PR TITLE
feat(onboarding): add guided first-run setup

### DIFF
--- a/src/api/backup.ts
+++ b/src/api/backup.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { publicProcedure } from './context';
+import { userFacingError } from './errors';
 import { saveBackupSettings } from '#server/services/settings-service';
 
 const backupInput = z.object({
@@ -17,7 +18,11 @@ const backupInput = z.object({
 export const backupRouter = {
   settings: {
     update: publicProcedure.input(backupInput).handler(async function updateBackupSettings({ input }) {
-      return saveBackupSettings(input);
+      try {
+        return await saveBackupSettings(input);
+      } catch (error) {
+        throw userFacingError(error, 'Could not save backup settings');
+      }
     }),
   },
 };

--- a/src/api/bootstrap.ts
+++ b/src/api/bootstrap.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
+import { getDb } from '#db/client';
 import { publicProcedure } from './context';
+import { userFacingError } from './errors';
 import { createJob, getActiveJob } from '#server/services/job-service';
+import { getAppAuthState } from '#server/services/app-auth-service';
 
 const bootstrapInput = z.object({
   target: z.enum(['prod', 'dev']),
@@ -23,7 +26,49 @@ export const bootstrapRouter = {
       return active;
     }
 
+    try {
+      await assertSetupReady();
+    } catch (error) {
+      throw userFacingError(error, 'Setup is not ready');
+    }
+
     const job = await createJob('setup');
     return job;
   }),
 };
+
+async function assertSetupReady(): Promise<void> {
+  const db = getDb();
+  const [appAuth, project, prodServer, backupConfigDone] = await Promise.all([
+    getAppAuthState(),
+    db.selectFrom('projects').select('id').orderBy('id').executeTakeFirst(),
+    db.selectFrom('servers').select(['id', 'host']).where('role', '=', 'prod').executeTakeFirst(),
+    isStepDone('backups-config'),
+  ]);
+
+  if (!appAuth.configured) {
+    throw new Error('Set the app password first');
+  }
+
+  if (!project) {
+    throw new Error('Create the project first');
+  }
+
+  if (!prodServer?.host) {
+    throw new Error('Save the production server first');
+  }
+
+  if (!backupConfigDone) {
+    throw new Error('Choose backup storage first');
+  }
+}
+
+async function isStepDone(key: string): Promise<boolean> {
+  const step = await getDb()
+    .selectFrom('setupSteps')
+    .select('status')
+    .where('key', '=', key)
+    .executeTakeFirst();
+
+  return step?.status === 'done';
+}

--- a/src/api/onboarding.ts
+++ b/src/api/onboarding.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { publicProcedure } from './context';
+import { userFacingError } from './errors';
+import { saveAppPassword } from '#server/services/app-auth-service';
+import { saveProject } from '#server/services/project-service';
+
+const appPasswordInput = z.object({
+  username: z.string().min(1),
+  password: z.string().min(8),
+});
+
+const projectInput = z.object({
+  name: z.string().min(1),
+  postgresVersion: z.string().min(1).optional(),
+  databaseName: z.string().min(1).optional(),
+  appUser: z.string().min(1).optional(),
+});
+
+export const onboardingRouter = {
+  appPassword: {
+    update: publicProcedure.input(appPasswordInput).handler(async function updateAppPassword({ input }) {
+      try {
+        return await saveAppPassword(input);
+      } catch (error) {
+        throw userFacingError(error, 'Could not save app password');
+      }
+    }),
+  },
+  project: {
+    update: publicProcedure.input(projectInput).handler(async function updateProject({ input }) {
+      try {
+        return await saveProject(input);
+      } catch (error) {
+        throw userFacingError(error, 'Could not save project');
+      }
+    }),
+  },
+};

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -5,6 +5,7 @@ import { branchesRouter } from './branches';
 import { createOrpcContext } from './context';
 import { dashboardRouter } from './dashboard';
 import { jobsRouter } from './jobs';
+import { onboardingRouter } from './onboarding';
 import { replicaBaseRouter } from './replica-base';
 import { serversRouter } from './servers';
 import { tablesRouter } from './tables';
@@ -13,6 +14,7 @@ import { updatesRouter } from './updates';
 export const appRouter = {
   dashboard: dashboardRouter,
   jobs: jobsRouter,
+  onboarding: onboardingRouter,
   servers: serversRouter,
   backup: backupRouter,
   bootstrap: bootstrapRouter,

--- a/src/api/servers.ts
+++ b/src/api/servers.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { publicProcedure } from './context';
+import { userFacingError } from './errors';
 import { checkServer, saveServer } from '#server/services/setup-state-service';
 
 const serverInput = z.object({
@@ -11,11 +12,19 @@ const serverInput = z.object({
 
 export const serversRouter = {
   update: publicProcedure.input(serverInput).handler(async function updateServer({ input }) {
-    return saveServer(input);
+    try {
+      return await saveServer(input);
+    } catch (error) {
+      throw userFacingError(error, 'Could not save server');
+    }
   }),
   check: publicProcedure
     .input(z.object({ role: z.enum(['prod', 'dev']) }))
     .handler(async function checkServerHealth({ input }) {
-      return checkServer(input.role);
+      try {
+        return await checkServer(input.role);
+      } catch (error) {
+        throw userFacingError(error, 'Could not check server');
+      }
     }),
 };

--- a/src/db/migrations/006_onboarding.sql
+++ b/src/db/migrations/006_onboarding.sql
@@ -1,0 +1,4 @@
+insert or ignore into setup_steps (key, label) values
+  ('app-password', 'Set app password'),
+  ('project', 'Create project'),
+  ('backups-config', 'Choose backup storage');

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -74,6 +74,9 @@ describe('control plane database', function controlPlaneDatabase() {
       'backups',
       'replica',
       'first-branch',
+      'app-password',
+      'project',
+      'backups-config',
     ]);
     expect(steps.every(function isPending(step) {
       return step.status === 'pending';

--- a/src/server/services/app-auth-service.ts
+++ b/src/server/services/app-auth-service.ts
@@ -1,0 +1,121 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'node:crypto';
+import { sql } from 'kysely';
+import { getDb } from '#db/client';
+import { getSetting, getSettings, setSetting } from './settings-service';
+
+const APP_AUTH_KEYS = [
+  'app.auth.username',
+  'app.auth.passwordHash',
+] as const;
+
+const DEFAULT_USERNAME = 'admin';
+
+export interface AppAuthInput {
+  username: string;
+  password: string;
+}
+
+export interface AppAuthState {
+  configured: boolean;
+  envConfigured: boolean;
+  username: string;
+}
+
+export async function getAppAuthState(): Promise<AppAuthState> {
+  const envUsername = process.env.VELO_BASIC_AUTH_USERNAME || '';
+  const envPassword = process.env.VELO_BASIC_AUTH_PASSWORD || '';
+
+  if (envUsername && envPassword) {
+    return {
+      configured: true,
+      envConfigured: true,
+      username: envUsername,
+    };
+  }
+
+  const settings = await getSettings(APP_AUTH_KEYS);
+  const username = settings['app.auth.username'] || DEFAULT_USERNAME;
+
+  return {
+    configured: Boolean(settings['app.auth.passwordHash']),
+    envConfigured: false,
+    username,
+  };
+}
+
+export async function saveAppPassword(input: AppAuthInput): Promise<AppAuthState> {
+  const username = input.username.trim() || DEFAULT_USERNAME;
+  const password = input.password.trim();
+
+  if (password.length < 8) {
+    throw new Error('Password must be at least 8 characters');
+  }
+
+  await Promise.all([
+    setSetting('app.auth.username', username),
+    setSetting('app.auth.passwordHash', hashPassword(password)),
+  ]);
+  await setAppPasswordStepDone();
+
+  return getAppAuthState();
+}
+
+async function setAppPasswordStepDone(): Promise<void> {
+  await getDb()
+    .updateTable('setupSteps')
+    .set({
+      status: 'done',
+      message: 'app password saved',
+      updatedAt: sql`datetime('now')`,
+    })
+    .where('key', '=', 'app-password')
+    .execute();
+}
+
+export async function verifyAppPassword(username: string, password: string): Promise<boolean> {
+  const state = await getAppAuthState();
+
+  if (!state.configured) {
+    return true;
+  }
+
+  if (state.envConfigured) {
+    return username === state.username && password === (process.env.VELO_BASIC_AUTH_PASSWORD || '');
+  }
+
+  if (username !== state.username) {
+    return false;
+  }
+
+  const passwordHash = await getSetting('app.auth.passwordHash');
+
+  if (!passwordHash) {
+    return false;
+  }
+
+  return verifyPassword(password, passwordHash);
+}
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+
+  return `${salt}:${hash}`;
+}
+
+function verifyPassword(password: string, storedHash: string): boolean {
+  const [salt, hash] = storedHash.split(':');
+
+  if (!salt || !hash) {
+    return false;
+  }
+
+  const expected = Buffer.from(hash, 'hex');
+  const actual = scryptSync(password, salt, expected.length);
+
+  if (actual.length !== expected.length) {
+    return false;
+  }
+
+  return timingSafeEqual(actual, expected);
+}

--- a/src/server/services/project-service.ts
+++ b/src/server/services/project-service.ts
@@ -1,0 +1,104 @@
+import { sql } from 'kysely';
+import { DEFAULTS } from '#config/defaults';
+import { getDb } from '#db/client';
+import type { Project } from '#db/schema';
+
+const DEFAULT_PROJECT_NAME = 'prod';
+
+export interface ProjectInput {
+  name: string;
+  postgresVersion?: string;
+  databaseName?: string;
+  appUser?: string;
+}
+
+export async function getCurrentProject(): Promise<Project | null> {
+  const project = await getDb()
+    .selectFrom('projects')
+    .selectAll()
+    .orderBy('id')
+    .executeTakeFirst();
+
+  return project ?? null;
+}
+
+export async function ensureProject(): Promise<Project> {
+  const existing = await getCurrentProject();
+
+  if (existing) {
+    return existing;
+  }
+
+  await getDb()
+    .insertInto('projects')
+    .values({
+      name: DEFAULT_PROJECT_NAME,
+      postgresVersion: DEFAULTS.postgres.defaultVersion,
+      databaseName: 'postgres',
+      appUser: 'postgres',
+    })
+    .execute();
+
+  return getDb()
+    .selectFrom('projects')
+    .selectAll()
+    .orderBy('id')
+    .executeTakeFirstOrThrow();
+}
+
+export async function saveProject(input: ProjectInput): Promise<Project> {
+  const name = input.name.trim();
+  const postgresVersion = (input.postgresVersion || DEFAULTS.postgres.defaultVersion).trim();
+  const databaseName = (input.databaseName || 'postgres').trim();
+  const appUser = (input.appUser || 'postgres').trim();
+
+  if (!name) {
+    throw new Error('Project name is required');
+  }
+
+  const existing = await getCurrentProject();
+
+  if (existing) {
+    await getDb()
+      .updateTable('projects')
+      .set({
+        name,
+        postgresVersion,
+        databaseName,
+        appUser,
+        updatedAt: sql`datetime('now')`,
+      })
+      .where('id', '=', existing.id)
+      .execute();
+  } else {
+    await getDb()
+      .insertInto('projects')
+      .values({
+        name,
+        postgresVersion,
+        databaseName,
+        appUser,
+      })
+      .execute();
+  }
+
+  await setProjectStepDone();
+
+  return getDb()
+    .selectFrom('projects')
+    .selectAll()
+    .orderBy('id')
+    .executeTakeFirstOrThrow();
+}
+
+async function setProjectStepDone(): Promise<void> {
+  await getDb()
+    .updateTable('setupSteps')
+    .set({
+      status: 'done',
+      message: 'project saved',
+      updatedAt: sql`datetime('now')`,
+    })
+    .where('key', '=', 'project')
+    .execute();
+}

--- a/src/server/services/settings-service.ts
+++ b/src/server/services/settings-service.ts
@@ -83,6 +83,8 @@ export async function setSetting(key: string, value: string): Promise<void> {
 }
 
 export async function saveBackupSettings(input: BackupSettingsInput): Promise<BackupSettings> {
+  await validateBackupSettings(input);
+
   await Promise.all([
     setSetting('backup.s3.enabled', input.enabled ? 'true' : 'false'),
     setSetting('backup.s3.endpoint', input.endpoint.trim()),
@@ -97,6 +99,8 @@ export async function saveBackupSettings(input: BackupSettingsInput): Promise<Ba
   if (input.secretAccessKey && input.secretAccessKey.trim()) {
     await setSetting('backup.s3.secretAccessKey', input.secretAccessKey.trim());
   }
+
+  await setBackupConfigStepDone(input.enabled ? 'S3 backup storage saved' : 'local backup storage saved');
 
   return getBackupSettings();
 }
@@ -133,4 +137,45 @@ function normalizePositiveInteger(value: number | undefined, fallback: number): 
   }
 
   return Math.floor(value);
+}
+
+async function validateBackupSettings(input: BackupSettingsInput): Promise<void> {
+  if (!input.enabled) {
+    return;
+  }
+
+  const missing = [];
+  const existingSecret = await getSetting('backup.s3.secretAccessKey');
+
+  if (!input.endpoint.trim()) {
+    missing.push('endpoint');
+  }
+
+  if (!input.bucket.trim()) {
+    missing.push('bucket');
+  }
+
+  if (!input.accessKeyId.trim()) {
+    missing.push('access key');
+  }
+
+  if (!input.secretAccessKey?.trim() && !existingSecret) {
+    missing.push('secret key');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing S3 backup ${missing.join(', ')}`);
+  }
+}
+
+async function setBackupConfigStepDone(message: string): Promise<void> {
+  await getDb()
+    .updateTable('setupSteps')
+    .set({
+      status: 'done',
+      message,
+      updatedAt: sql`datetime('now')`,
+    })
+    .where('key', '=', 'backups-config')
+    .execute();
 }

--- a/src/server/services/setup-state-service.ts
+++ b/src/server/services/setup-state-service.ts
@@ -6,6 +6,21 @@ import { listJobs, type JobRecord } from './job-service';
 import { getBackupAvailability, type BackupAvailability } from './backup-availability-service';
 import { getBackupSettings, getSetting, type BackupSettings } from './settings-service';
 import { checkLocalDocker, isLocalDockerMode } from './local-docker-service';
+import { getAppAuthState, type AppAuthState } from './app-auth-service';
+import { getCurrentProject } from './project-service';
+import type { Project } from '#db/schema';
+
+const SETUP_STEP_ORDER = [
+  'app-password',
+  'project',
+  'dev-check',
+  'prod-check',
+  'backups-config',
+  'prod-setup',
+  'backups',
+  'replica',
+  'first-branch',
+];
 
 export interface ServerInput {
   role: 'prod' | 'dev';
@@ -36,6 +51,8 @@ export interface ControlPlaneState {
     expiresAt: string | null;
     createdAt: string;
   }>;
+  project: Project | null;
+  appAuth: AppAuthState;
   jobs: JobRecord[];
   backup: BackupSettings;
   backupAvailability: BackupAvailability;
@@ -44,12 +61,13 @@ export interface ControlPlaneState {
 
 export async function getControlPlaneState(): Promise<ControlPlaneState> {
   const db = getDb();
-  const [servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl] = await Promise.all([
+  await syncDerivedOnboardingSteps();
+
+  const [servers, setupSteps, branches, project, appAuth, jobs, backup, backupAvailability, prodConnectionUrl] = await Promise.all([
     db.selectFrom('servers').selectAll().orderBy('role').execute(),
     db
       .selectFrom('setupSteps')
       .select(['key', 'label', 'status', 'message', 'updatedAt'])
-      .orderBy('id')
       .execute(),
     db
       .selectFrom('branches')
@@ -70,34 +88,61 @@ export async function getControlPlaneState(): Promise<ControlPlaneState> {
       .where('branches.slug', 'not like', 'preview-%')
       .orderBy('branches.createdAt', 'desc')
       .execute(),
+    getCurrentProject(),
+    getAppAuthState(),
     listJobs(10),
     getBackupSettings(),
     getBackupAvailability(),
     getSetting('prod.connectionUrl'),
   ]);
 
-  return { servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl };
+  return {
+    servers,
+    setupSteps: sortSetupSteps(setupSteps),
+    branches,
+    project,
+    appAuth,
+    jobs,
+    backup,
+    backupAvailability,
+    prodConnectionUrl,
+  };
 }
 
 export async function saveServer(input: ServerInput): Promise<Server> {
   const db = getDb();
+  const host = input.host.trim();
+  const sshUser = input.sshUser.trim();
+  const sshKeyPath = input.sshKeyPath.trim();
+
+  if (!host) {
+    throw new Error('Host is required');
+  }
+
+  if (!sshUser) {
+    throw new Error('SSH user is required');
+  }
+
+  if (!sshKeyPath) {
+    throw new Error('SSH key path is required');
+  }
 
   await db
     .insertInto('servers')
     .values({
       role: input.role,
-      host: input.host,
-      sshUser: input.sshUser,
-      sshKeyPath: input.sshKeyPath,
+      host,
+      sshUser,
+      sshKeyPath,
       status: 'unknown',
       statusMessage: null,
       lastCheckedAt: null,
     })
     .onConflict(function updateExisting(oc) {
       return oc.column('role').doUpdateSet({
-        host: input.host,
-        sshUser: input.sshUser,
-        sshKeyPath: input.sshKeyPath,
+        host,
+        sshUser,
+        sshKeyPath,
         status: 'unknown',
         statusMessage: null,
         updatedAt: sql`datetime('now')`,
@@ -174,4 +219,45 @@ export async function setStepStatus(
     })
     .where('key', '=', key)
     .execute();
+}
+
+async function syncDerivedOnboardingSteps(): Promise<void> {
+  const [project, appAuth] = await Promise.all([
+    getCurrentProject(),
+    getAppAuthState(),
+  ]);
+
+  if (project) {
+    await markStepDoneIfNeeded('project', 'project saved');
+  }
+
+  if (appAuth.configured) {
+    await markStepDoneIfNeeded('app-password', appAuth.envConfigured ? 'app password set by env' : 'app password saved');
+  }
+}
+
+async function markStepDoneIfNeeded(key: string, message: string): Promise<void> {
+  const step = await getDb()
+    .selectFrom('setupSteps')
+    .select('status')
+    .where('key', '=', key)
+    .executeTakeFirst();
+
+  if (step?.status === 'done') {
+    return;
+  }
+
+  await setStepStatus(key, 'done', message);
+}
+
+function sortSetupSteps<T extends { key: string }>(steps: T[]): T[] {
+  return steps.slice().sort(function sortBySetupOrder(first, second) {
+    return getSetupStepIndex(first.key) - getSetupStepIndex(second.key);
+  });
+}
+
+function getSetupStepIndex(key: string): number {
+  const index = SETUP_STEP_ORDER.indexOf(key);
+
+  return index === -1 ? SETUP_STEP_ORDER.length : index;
 }

--- a/src/server/web-runtime.ts
+++ b/src/server/web-runtime.ts
@@ -6,6 +6,7 @@ import { startUpdateScheduler } from '#server/services/update-scheduler';
 import { jobHandlers } from '#server/services/job-handlers';
 import { startJobWorker } from '#server/services/job-service';
 import { startBranchCleanupScheduler } from '#server/services/branch-cleanup-scheduler';
+import { getAppAuthState, verifyAppPassword } from '#server/services/app-auth-service';
 
 const host = process.env.HOST || '0.0.0.0';
 const port = Number(process.env.PORT || 3000);
@@ -28,7 +29,7 @@ Bun.serve({
   hostname: host,
   port,
   async fetch(request) {
-    const authResponse = requireBasicAuth(request);
+    const authResponse = await requireBasicAuth(request);
 
     if (authResponse) {
       return authResponse;
@@ -46,11 +47,14 @@ Bun.serve({
 
 console.log(`Started server: http://${host}:${port}`);
 
-function requireBasicAuth(request: Request): Response | null {
+async function requireBasicAuth(request: Request): Promise<Response | null> {
   const username = process.env.VELO_BASIC_AUTH_USERNAME || '';
   const password = process.env.VELO_BASIC_AUTH_PASSWORD || '';
+  const appAuth = username && password
+    ? { configured: true, envConfigured: true, username }
+    : await getAppAuthState();
 
-  if (!username || !password) {
+  if (!appAuth.configured) {
     return null;
   }
 
@@ -71,7 +75,7 @@ function requireBasicAuth(request: Request): Response | null {
   const providedUsername = decoded.slice(0, separator);
   const providedPassword = decoded.slice(separator + 1);
 
-  if (providedUsername !== username || providedPassword !== password) {
+  if (!(await verifyAppPassword(providedUsername, providedPassword))) {
     return unauthorizedResponse();
   }
 

--- a/src/web/components/onboarding-wizard.tsx
+++ b/src/web/components/onboarding-wizard.tsx
@@ -1,14 +1,32 @@
-import { useEffect } from 'react';
+import type { FormEvent, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { Link } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  AlertTriangle,
   CheckCircle2,
+  Copy,
   Database,
+  Folder,
   GitBranch,
   HardDrive,
+  KeyRound,
   Loader2,
   RefreshCw,
   ShieldCheck,
 } from 'lucide-react';
+import { cn } from '#lib/utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '#web/components/ui/alert-dialog';
 import { Badge } from '#web/components/ui/badge';
 import { Button } from '#web/components/ui/button';
 import {
@@ -18,6 +36,8 @@ import {
   CardHeader,
   CardTitle,
 } from '#web/components/ui/card';
+import { Input } from '#web/components/ui/input';
+import { Label } from '#web/components/ui/label';
 import { orpc, type ControlPlaneState } from '#web/lib/api-client';
 import {
   BackupPanel,
@@ -33,9 +53,11 @@ export function isSetupComplete(state: ControlPlaneState): boolean {
   });
 }
 
-export function OnboardingWizard() {
+export function OnboardingWizard(props: Readonly<{ onDismissComplete?: () => void }>) {
   const queryClient = useQueryClient();
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
+  const saveAppPassword = useMutation(orpc.onboarding.appPassword.update.mutationOptions({ onSuccess: refreshDashboard }));
+  const saveProject = useMutation(orpc.onboarding.project.update.mutationOptions({ onSuccess: refreshDashboard }));
   const saveServer = useMutation(orpc.servers.update.mutationOptions({ onSuccess: refreshDashboard }));
   const checkServer = useMutation(orpc.servers.check.mutationOptions({ onSuccess: refreshDashboard }));
   const saveBackupSettings = useMutation(orpc.backup.settings.update.mutationOptions({ onSuccess: refreshDashboard }));
@@ -69,6 +91,14 @@ export function OnboardingWizard() {
 
     if (activeJob) {
       return activeJob.type;
+    }
+
+    if (saveAppPassword.isPending) {
+      return 'save-app-password';
+    }
+
+    if (saveProject.isPending) {
+      return 'save-project';
     }
 
     if (saveServer.isPending) {
@@ -105,33 +135,67 @@ export function OnboardingWizard() {
   const doneSteps = state.setupSteps.filter(function countDone(step) {
     return step.status === 'done';
   }).length;
+  const error = getErrorMessage([
+    saveAppPassword.error,
+    saveProject.error,
+    saveServer.error,
+    checkServer.error,
+    saveBackupSettings.error,
+    completeSetup.error,
+  ]);
 
-  async function handleSave(formData: FormData) {
-    const role = formData.get('role') === 'prod' ? 'prod' : 'dev';
-    await saveServer.mutateAsync({
-      role,
-      host: String(formData.get('host') || ''),
-      sshUser: String(formData.get('sshUser') || ''),
-      sshKeyPath: String(formData.get('sshKeyPath') || ''),
-    });
+  async function handleSaveAppPassword(formData: FormData) {
+    try {
+      await saveAppPassword.mutateAsync({
+        username: String(formData.get('username') || 'admin'),
+        password: String(formData.get('password') || ''),
+      });
+    } catch {}
   }
 
-  async function handleCheck(role: ServerRole) {
-    await checkServer.mutateAsync({ role });
+  async function handleSaveProject(formData: FormData) {
+    try {
+      await saveProject.mutateAsync({
+        name: String(formData.get('name') || ''),
+        postgresVersion: String(formData.get('postgresVersion') || '17'),
+        databaseName: String(formData.get('databaseName') || 'postgres'),
+        appUser: String(formData.get('appUser') || 'postgres'),
+      });
+    } catch {}
+  }
+
+  async function handleSaveServer(formData: FormData) {
+    try {
+      const role = formData.get('role') === 'prod' ? 'prod' : 'dev';
+      await saveServer.mutateAsync({
+        role,
+        host: String(formData.get('host') || ''),
+        sshUser: String(formData.get('sshUser') || ''),
+        sshKeyPath: String(formData.get('sshKeyPath') || ''),
+      });
+    } catch {}
+  }
+
+  async function handleCheckServer(role: ServerRole) {
+    try {
+      await checkServer.mutateAsync({ role });
+    } catch {}
   }
 
   async function handleSaveBackup(formData: FormData) {
-    await saveBackupSettings.mutateAsync({
-      enabled: formData.get('enabled') === 'on',
-      endpoint: String(formData.get('endpoint') || ''),
-      bucket: String(formData.get('bucket') || ''),
-      region: String(formData.get('region') || 'auto'),
-      accessKeyId: String(formData.get('accessKeyId') || ''),
-      secretAccessKey: String(formData.get('secretAccessKey') || ''),
-      path: String(formData.get('path') || '/prod'),
-      pitrDays: Number(formData.get('pitrDays') || 7),
-      fullBackupRetentionDays: Number(formData.get('fullBackupRetentionDays') || 90),
-    });
+    try {
+      await saveBackupSettings.mutateAsync({
+        enabled: formData.get('enabled') === 'on',
+        endpoint: String(formData.get('endpoint') || ''),
+        bucket: String(formData.get('bucket') || ''),
+        region: String(formData.get('region') || 'auto'),
+        accessKeyId: String(formData.get('accessKeyId') || ''),
+        secretAccessKey: String(formData.get('secretAccessKey') || ''),
+        path: String(formData.get('path') || '/prod'),
+        pitrDays: Number(formData.get('pitrDays') || 7),
+        fullBackupRetentionDays: Number(formData.get('fullBackupRetentionDays') || 90),
+      });
+    } catch {}
   }
 
   async function handleCompleteSetup() {
@@ -139,7 +203,9 @@ export function OnboardingWizard() {
       return;
     }
 
-    await completeSetup.mutateAsync(undefined);
+    try {
+      await completeSetup.mutateAsync(undefined);
+    } catch {}
   }
 
   return (
@@ -153,7 +219,7 @@ export function OnboardingWizard() {
             </div>
             <h1 className="mt-3 text-3xl font-semibold tracking-normal md:text-4xl">Set up Velo</h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-              Finish setup before using branches, SQL, tables, or restore tools.
+              Follow each step. Progress is saved, so refresh is safe.
             </p>
           </div>
           <Button variant="outline" onClick={function refreshPage() { void dashboard.refetch(); }}>
@@ -162,50 +228,362 @@ export function OnboardingWizard() {
           </Button>
         </header>
 
-        <Card>
-          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <CardTitle>{doneSteps}/{state.setupSteps.length} complete</CardTitle>
-              <CardDescription>{nextStep ? `Next: ${nextStep.label}` : 'Setup complete'}</CardDescription>
-            </div>
-            <Button onClick={handleCompleteSetup} disabled={!nextStep || Boolean(busy)}>
-              {busy ? <Loader2 className="animate-spin" /> : getStepIcon(nextStep?.key)}
-              {busy ? 'Working...' : nextStep ? 'Finish setup' : 'Done'}
-            </Button>
-          </CardHeader>
-          <CardContent className="grid gap-3 md:grid-cols-2">
-            {state.setupSteps.map(function renderStep(step) {
-              const isActive = nextStep?.key === step.key;
-
-              return (
-                <div className="border-t border-border pt-3 first:border-t-0 first:pt-0" key={step.key}>
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="font-medium">{step.label}</p>
-                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
-                        {step.message || (isActive ? 'Ready' : 'Waiting')}
-                      </p>
-                    </div>
-                    <StatusBadge status={isActive && busy ? 'running' : step.status} />
-                  </div>
-                </div>
-              );
+        <div className="grid gap-6 xl:grid-cols-[280px_minmax(0,1fr)_360px]">
+          <SetupStepsCard steps={state.setupSteps} activeKey={nextStep?.key || null} doneSteps={doneSteps} />
+          <div className="grid gap-4">
+            {error ? <ErrorNote message={error} /> : null}
+            {renderCurrentStep({
+              state,
+              nextStep,
+              busy,
+              prodServer,
+              devServer,
+              onSaveAppPassword: handleSaveAppPassword,
+              onSaveProject: handleSaveProject,
+              onSaveServer: handleSaveServer,
+              onCheckServer: handleCheckServer,
+              onSaveBackup: handleSaveBackup,
+              onCompleteSetup: handleCompleteSetup,
+              onDismissComplete: props.onDismissComplete,
             })}
-          </CardContent>
-        </Card>
-
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
-          <div className="grid gap-6">
-            <div className="grid gap-6 lg:grid-cols-2">
-              <ServerPanel title="Production" role="prod" server={prodServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
-              <ServerPanel title="Development" role="dev" server={devServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
-            </div>
-            <BackupPanel backup={state.backup} busy={busy === 'save-backup'} onSave={handleSaveBackup} />
           </div>
           <JobsPanel jobs={state.jobs} activeJobs={activeJobs.length} />
         </div>
       </section>
     </main>
+  );
+}
+
+interface CurrentStepProps {
+  state: ControlPlaneState;
+  nextStep: ControlPlaneState['setupSteps'][number] | undefined;
+  busy: string | null;
+  prodServer: ControlPlaneState['servers'][number] | undefined;
+  devServer: ControlPlaneState['servers'][number] | undefined;
+  onSaveAppPassword: (formData: FormData) => Promise<void>;
+  onSaveProject: (formData: FormData) => Promise<void>;
+  onSaveServer: (formData: FormData) => Promise<void>;
+  onCheckServer: (role: ServerRole) => Promise<void>;
+  onSaveBackup: (formData: FormData) => Promise<void>;
+  onCompleteSetup: () => Promise<void>;
+  onDismissComplete?: () => void;
+}
+
+function renderCurrentStep(props: CurrentStepProps): ReactNode {
+  const step = props.nextStep;
+
+  if (!step) {
+    return <SetupCompleteStep state={props.state} onDismiss={props.onDismissComplete} />;
+  }
+
+  if (step.key === 'app-password') {
+    return <AppPasswordStep state={props.state} busy={props.busy === 'save-app-password'} onSave={props.onSaveAppPassword} />;
+  }
+
+  if (step.key === 'project') {
+    return <ProjectStep state={props.state} busy={props.busy === 'save-project'} onSave={props.onSaveProject} />;
+  }
+
+  if (step.key === 'dev-check') {
+    return (
+      <ServerPanel
+        key="dev-server-step"
+        title="Development"
+        role="dev"
+        server={props.devServer}
+        busy={props.busy}
+        onSave={props.onSaveServer}
+        onCheck={props.onCheckServer}
+      />
+    );
+  }
+
+  if (step.key === 'prod-check') {
+    return (
+      <ServerPanel
+        key="prod-server-step"
+        title="Production"
+        role="prod"
+        server={props.prodServer}
+        busy={props.busy}
+        onSave={props.onSaveServer}
+        onCheck={props.onCheckServer}
+      />
+    );
+  }
+
+  if (step.key === 'backups-config') {
+    return <BackupPanel backup={props.state.backup} busy={props.busy === 'save-backup'} onSave={props.onSaveBackup} />;
+  }
+
+  return <RunSetupStep step={step} busy={props.busy === 'setup'} onRun={props.onCompleteSetup} />;
+}
+
+function SetupStepsCard(props: {
+  steps: ControlPlaneState['setupSteps'];
+  activeKey: string | null;
+  doneSteps: number;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{props.doneSteps}/{props.steps.length} complete</CardTitle>
+        <CardDescription>{props.activeKey ? 'Current blocker shown at right' : 'Ready to use'}</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-2">
+        {props.steps.map(function renderStep(step, index) {
+          const active = step.key === props.activeKey;
+          const Icon = getStepIcon(step.key);
+
+          return (
+            <div
+              className={cn(
+                'grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-md border px-3 py-2',
+                active ? 'border-primary bg-primary/5' : 'border-border'
+              )}
+              key={step.key}
+            >
+              <div className="grid size-7 place-items-center rounded-md bg-muted text-muted-foreground">
+                <Icon className="size-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{step.label}</p>
+                <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                  {step.message || (active ? 'Ready' : `Step ${index + 1}`)}
+                </p>
+              </div>
+              <StatusBadge status={active && step.status === 'pending' ? 'ready' : step.status} />
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AppPasswordStep(props: {
+  state: ControlPlaneState;
+  busy: boolean;
+  onSave: (formData: FormData) => Promise<void>;
+}) {
+  async function submitForm(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await props.onSave(new FormData(event.currentTarget));
+  }
+
+  return (
+    <StepCard icon={KeyRound} title="Set app password" detail="Protect the web app before setup changes servers.">
+      <form className="grid gap-4" onSubmit={submitForm}>
+        <Field label="Username" htmlFor="app-username">
+          <Input id="app-username" name="username" defaultValue={props.state.appAuth.username || 'admin'} autoComplete="username" />
+        </Field>
+        <Field label="Password" htmlFor="app-password">
+          <Input id="app-password" name="password" type="password" minLength={8} autoComplete="new-password" />
+        </Field>
+        <Button type="submit" disabled={props.busy}>
+          {props.busy ? <Loader2 className="animate-spin" /> : <KeyRound />}
+          Save password
+        </Button>
+      </form>
+    </StepCard>
+  );
+}
+
+function ProjectStep(props: {
+  state: ControlPlaneState;
+  busy: boolean;
+  onSave: (formData: FormData) => Promise<void>;
+}) {
+  async function submitForm(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await props.onSave(new FormData(event.currentTarget));
+  }
+
+  return (
+    <StepCard icon={Folder} title="Create project" detail="Name the control-plane project and pick Postgres defaults.">
+      <form className="grid gap-4" onSubmit={submitForm}>
+        <Field label="Project name" htmlFor="project-name">
+          <Input id="project-name" name="name" defaultValue={props.state.project?.name || 'prod'} />
+        </Field>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <Field label="Postgres" htmlFor="project-postgres-version">
+            <Input id="project-postgres-version" name="postgresVersion" defaultValue={props.state.project?.postgresVersion || '17'} />
+          </Field>
+          <Field label="Database" htmlFor="project-database-name">
+            <Input id="project-database-name" name="databaseName" defaultValue={props.state.project?.databaseName || 'postgres'} />
+          </Field>
+          <Field label="App user" htmlFor="project-app-user">
+            <Input id="project-app-user" name="appUser" defaultValue={props.state.project?.appUser || 'postgres'} />
+          </Field>
+        </div>
+        <Button type="submit" disabled={props.busy}>
+          {props.busy ? <Loader2 className="animate-spin" /> : <Folder />}
+          Save project
+        </Button>
+      </form>
+    </StepCard>
+  );
+}
+
+function RunSetupStep(props: {
+  step: ControlPlaneState['setupSteps'][number];
+  busy: boolean;
+  onRun: () => Promise<void>;
+}) {
+  const needsWarning = props.step.key === 'prod-setup' || props.step.key === 'backups';
+
+  return (
+    <StepCard icon={ShieldCheck} title="Run setup" detail={getRunSetupDetail(props.step.key)}>
+      <div className="grid gap-4">
+        <div className="rounded-md border border-border bg-muted/30 p-3 text-xs leading-5 text-muted-foreground">
+          {props.step.message || 'Ready to continue.'}
+        </div>
+        {needsWarning ? (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button disabled={props.busy}>
+                {props.busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
+                Run setup
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Run production setup?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This installs packages, writes Postgres and pgBackRest config, restarts Postgres, and creates the first full backup.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={props.busy}>Cancel</AlertDialogCancel>
+                <AlertDialogAction disabled={props.busy} onClick={function confirmRun() { void props.onRun(); }}>
+                  Continue
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        ) : (
+          <Button disabled={props.busy} onClick={function clickRun() { void props.onRun(); }}>
+            {props.busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
+            Run setup
+          </Button>
+        )}
+      </div>
+    </StepCard>
+  );
+}
+
+function SetupCompleteStep(props: { state: ControlPlaneState; onDismiss?: () => void }) {
+  const devBranch = props.state.branches.find(function findDev(branch) {
+    return branch.slug === 'dev';
+  }) || props.state.branches[0];
+
+  return (
+    <StepCard icon={CheckCircle2} title="Setup complete" detail="Velo is ready.">
+      <div className="grid gap-4">
+        <Field label="Production">
+          <CopyValue value={props.state.prodConnectionUrl} />
+        </Field>
+        <Field label={devBranch ? devBranch.displayName : 'Dev branch'}>
+          <CopyValue value={devBranch?.connectionUrl || null} />
+        </Field>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="secondary" onClick={props.onDismiss}>
+            <CheckCircle2 />
+            Show dashboard
+          </Button>
+          <Button asChild>
+            <Link to="/branch/$branchId/overview" params={{ branchId: 'prod' }}>
+              <Database />
+              Open prod
+            </Link>
+          </Button>
+          {devBranch ? (
+            <Button asChild variant="outline">
+              <Link to="/branch/$branchId/overview" params={{ branchId: devBranch.slug }}>
+                <GitBranch />
+                Open dev
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </StepCard>
+  );
+}
+
+function StepCard(props: {
+  icon: typeof Database;
+  title: string;
+  detail: string;
+  children: ReactNode;
+}) {
+  const Icon = props.icon;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start gap-3">
+        <div className="grid size-9 place-items-center rounded-md bg-primary/10 text-primary">
+          <Icon className="size-4" />
+        </div>
+        <div>
+          <CardTitle>{props.title}</CardTitle>
+          <CardDescription>{props.detail}</CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent>{props.children}</CardContent>
+    </Card>
+  );
+}
+
+function ErrorNote(props: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      <AlertTriangle className="mt-0.5 size-4" />
+      <span>{props.message}</span>
+    </div>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  htmlFor?: string;
+  children: ReactNode;
+}
+
+function Field(props: FieldProps) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={props.htmlFor}>{props.label}</Label>
+      {props.children}
+    </div>
+  );
+}
+
+function CopyValue(props: { value: string | null }) {
+  const [copied, setCopied] = useState(false);
+  const value = props.value || '';
+
+  async function copyValue() {
+    if (!value) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    window.setTimeout(function resetCopied() {
+      setCopied(false);
+    }, 1200);
+  }
+
+  return (
+    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+      <code className="min-w-0 truncate rounded-md border border-border bg-muted/40 px-3 py-2 font-mono text-xs text-muted-foreground">
+        {value || 'not ready'}
+      </code>
+      <Button type="button" size="icon" variant="outline" onClick={copyValue} disabled={!value} title="Copy">
+        {copied ? <CheckCircle2 className="text-emerald-600" /> : <Copy />}
+      </Button>
+    </div>
   );
 }
 
@@ -215,24 +593,64 @@ function getNextStep(state: ControlPlaneState) {
   });
 }
 
-function getStepIcon(key: string | undefined) {
-  if (key === 'dev-check') {
-    return <HardDrive />;
+function getStepIcon(key: string) {
+  if (key === 'app-password') {
+    return KeyRound;
   }
 
-  if (key === 'prod-check' || key === 'prod-setup' || key === 'backups') {
-    return <ShieldCheck />;
+  if (key === 'project') {
+    return Folder;
+  }
+
+  if (key === 'dev-check') {
+    return HardDrive;
+  }
+
+  if (key === 'prod-check' || key === 'prod-setup' || key === 'backups' || key === 'backups-config') {
+    return ShieldCheck;
   }
 
   if (key === 'replica') {
-    return <Database />;
+    return Database;
   }
 
   if (key === 'first-branch') {
-    return <GitBranch />;
+    return GitBranch;
   }
 
-  return <CheckCircle2 />;
+  return CheckCircle2;
+}
+
+function getRunSetupDetail(key: string): string {
+  if (key === 'prod-setup' || key === 'backups') {
+    return 'Install production Postgres, configure backups, and create the first backup.';
+  }
+
+  if (key === 'replica') {
+    return 'Create the dev replica base from production.';
+  }
+
+  if (key === 'first-branch') {
+    return 'Create the first writable dev branch.';
+  }
+
+  return 'Continue setup.';
+}
+
+function getErrorMessage(errors: unknown[]): string | null {
+  const error = errors.find(function hasError(item) {
+    return Boolean(item);
+  });
+
+  if (!error) {
+    return null;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return 'Action failed';
 }
 
 function OnboardingLoading(props: Readonly<{ message: string }>) {

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Database, Loader2 } from 'lucide-react';
 import {
   AppSidebar,
@@ -15,6 +15,7 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
+  const [hideCompletedSetup, setHideCompletedSetup] = useState(false);
   const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
     return job.status === 'queued' || job.status === 'running';
   }).length ?? 0;
@@ -33,14 +34,23 @@ function HomePage() {
     };
   }, [activeJobs, dashboard]);
 
+  useEffect(function loadCompletedSetupPreference() {
+    setHideCompletedSetup(window.localStorage.getItem('velo.onboarding.complete.dismissed') === 'true');
+  }, []);
+
   if (!dashboard.data) {
     return <LoadingPage message={dashboard.error ? 'Could not load dashboard.' : 'Loading dashboard...'} />;
   }
 
   const state = dashboard.data;
 
-  if (!isSetupComplete(state)) {
-    return <OnboardingWizard />;
+  if (!isSetupComplete(state) || !hideCompletedSetup) {
+    return <OnboardingWizard onDismissComplete={handleDismissCompletedSetup} />;
+  }
+
+  function handleDismissCompletedSetup() {
+    window.localStorage.setItem('velo.onboarding.complete.dismissed', 'true');
+    setHideCompletedSetup(true);
   }
 
   return (


### PR DESCRIPTION
## Summary
- add guided first-run onboarding with persisted app password, project, server, backup, setup, and done steps
- add final copyable connection strings screen before entering the dashboard
- validate setup blockers before long jobs and show user-facing errors

## API routes, procedures, and contracts
- Added oRPC procedures: `onboarding.appPassword.update`, `onboarding.project.update`
- Updated `bootstrap.complete` to validate onboarding prerequisites before creating the setup job
- Updated `backup.settings.update` to validate S3 settings and mark backup config complete
- Updated `servers.update` and `servers.check` to return user-facing errors
- Added SQLite setup steps: `app-password`, `project`, `backups-config`
- Added SQLite-backed app auth settings used by production Basic Auth when env auth is unset

## QA
- Browser QA through in-app Browser plugin on fresh SQLite DB
- `bun run typecheck`
- `bun run test`
- `bun run web:build`