### PR TITLE
fix(setup): stop creating dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The agent installs Velo end-to-end:
 - creates the Velo web service
 - configures production Postgres and pgBackRest
 - creates the dev replica base
-- creates the first dev branch
 - verifies readiness with `/healthz?ready=1`
 
 When the agent finishes, Velo is ready at:

--- a/install.md
+++ b/install.md
@@ -47,7 +47,6 @@ This install may:
 - configure pgBackRest
 - create an initial full backup
 - create a dev replica base
-- create first dev branch
 
 ## Use Repo Code
 
@@ -281,7 +280,6 @@ cd '$VELO_DIR'
 VELO_DB='$VELO_DIR/.velo/velo.sqlite' bun - <<'BUN'
 import { runDevBootstrap, runProdBootstrap } from './src/server/services/bootstrap-service.ts';
 import { createReplicaBase } from './src/server/services/replica-service.ts';
-import { createBranchFromBase } from './src/server/services/branch-service.ts';
 
 function assertOk(result) {
   if (!result.ok) {
@@ -292,7 +290,6 @@ function assertOk(result) {
 assertOk(await runDevBootstrap());
 assertOk(await runProdBootstrap());
 assertOk(await createReplicaBase());
-await createBranchFromBase({ name: 'dev' });
 BUN
 systemctl restart velo-web
 "

--- a/scripts/deploy-hetzner.sh
+++ b/scripts/deploy-hetzner.sh
@@ -193,7 +193,6 @@ VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun -
 import { checkServer } from \"./src/server/services/setup-state-service.ts\";
 import { runDevBootstrap, runProdBootstrap } from \"./src/server/services/bootstrap-service.ts\";
 import { createReplicaBase } from \"./src/server/services/replica-service.ts\";
-import { createBranchFromBase } from \"./src/server/services/branch-service.ts\";
 
 function assertOk(result) {
   if (!result.ok) {
@@ -206,7 +205,6 @@ await checkServer(\"prod\");
 assertOk(await runDevBootstrap());
 assertOk(await runProdBootstrap());
 assertOk(await createReplicaBase());
-await createBranchFromBase({ name: \"dev\" });
 '
 systemctl restart velo-web
 "
@@ -237,18 +235,13 @@ import { Database } from \"bun:sqlite\";
 const db = new Database(process.env.VELO_DB);
 const servers = db.query(\"select role, status from servers order by role\").all();
 const steps = db.query(\"select key, status from setup_steps order by key\").all();
-const branches = db.query(\"select slug, status from branches order by slug\").all();
 
 if (servers.length !== 2 || servers.some(function isBad(server) { return server.status !== \"ok\"; })) {
   throw new Error(\"bad servers: \" + JSON.stringify(servers));
 }
 
-if (steps.length !== 6 || steps.some(function isBad(step) { return step.status !== \"done\"; })) {
+if (steps.length !== 5 || steps.some(function isBad(step) { return step.status !== \"done\"; })) {
   throw new Error(\"bad setup steps: \" + JSON.stringify(steps));
-}
-
-if (branches.length !== 1 || branches[0].slug !== \"dev\" || branches[0].status !== \"running\") {
-  throw new Error(\"fresh deploy should create one dev branch: \" + JSON.stringify(branches));
 }
 
 db.close();

--- a/src/db/migrations/001_initial.sql
+++ b/src/db/migrations/001_initial.sql
@@ -62,5 +62,4 @@ insert or ignore into setup_steps (key, label) values
   ('prod-check', 'Check prod server'),
   ('prod-setup', 'Configure prod Postgres'),
   ('backups', 'Configure backups and PITR'),
-  ('replica', 'Create dev replica'),
-  ('first-branch', 'Create first branch');
+  ('replica', 'Create dev replica');

--- a/src/db/migrations/006_remove_first_branch_setup_step.sql
+++ b/src/db/migrations/006_remove_first_branch_setup_step.sql
@@ -1,0 +1,1 @@
+delete from setup_steps where key = 'first-branch';

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -73,7 +73,6 @@ describe('control plane database', function controlPlaneDatabase() {
       'prod-setup',
       'backups',
       'replica',
-      'first-branch',
     ]);
     expect(steps.every(function isPending(step) {
       return step.status === 'pending';
@@ -186,9 +185,9 @@ describe('control plane database', function controlPlaneDatabase() {
       .selectFrom('setupSteps')
       .select(['status'])
       .where('key', '=', 'first-branch')
-      .executeTakeFirstOrThrow();
+      .executeTakeFirst();
 
-    expect(firstBranchStep.status).toBe('pending');
+    expect(firstBranchStep).toBeUndefined();
   });
 
   test('tracks branch expiry and skips active cleanup targets', async function testBranchExpiry() {

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -63,8 +63,6 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
   }
 
   await ensureBranchSourceReady(source.slug);
-  await setStepStatus('first-branch', 'running', `creating ${displayName}`);
-
   try {
     if (isLocalDockerMode()) {
       const result = await createLocalDockerBranch({
@@ -76,8 +74,6 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
         parentBranchId: source.id,
         expiresAt,
       });
-
-      await setStepStatus('first-branch', 'done', `${displayName} ready`);
 
       return result;
     }
@@ -94,11 +90,8 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
       readOnly: false,
     });
 
-    await setStepStatus('first-branch', 'done', `${displayName} ready`);
-
     return result;
   } catch (error: any) {
-    await setStepStatus('first-branch', 'error', error?.message || 'branch create failed');
     throw error;
   }
 }
@@ -432,16 +425,6 @@ export async function deleteBranch(input: DeleteBranchInput): Promise<DeleteBran
     .deleteFrom('branches')
     .where('id', '=', branch.id)
     .execute();
-
-  const remaining = await db
-    .selectFrom('branches')
-    .select('id')
-    .limit(1)
-    .executeTakeFirst();
-
-  if (!remaining) {
-    await setStepStatus('first-branch', 'pending', 'no branches yet');
-  }
 
   return {
     id: branch.id,

--- a/src/server/services/job-handlers.ts
+++ b/src/server/services/job-handlers.ts
@@ -122,11 +122,6 @@ async function runSetupJob(context: JobContext): Promise<void> {
     await context.log('creating dev replica base');
     assertOk(await createReplicaBase());
   }
-
-  if (!(await isStepDone('first-branch'))) {
-    await context.log('creating first dev branch');
-    await createBranchFromBase({ name: 'dev' });
-  }
 }
 
 async function isStepDone(key: string): Promise<boolean> {

--- a/src/server/services/local-docker-service.ts
+++ b/src/server/services/local-docker-service.ts
@@ -196,16 +196,6 @@ export async function deleteLocalDockerBranch(id: number) {
     .where('id', '=', branch.id)
     .execute();
 
-  const remaining = await db
-    .selectFrom('branches')
-    .select('id')
-    .limit(1)
-    .executeTakeFirst();
-
-  if (!remaining) {
-    await setLocalStepStatus('first-branch', 'pending', 'no branches yet');
-  }
-
   return {
     id: branch.id,
     slug: branch.slug,

--- a/src/server/web-runtime.ts
+++ b/src/server/web-runtime.ts
@@ -71,7 +71,6 @@ async function handleHealthCheck(request: Request): Promise<Response | null> {
     setup: !requireReady,
     servers: !requireReady,
     prodConnection: !requireReady,
-    branches: !requireReady,
   };
   const errors: string[] = [];
 
@@ -103,9 +102,6 @@ async function handleHealthCheck(request: Request): Promise<Response | null> {
         return server.status === 'ok';
       });
       checks.prodConnection = Boolean(state.prodConnectionUrl);
-      checks.branches = state.branches.some(function isRunningBranch(branch) {
-        return branch.status === 'running';
-      });
 
       if (!checks.setup) {
         errors.push('setup: not all setup steps are done');
@@ -117,10 +113,6 @@ async function handleHealthCheck(request: Request): Promise<Response | null> {
 
       if (!checks.prodConnection) {
         errors.push('prodConnection: missing production connection URL');
-      }
-
-      if (!checks.branches) {
-        errors.push('branches: no running dev branch found');
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- stop setup/deploy from auto-creating the initial `dev` branch
- remove `first-branch` from setup steps and migrate old rows away
- make `/healthz?ready=1` pass without requiring a running branch

## API routes, procedures, contracts
- Updated `/healthz?ready=1`: readiness no longer requires any dev branch.
- No API routes or procedures added/deleted.

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`
