### PR TITLE
fix(network): restrict prod postgres access

### DIFF
--- a/src/api/servers.ts
+++ b/src/api/servers.ts
@@ -7,6 +7,7 @@ const serverInput = z.object({
   host: z.string().min(1),
   sshUser: z.string().min(1),
   sshKeyPath: z.string().min(1),
+  allowedCidr: z.string().optional(),
 });
 
 export const serversRouter = {

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -13,6 +13,7 @@ import { createBranchFromBase, runExpiredBranchCleanup, updateBranchExpiry } fro
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, saveServer } from './services/setup-state-service';
+import { defaultCidrForHost, getProdAllowedCidr, normalizeAllowedCidr } from './services/prod-network-service';
 
 let testDir: string;
 
@@ -146,6 +147,40 @@ describe('control plane database', function controlPlaneDatabase() {
     });
     expect(JSON.stringify(state)).not.toContain('super-secret');
     expect(state.prodConnectionUrl).toBe('postgresql://postgres:secret@example.com:5432/postgres');
+  });
+
+  test('defaults prod allowed cidr to dev server ip', async function testProdAllowedCidrDefault() {
+    await saveServer({
+      role: 'dev',
+      host: '157.180.22.136',
+      sshUser: 'root',
+      sshKeyPath: '/root/.ssh/frost-e2e-ci',
+    });
+
+    expect(await getProdAllowedCidr()).toBe('157.180.22.136/32');
+    expect(defaultCidrForHost('2001:db8::1')).toBe('2001:db8::1/128');
+  });
+
+  test('saves prod allowed cidr override', async function testSaveProdAllowedCidr() {
+    await saveServer({
+      role: 'prod',
+      host: '89.167.89.255',
+      sshUser: 'root',
+      sshKeyPath: '/root/.ssh/frost-e2e-ci',
+      allowedCidr: '198.51.100.0/24',
+    });
+
+    const state = await getControlPlaneState();
+    expect(state.prodAllowedCidr).toBe('198.51.100.0/24');
+  });
+
+  test('rejects invalid prod allowed cidr', function testInvalidProdAllowedCidr() {
+    expect(function invalidNoPrefix() {
+      normalizeAllowedCidr('0.0.0.0');
+    }).toThrow('CIDR');
+    expect(function invalidPrefix() {
+      normalizeAllowedCidr('203.0.113.10/99');
+    }).toThrow('between 0 and 32');
   });
 
   test('keeps existing backup secret when saving without a new one', async function testKeepBackupSecret() {

--- a/src/server/services/bootstrap-service.ts
+++ b/src/server/services/bootstrap-service.ts
@@ -4,6 +4,7 @@ import { runCommand, runSshCommand } from './command-service';
 import { getBackupSettings, getSetting, setSetting } from './settings-service';
 import { setStepStatus } from './setup-state-service';
 import { bootstrapLocalDocker, isLocalDockerMode } from './local-docker-service';
+import { getProdAllowedCidr } from './prod-network-service';
 
 export interface BootstrapResult {
   ok: boolean;
@@ -72,7 +73,7 @@ export async function runProdBootstrap(): Promise<BootstrapResult> {
   await setStepStatus('prod-setup', 'running', 'installing Postgres on prod');
   await setStepStatus('backups', 'running', 'configuring pgBackRest');
 
-  const allowedCidr = await getSetting('prod.allowedCidr') || '0.0.0.0/0';
+  const allowedCidr = await getProdAllowedCidr();
   let pgBackRestConfig: string;
   try {
     pgBackRestConfig = await buildPgBackRestConfig();
@@ -109,7 +110,8 @@ export async function runProdBootstrap(): Promise<BootstrapResult> {
       `sudo -u postgres psql -c "alter system set ssl = 'on'"`,
       `sudo -u postgres psql -c "alter role postgres with password ${sqlStringLiteral(prodPassword)}"`,
       'HBA_FILE=$(sudo -u postgres psql -tAc "show hba_file" | xargs)',
-      `grep -q "velo prod access ${allowedCidr}" "$HBA_FILE" || echo "hostssl all postgres ${allowedCidr} scram-sha-256 # velo prod access ${allowedCidr}" | sudo tee -a "$HBA_FILE" >/dev/null`,
+      'sudo sed -i "/# velo prod access /d" "$HBA_FILE"',
+      `echo "hostssl all postgres ${allowedCidr} scram-sha-256 # velo prod access ${allowedCidr}" | sudo tee -a "$HBA_FILE" >/dev/null`,
       'sudo systemctl restart postgresql',
       'sudo -u postgres pgbackrest --stanza=main stanza-create || sudo -u postgres pgbackrest --stanza=main info',
       'sudo -u postgres pgbackrest --stanza=main check',
@@ -130,7 +132,20 @@ export async function runProdBootstrap(): Promise<BootstrapResult> {
   await setStepStatus('backups', ok ? 'done' : 'error', ok ? 'pgBackRest full backup ready' : message);
 
   if (ok) {
-    await setSetting('prod.connectionUrl', formatProdConnectionUrl(prod.host, prodPassword));
+    const connectionUrl = formatProdConnectionUrl(prod.host, prodPassword);
+    const connectionCheck = await runCommand([
+      'sh',
+      '-lc',
+      `psql ${shellQuote(connectionUrl)} -tAc 'select 1'`,
+    ], 30_000);
+
+    if (connectionCheck.exitCode !== 0) {
+      const checkMessage = connectionCheck.stderr || connectionCheck.stdout || `prod connection failed from app server. Check allowed CIDR ${allowedCidr}.`;
+      await setStepStatus('prod-setup', 'error', checkMessage);
+      return { ok: false, message: checkMessage };
+    }
+
+    await setSetting('prod.connectionUrl', connectionUrl);
   }
 
   return { ok, message };

--- a/src/server/services/prod-network-service.ts
+++ b/src/server/services/prod-network-service.ts
@@ -1,0 +1,74 @@
+import { isIP } from 'node:net';
+import { getDb } from '../../db/client';
+import { getSetting, setSetting } from './settings-service';
+
+const PROD_ALLOWED_CIDR_KEY = 'prod.allowedCidr';
+
+export async function getProdAllowedCidr(): Promise<string> {
+  const configured = await getSetting(PROD_ALLOWED_CIDR_KEY);
+  if (configured) {
+    return normalizeAllowedCidr(configured);
+  }
+
+  const devServer = await getDb()
+    .selectFrom('servers')
+    .select('host')
+    .where('role', '=', 'dev')
+    .executeTakeFirst();
+
+  return defaultCidrForHost(devServer?.host || '');
+}
+
+export async function saveProdAllowedCidr(value: string): Promise<string> {
+  const cidr = normalizeAllowedCidr(value);
+  await setSetting(PROD_ALLOWED_CIDR_KEY, cidr);
+  return cidr;
+}
+
+export function defaultCidrForHost(host: string): string {
+  const normalized = host.trim();
+  if (!normalized) {
+    throw new Error('Set the dev server host or production allowed CIDR before production setup.');
+  }
+
+  const version = isIP(normalized);
+  if (version === 4) {
+    return `${normalized}/32`;
+  }
+
+  if (version === 6) {
+    return `${normalized}/128`;
+  }
+
+  return normalizeAllowedCidr(normalized);
+}
+
+export function normalizeAllowedCidr(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('Production allowed CIDR is required.');
+  }
+
+  const parts = trimmed.split('/');
+  if (parts.length !== 2) {
+    throw new Error('Production allowed CIDR must be a CIDR block, like 203.0.113.10/32.');
+  }
+
+  const [address, prefixText] = parts;
+  const version = isIP(address || '');
+  const prefix = Number(prefixText);
+
+  if (!version || !Number.isInteger(prefix)) {
+    throw new Error('Production allowed CIDR must be a valid IPv4 or IPv6 CIDR block.');
+  }
+
+  if (version === 4 && (prefix < 0 || prefix > 32)) {
+    throw new Error('IPv4 CIDR prefix must be between 0 and 32.');
+  }
+
+  if (version === 6 && (prefix < 0 || prefix > 128)) {
+    throw new Error('IPv6 CIDR prefix must be between 0 and 128.');
+  }
+
+  return `${address}/${prefix}`;
+}

--- a/src/server/services/setup-state-service.ts
+++ b/src/server/services/setup-state-service.ts
@@ -6,12 +6,14 @@ import { listJobs, type JobRecord } from './job-service';
 import { getBackupAvailability, type BackupAvailability } from './backup-availability-service';
 import { getBackupSettings, getSetting, type BackupSettings } from './settings-service';
 import { checkLocalDocker, isLocalDockerMode } from './local-docker-service';
+import { getProdAllowedCidr, saveProdAllowedCidr } from './prod-network-service';
 
 export interface ServerInput {
   role: 'prod' | 'dev';
   host: string;
   sshUser: string;
   sshKeyPath: string;
+  allowedCidr?: string;
 }
 
 export interface ControlPlaneState {
@@ -40,11 +42,12 @@ export interface ControlPlaneState {
   backup: BackupSettings;
   backupAvailability: BackupAvailability;
   prodConnectionUrl: string | null;
+  prodAllowedCidr: string | null;
 }
 
 export async function getControlPlaneState(): Promise<ControlPlaneState> {
   const db = getDb();
-  const [servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl] = await Promise.all([
+  const [servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl, prodAllowedCidr] = await Promise.all([
     db.selectFrom('servers').selectAll().orderBy('role').execute(),
     db
       .selectFrom('setupSteps')
@@ -74,9 +77,12 @@ export async function getControlPlaneState(): Promise<ControlPlaneState> {
     getBackupSettings(),
     getBackupAvailability(),
     getSetting('prod.connectionUrl'),
+    getProdAllowedCidr().catch(function ignoreMissingCidr() {
+      return null;
+    }),
   ]);
 
-  return { servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl };
+  return { servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl, prodAllowedCidr };
 }
 
 export async function saveServer(input: ServerInput): Promise<Server> {
@@ -104,6 +110,10 @@ export async function saveServer(input: ServerInput): Promise<Server> {
       });
     })
     .execute();
+
+  if (input.role === 'prod' && input.allowedCidr) {
+    await saveProdAllowedCidr(input.allowedCidr);
+  }
 
   const server = await db
     .selectFrom('servers')

--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -675,6 +675,7 @@ export interface ServerPanelProps {
     status: string;
     statusMessage: string | null;
   } | undefined;
+  allowedCidr?: string;
   busy: string | null;
   onSave: (formData: FormData) => Promise<void>;
   onCheck: (role: ServerRole) => Promise<void>;
@@ -716,6 +717,11 @@ export function ServerPanel(props: ServerPanelProps) {
               <Input name="sshKeyPath" defaultValue={props.server?.sshKeyPath || '~/.ssh/id_ed25519'} />
             </Field>
           </div>
+          {props.role === 'prod' ? (
+            <Field label="Allowed CIDR">
+              <Input name="allowedCidr" defaultValue={props.allowedCidr || ''} placeholder="203.0.113.10/32" />
+            </Field>
+          ) : null}
           <div className="flex gap-2">
             <Button type="submit" className="flex-1" disabled={isSaving}>
               {isSaving ? <Loader2 className="animate-spin" /> : <CheckCircle2 />}

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -117,6 +117,7 @@ function SettingsPage() {
         host: String(formData.get('host') || ''),
         sshUser: String(formData.get('sshUser') || ''),
         sshKeyPath: String(formData.get('sshKeyPath') || ''),
+        allowedCidr: role === 'prod' ? String(formData.get('allowedCidr') || '') : undefined,
       });
       toast.success(`${role === 'prod' ? 'Production' : 'Development'} server saved.`);
     } catch (error: any) {
@@ -209,7 +210,7 @@ function SettingsPage() {
 
               <TabsContent value="servers" className="min-w-0">
                 <div className="grid gap-6 lg:grid-cols-2">
-                  <ServerPanel title="Production" role="prod" server={prodServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
+                  <ServerPanel title="Production" role="prod" server={prodServer} allowedCidr={state.prodAllowedCidr || ''} busy={busy} onSave={handleSave} onCheck={handleCheck} />
                   <ServerPanel title="Development" role="dev" server={devServer} busy={busy} onSave={handleSave} onCheck={handleCheck} />
                 </div>
               </TabsContent>


### PR DESCRIPTION
## Summary
- default prod Postgres pg_hba access to the dev/control server IP CIDR instead of 0.0.0.0/0
- add a production allowed CIDR setting in Settings for explicit override
- remove older Velo-managed prod access pg_hba lines before adding the current one
- verify the app server can connect to prod before saving the prod connection URL

## API routes and contracts
- Updated ORPC servers.update input with optional allowedCidr for prod server saves
- Updated dashboard.retrieve response with prodAllowedCidr for Settings UI
- No routes or procedures deleted

## Checks
- bun run test
- bun run typecheck
- bun run web:build

Closes #90