### PR TITLE
fix(branches): make replacement atomic

### DIFF
--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -9,7 +9,7 @@ import { closeDb, getDb } from '../db/client';
 import { migrateDatabase } from '../db/migrate';
 import { createJob, getActiveJob, getJob, listJobs, startJobWorker, type JobHandlers } from './services/job-service';
 import { parseCreateBranchJobInput } from './services/job-handlers';
-import { createBranchFromBase, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
+import { createBranchFromBase, replaceBranchWithReadyBranch, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, saveServer } from './services/setup-state-service';
@@ -343,7 +343,198 @@ describe('control plane database', function controlPlaneDatabase() {
       ttlHours: 1,
     });
   });
+
+  test('promotes ready replacement without changing branch identity', async function testPromoteReadyReplacement() {
+    const projectId = await createProject();
+    const originalId = await createBranchRecord({
+      projectId,
+      slug: 'dev',
+      displayName: 'dev',
+      dataset: 'prod.dev',
+      port: 41001,
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+    const replacementId = await createBranchRecord({
+      projectId,
+      slug: 'dev-tmp',
+      displayName: 'dev',
+      dataset: 'prod.dev_tmp',
+      port: 41002,
+      connectionUrl: 'postgresql://postgres:new@example.com:41002/postgres',
+    });
+
+    const result = await replaceBranchWithReadyBranch({
+      targetBranchId: originalId,
+      replacementBranchId: replacementId,
+      cleanupReplacedBranch: async function cleanup(branch) {
+        return [`cleaned ${branch.dataset}`];
+      },
+    });
+    const branches = await getDb()
+      .selectFrom('branches')
+      .select(['id', 'slug', 'dataset', 'port', 'connectionUrl'])
+      .orderBy('id')
+      .execute();
+
+    expect(result).toMatchObject({
+      id: originalId,
+      slug: 'dev',
+      displayName: 'dev',
+      connectionUrl: 'postgresql://postgres:new@example.com:41002/postgres',
+      cleanupLogs: ['cleaned prod.dev'],
+    });
+    expect(branches).toEqual([{
+      id: originalId,
+      slug: 'dev',
+      dataset: 'prod.dev_tmp',
+      port: 41002,
+      connectionUrl: 'postgresql://postgres:new@example.com:41002/postgres',
+    }]);
+  });
+
+  test('keeps original branch when replacement promotion fails', async function testReplacementPromotionFailureKeepsOriginal() {
+    const projectId = await createProject();
+    const originalId = await createBranchRecord({
+      projectId,
+      slug: 'dev',
+      displayName: 'dev',
+      dataset: 'prod.dev',
+      port: 41001,
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+    const replacementId = await createBranchRecord({
+      projectId,
+      slug: 'dev-tmp',
+      displayName: 'dev',
+      dataset: 'prod.dev_tmp',
+      port: 41002,
+      connectionUrl: 'postgresql://postgres:new@example.com:41002/postgres',
+    });
+    await createBranchRecord({
+      projectId,
+      slug: 'child',
+      displayName: 'child',
+      dataset: 'prod.child',
+      parentBranchId: originalId,
+    });
+    const cleanedReplacementIds: number[] = [];
+
+    await expect(replaceBranchWithReadyBranch({
+      targetBranchId: originalId,
+      replacementBranchId: replacementId,
+      cleanupFailedReplacement: async function cleanupReplacement(branchId) {
+        cleanedReplacementIds.push(branchId);
+      },
+    })).rejects.toThrow('Branch has child branches');
+
+    const original = await getDb()
+      .selectFrom('branches')
+      .select(['id', 'slug', 'dataset', 'port', 'connectionUrl'])
+      .where('id', '=', originalId)
+      .executeTakeFirstOrThrow();
+
+    expect(original).toEqual({
+      id: originalId,
+      slug: 'dev',
+      dataset: 'prod.dev',
+      port: 41001,
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+    expect(cleanedReplacementIds).toEqual([replacementId]);
+  });
+
+  test('keeps promoted branch when old resource cleanup fails', async function testReplacementCleanupFailure() {
+    const projectId = await createProject();
+    const originalId = await createBranchRecord({
+      projectId,
+      slug: 'dev',
+      displayName: 'dev',
+      dataset: 'prod.dev',
+      port: 41001,
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+    const replacementId = await createBranchRecord({
+      projectId,
+      slug: 'dev-tmp',
+      displayName: 'dev',
+      dataset: 'prod.dev_tmp',
+      port: 41002,
+      connectionUrl: 'postgresql://postgres:new@example.com:41002/postgres',
+    });
+
+    const result = await replaceBranchWithReadyBranch({
+      targetBranchId: originalId,
+      replacementBranchId: replacementId,
+      cleanupReplacedBranch: async function cleanup() {
+        return ['replacement succeeded, but old resource cleanup failed: cleanup broke'];
+      },
+    });
+    const promoted = await getDb()
+      .selectFrom('branches')
+      .select(['id', 'slug', 'dataset'])
+      .where('id', '=', originalId)
+      .executeTakeFirstOrThrow();
+
+    expect(promoted).toEqual({
+      id: originalId,
+      slug: 'dev',
+      dataset: 'prod.dev_tmp',
+    });
+    expect(result.cleanupLogs).toEqual(['replacement succeeded, but old resource cleanup failed: cleanup broke']);
+  });
 });
+
+async function createProject(): Promise<number> {
+  await getDb()
+    .insertInto('projects')
+    .values({
+      name: 'prod',
+      postgresVersion: '17',
+      databaseName: 'postgres',
+      appUser: 'postgres',
+    })
+    .execute();
+
+  const project = await getDb()
+    .selectFrom('projects')
+    .select('id')
+    .where('name', '=', 'prod')
+    .executeTakeFirstOrThrow();
+
+  return project.id;
+}
+
+async function createBranchRecord(input: {
+  projectId: number;
+  slug: string;
+  displayName: string;
+  dataset: string;
+  parentBranchId?: number | null;
+  port?: number | null;
+  connectionUrl?: string | null;
+}): Promise<number> {
+  await getDb()
+    .insertInto('branches')
+    .values({
+      projectId: input.projectId,
+      slug: input.slug,
+      displayName: input.displayName,
+      dataset: input.dataset,
+      status: 'running',
+      parentBranchId: input.parentBranchId ?? null,
+      port: input.port ?? null,
+      connectionUrl: input.connectionUrl ?? null,
+    })
+    .execute();
+
+  const branch = await getDb()
+    .selectFrom('branches')
+    .select('id')
+    .where('slug', '=', input.slug)
+    .executeTakeFirstOrThrow();
+
+  return branch.id;
+}
 
 function createPreQueueDatabase(databasePath: string): void {
   const db = new Database(databasePath);

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -11,7 +11,7 @@ import { getDb } from '../../db/client';
 import { runCommand } from './command-service';
 import { setStepStatus } from './setup-state-service';
 import { createBranchFromPgBackRest } from './pgbackrest-restore-service';
-import { createLocalDockerBranch, deleteLocalDockerBranch, isLocalDockerMode } from './local-docker-service';
+import { createLocalDockerBranch, deleteLocalDockerBranch, deleteLocalDockerBranchResources, isLocalDockerMode } from './local-docker-service';
 import { createJob, getActiveJobs } from './job-service';
 import { getBranchConnectionHost } from './branch-network-service';
 
@@ -47,6 +47,23 @@ export interface DeleteBranchInput {
 export interface DeleteBranchResult {
   id: number;
   slug: string;
+  displayName: string;
+}
+
+export interface ReplaceBranchResult extends CreateBranchResult {
+  cleanupLogs: string[];
+}
+
+export interface ReplaceBranchWithReadyBranchInput {
+  targetBranchId: number;
+  replacementBranchId: number;
+  cleanupReplacedBranch?: (branch: ReplacedBranchResource) => Promise<string[]>;
+  cleanupFailedReplacement?: (branchId: number) => Promise<void>;
+}
+
+export interface ReplacedBranchResource {
+  slug: string;
+  dataset: string;
   displayName: string;
 }
 
@@ -258,24 +275,88 @@ async function createBranchClone(options: {
   }
 }
 
-export async function resetBranchFromParent(input: DeleteBranchInput): Promise<CreateBranchResult> {
+export async function resetBranchFromParent(input: DeleteBranchInput): Promise<ReplaceBranchResult> {
   const db = getDb();
   const branch = await db
     .selectFrom('branches')
-    .select(['id', 'slug', 'displayName', 'parentBranchId', 'connectionUrl', 'port'])
+    .select(['id', 'slug', 'displayName', 'parentBranchId', 'connectionUrl'])
     .where('id', '=', input.id)
     .executeTakeFirstOrThrow();
   const branchPassword = getPasswordFromConnectionUrl(branch.connectionUrl);
+  const replacementSlug = buildReplacementBranchSlug(branch.slug);
 
-  await deleteBranch({ id: branch.id });
-
-  return createBranchFromBase({
+  const replacement = await createBranchFromBase({
     name: branch.displayName,
-    slug: branch.slug,
+    slug: replacementSlug,
     parentBranchId: branch.parentBranchId,
     branchPassword,
-    preferredPort: branch.port,
   });
+
+  return replaceBranchWithReadyBranch({
+    targetBranchId: branch.id,
+    replacementBranchId: replacement.id,
+  });
+}
+
+export async function replaceBranchWithReadyBranch(input: ReplaceBranchWithReadyBranchInput): Promise<ReplaceBranchResult> {
+  const db = getDb();
+  const target = await db
+    .selectFrom('branches')
+    .selectAll()
+    .where('id', '=', input.targetBranchId)
+    .executeTakeFirstOrThrow();
+  const replacement = await db
+    .selectFrom('branches')
+    .selectAll()
+    .where('id', '=', input.replacementBranchId)
+    .executeTakeFirstOrThrow();
+  let promoted = false;
+
+  try {
+    await assertBranchHasNoChildren(target.id);
+
+    await db.transaction().execute(async function promoteReplacement(tx) {
+      await tx
+        .updateTable('branches')
+        .set({
+          dataset: replacement.dataset,
+          port: replacement.port,
+          status: replacement.status,
+          sourceReplayAt: replacement.sourceReplayAt,
+          connectionUrl: replacement.connectionUrl,
+          updatedAt: new Date().toISOString(),
+        })
+        .where('id', '=', target.id)
+        .execute();
+
+      await tx
+        .deleteFrom('branches')
+        .where('id', '=', replacement.id)
+        .execute();
+    });
+
+    promoted = true;
+  } catch (error) {
+    if (input.cleanupFailedReplacement) {
+      await input.cleanupFailedReplacement(replacement.id).catch(function ignoreReplacementCleanupError() {});
+    } else {
+      await deleteBranch({ id: replacement.id }).catch(function ignoreReplacementCleanupError() {});
+    }
+
+    throw error;
+  }
+
+  const cleanupLogs = promoted
+    ? await (input.cleanupReplacedBranch || cleanupReplacedBranchResources)(target)
+    : [];
+
+  return {
+    id: target.id,
+    slug: target.slug,
+    displayName: target.displayName,
+    connectionUrl: replacement.connectionUrl || target.connectionUrl || '',
+    cleanupLogs,
+  };
 }
 
 export async function updateBranchExpiry(input: UpdateBranchExpiryInput): Promise<void> {
@@ -383,15 +464,7 @@ async function ensureBranchSourceReady(sourceSlug: string): Promise<void> {
 
 export async function deleteBranch(input: DeleteBranchInput): Promise<DeleteBranchResult> {
   const db = getDb();
-  const child = await db
-    .selectFrom('branches')
-    .select(['id', 'displayName'])
-    .where('parentBranchId', '=', input.id)
-    .executeTakeFirst();
-
-  if (child) {
-    throw new Error(`Branch has child branches. Delete ${child.displayName} first.`);
-  }
+  await assertBranchHasNoChildren(input.id);
 
   if (isLocalDockerMode()) {
     return deleteLocalDockerBranch(input.id);
@@ -402,13 +475,55 @@ export async function deleteBranch(input: DeleteBranchInput): Promise<DeleteBran
     .selectAll()
     .where('id', '=', input.id)
     .executeTakeFirstOrThrow();
+  await deleteBranchResources(branch);
 
+  await db
+    .deleteFrom('branches')
+    .where('id', '=', branch.id)
+    .execute();
+
+  return {
+    id: branch.id,
+    slug: branch.slug,
+    displayName: branch.displayName,
+  };
+}
+
+async function assertBranchHasNoChildren(branchId: number): Promise<void> {
+  const child = await getDb()
+    .selectFrom('branches')
+    .select(['id', 'displayName'])
+    .where('parentBranchId', '=', branchId)
+    .executeTakeFirst();
+
+  if (child) {
+    throw new Error(`Branch has child branches. Delete ${child.displayName} first.`);
+  }
+}
+
+async function cleanupReplacedBranchResources(branch: ReplacedBranchResource): Promise<string[]> {
+  try {
+    if (isLocalDockerMode()) {
+      await deleteLocalDockerBranchResources(branch.dataset);
+    } else {
+      await deleteBranchResources(branch);
+    }
+
+    return [`cleaned up old branch resources for ${branch.displayName}`];
+  } catch (error: any) {
+    return [`replacement succeeded, but old resource cleanup failed: ${error.message || String(error)}`];
+  }
+}
+
+async function deleteBranchResources(branch: {
+  slug: string;
+  dataset: string;
+}): Promise<void> {
   const pool = await getZFSPool();
   const zfs = new ZFSManager(pool, DEFAULTS.zfs.datasetBase);
   const docker = new DockerManager();
   const wal = new WALManager();
-  const containerName = getContainerName(PROJECT_NAME, branch.slug);
-  const containerId = await docker.getContainerByName(containerName);
+  const containerId = await getBranchContainerId(docker, branch);
   const originSnapshot = await getOriginSnapshot(zfs, branch.dataset);
 
   if (containerId) {
@@ -433,17 +548,23 @@ export async function deleteBranch(input: DeleteBranchInput): Promise<DeleteBran
   }
 
   await wal.deleteArchiveDir(branch.dataset);
+}
 
-  await db
-    .deleteFrom('branches')
-    .where('id', '=', branch.id)
-    .execute();
+async function getBranchContainerId(docker: DockerManager, branch: {
+  slug: string;
+  dataset: string;
+}): Promise<string | null> {
+  const slugContainer = await docker.getContainerByName(getContainerName(PROJECT_NAME, branch.slug));
 
-  return {
-    id: branch.id,
-    slug: branch.slug,
-    displayName: branch.displayName,
-  };
+  if (slugContainer) {
+    return slugContainer;
+  }
+
+  if (branch.dataset.startsWith(`${PROJECT_NAME}.`)) {
+    return docker.getContainerByName(getContainerName(PROJECT_NAME, branch.dataset.slice(PROJECT_NAME.length + 1)));
+  }
+
+  return null;
 }
 
 async function setBranchPassword(docker: DockerManager, containerId: string, password: string): Promise<void> {
@@ -597,6 +718,12 @@ function normalizeSourceBranch(name: string): string {
 function buildPreviewBranchName(sourceBranch: string): string {
   const safeSource = sourceBranch.replace(/[^a-z0-9_-]/g, '-').slice(0, 28);
   return normalizeBranchSlug(`preview-${safeSource}-${formatTimestamp(new Date())}`.slice(0, 63));
+}
+
+function buildReplacementBranchSlug(slug: string): string {
+  const suffix = formatTimestamp(new Date()).toLowerCase();
+  const prefix = slug.slice(0, Math.max(1, 63 - suffix.length - 5));
+  return normalizeBranchSlug(`${prefix}-tmp-${suffix}`);
 }
 
 function parseRestoreTime(value: string): Date {

--- a/src/server/services/job-handlers.ts
+++ b/src/server/services/job-handlers.ts
@@ -1,11 +1,10 @@
 import { z } from 'zod';
 import { getDb } from '#db/client';
-import { createBranchFromBase, deleteBranch, normalizeBranchSlug, resetBranchFromParent } from '#server/services/branch-service';
+import { createBranchFromBase, deleteBranch, normalizeBranchSlug, replaceBranchWithReadyBranch, resetBranchFromParent } from '#server/services/branch-service';
 import { restoreDevelopmentBranchFromPgBackRest, restoreProductionFromPgBackRest } from '#server/services/pgbackrest-restore-service';
 import { runDevBootstrap, runProdBootstrap, type BootstrapResult } from '#server/services/bootstrap-service';
 import { createReplicaBase, type ReplicaResult } from '#server/services/replica-service';
 import { checkServer } from '#server/services/setup-state-service';
-import { isLocalDockerMode } from '#server/services/local-docker-service';
 import type { JobContext, JobHandlers } from './job-service';
 
 const branchInput = z.object({
@@ -74,24 +73,55 @@ export const jobHandlers: JobHandlers = {
 
     const existing = await findBranchBySlug(normalizeBranchLookup(parsed.targetBranch));
     const branchPassword = getPasswordFromConnectionUrl(existing?.connectionUrl || null);
-    const preferredPort = getPreferredReplacementPort(existing);
 
     if (existing) {
       await context.log(`replacing existing branch ${parsed.targetBranch}`);
-      await deleteBranch({ id: existing.id });
+      let result: Awaited<ReturnType<typeof replaceBranchWithReadyBranch>>;
+
+      try {
+        const replacement = await restoreDevelopmentBranchFromPgBackRest({
+          ...parsed,
+          targetBranch: buildReplacementBranchSlug(parsed.targetBranch),
+          branchPassword,
+        });
+        result = await replaceBranchWithReadyBranch({
+          targetBranchId: existing.id,
+          replacementBranchId: replacement.id,
+        });
+      } catch (error) {
+        await context.log(`restore failed; kept existing branch ${parsed.targetBranch}`);
+        throw error;
+      }
+
+      for (const message of result.cleanupLogs) {
+        await context.log(message);
+      }
+
+      await context.log(`branch restored: ${result.displayName}`);
+      return;
     }
 
     const result = await restoreDevelopmentBranchFromPgBackRest({
       ...parsed,
       branchPassword,
-      preferredPort,
     });
     await context.log(`branch restored: ${result.displayName}`);
   },
   'reset-branch': async function resetBranchJob(input, context) {
     const parsed = branchIdInput.parse(input);
     await context.log(`resetting branch ${parsed.id} from parent`);
-    const result = await resetBranchFromParent(parsed);
+    let result: Awaited<ReturnType<typeof resetBranchFromParent>>;
+
+    try {
+      result = await resetBranchFromParent(parsed);
+    } catch (error) {
+      await context.log(`reset failed; kept existing branch ${parsed.id}`);
+      throw error;
+    }
+
+    for (const message of result.cleanupLogs) {
+      await context.log(message);
+    }
     await context.log(`reset branch ${result.displayName}`);
   },
   'dev-bootstrap': async function devBootstrapJob(_input, context) {
@@ -165,30 +195,23 @@ async function branchExists(id: number): Promise<boolean> {
 async function findBranchBySlug(slug: string): Promise<{
   id: number;
   connectionUrl: string | null;
-  dataset: string;
-  port: number | null;
 } | undefined> {
   return getDb()
     .selectFrom('branches')
-    .select(['id', 'connectionUrl', 'dataset', 'port'])
+    .select(['id', 'connectionUrl'])
     .where('slug', '=', slug)
     .executeTakeFirst();
 }
 
-function getPreferredReplacementPort(branch: Awaited<ReturnType<typeof findBranchBySlug>>): number | null {
-  if (!branch?.port) {
-    return null;
-  }
-
-  if (isLocalDockerMode() && !branch.dataset.startsWith('container:')) {
-    return null;
-  }
-
-  return branch.port;
-}
-
 function normalizeBranchLookup(name: string): string {
   return normalizeBranchSlug(name.trim().toLowerCase());
+}
+
+function buildReplacementBranchSlug(slug: string): string {
+  const normalized = normalizeBranchLookup(slug);
+  const suffix = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 23).toLowerCase();
+  const prefix = normalized.slice(0, Math.max(1, 63 - suffix.length - 5));
+  return normalizeBranchSlug(`${prefix}-tmp-${suffix}`);
 }
 
 function assertOk(result: BootstrapResult | ReplicaResult): void {

--- a/src/server/services/local-docker-service.ts
+++ b/src/server/services/local-docker-service.ts
@@ -208,6 +208,15 @@ export async function deleteLocalDockerBranch(id: number) {
   };
 }
 
+export async function deleteLocalDockerBranchResources(dataset: string): Promise<void> {
+  if (dataset.startsWith('container:')) {
+    await deleteRestoreContainer(dataset);
+    return;
+  }
+
+  await dropDevDatabase(dataset);
+}
+
 export async function createLocalDockerPitrBranch(input: LocalDockerRestoreInput): Promise<LocalDockerBranchResult> {
   const branchSlug = normalizeBranchSlug(input.targetBranch);
   const restoreTime = parseRestoreTime(input.restoreTime);


### PR DESCRIPTION
## Summary
- build reset and restore replacements as temporary ready branches before swapping metadata
- keep the original branch intact when replacement creation or promotion fails
- log rollback and cleanup outcomes for replacement jobs
- add focused tests for replacement promotion, rollback, and cleanup-warning behavior

## API routes, procedures, contracts
- Updated `branches.restore` job behavior for existing dev branches: replacement now promotes only after restore health checks pass
- Updated `branches.reset` job behavior: reset now promotes a ready temp branch instead of deleting first
- Added an internal branch replacement helper contract for atomic metadata promotion and testable cleanup handling
- No API routes or input contracts added or removed

Fixes #91

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`
- `bash -n scripts/*.sh`