### PR TITLE
feat(replica): show base freshness

### DIFF
--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -14,6 +14,7 @@ import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, saveServer } from './services/setup-state-service';
 import { defaultCidrForHost, getProdAllowedCidr, normalizeAllowedCidr } from './services/prod-network-service';
+import { buildReplicaFreshness } from './services/replica-service';
 
 let testDir: string;
 
@@ -147,6 +148,20 @@ describe('control plane database', function controlPlaneDatabase() {
     });
     expect(JSON.stringify(state)).not.toContain('super-secret');
     expect(state.prodConnectionUrl).toBe('postgresql://postgres:secret@example.com:5432/postgres');
+    expect(state.replicaFreshness).toBe(null);
+  });
+
+  test('computes replica freshness lag and bytes', function testReplicaFreshness() {
+    const freshness = buildReplicaFreshness(
+      '0/3000000',
+      '0/2000000',
+      '2026-05-16T10:00:00.000Z',
+      new Date('2026-05-16T10:00:03.000Z')
+    );
+
+    expect(freshness.lagMs).toBe(3000);
+    expect(freshness.byteLag).toBe(16777216);
+    expect(freshness.stale).toBe(false);
   });
 
   test('defaults prod allowed cidr to dev server ip', async function testProdAllowedCidrDefault() {

--- a/src/server/services/replica-service.ts
+++ b/src/server/services/replica-service.ts
@@ -16,10 +16,20 @@ import { createLocalDockerReplicaBase, isLocalDockerMode } from './local-docker-
 const PROJECT_NAME = 'prod';
 const BASE_BRANCH_NAME = 'base';
 const REPLICATION_USER = 'velo_replica';
+const STALE_REPLICA_MS = 30_000;
 
 export interface ReplicaResult {
   ok: boolean;
   message: string;
+}
+
+export interface ReplicaFreshness {
+  prodCurrentLsn: string;
+  devReplayLsn: string | null;
+  replayedAt: string | null;
+  lagMs: number | null;
+  byteLag: number | null;
+  stale: boolean;
 }
 
 export async function createReplicaBase(): Promise<ReplicaResult> {
@@ -128,6 +138,29 @@ export async function createReplicaBase(): Promise<ReplicaResult> {
   };
 }
 
+export async function getReplicaFreshness(): Promise<ReplicaFreshness | null> {
+  const replicaStep = await getDb()
+    .selectFrom('setupSteps')
+    .select(['status'])
+    .where('key', '=', 'replica')
+    .executeTakeFirst();
+
+  if (replicaStep?.status !== 'done') {
+    return null;
+  }
+
+  if (isLocalDockerMode()) {
+    return getLocalDockerReplicaFreshness();
+  }
+
+  const [prodCurrentLsn, replicaState] = await Promise.all([
+    getProductionCurrentLsn(),
+    getDevBaseReplayState(),
+  ]);
+
+  return buildReplicaFreshness(prodCurrentLsn, replicaState.devReplayLsn, replicaState.replayedAt);
+}
+
 async function configureProdReplication(options: {
   host: string;
   user: string;
@@ -164,6 +197,143 @@ async function configureProdReplication(options: {
     await setStepStatus('replica', 'error', result.stderr || result.stdout || 'prod replication setup failed');
     throw new Error(result.stderr || result.stdout || 'prod replication setup failed');
   }
+}
+
+async function getProductionCurrentLsn(): Promise<string> {
+  const prod = await getDb()
+    .selectFrom('servers')
+    .selectAll()
+    .where('role', '=', 'prod')
+    .executeTakeFirstOrThrow();
+
+  const result = await runSshCommand(
+    {
+      host: prod.host,
+      user: prod.sshUser,
+      keyPath: prod.sshKeyPath,
+    },
+    'sudo -u postgres psql -tAc "select pg_current_wal_lsn()"'
+  );
+
+  if (result.exitCode !== 0 || !result.stdout) {
+    throw new Error(result.stderr || result.stdout || 'could not read production WAL LSN');
+  }
+
+  return result.stdout.trim();
+}
+
+async function getDevBaseReplayState(): Promise<{ devReplayLsn: string | null; replayedAt: string | null }> {
+  const docker = new DockerManager();
+  const containerName = getContainerName(PROJECT_NAME, BASE_BRANCH_NAME);
+  const containerId = await docker.getContainerByName(containerName);
+
+  if (!containerId) {
+    throw new Error(`Replica base container not found: ${containerName}`);
+  }
+
+  const output = await docker.execSQL(
+    containerId,
+    "select pg_last_wal_replay_lsn(), pg_last_xact_replay_timestamp()"
+  );
+
+  return parseReplayState(output);
+}
+
+async function getLocalDockerReplicaFreshness(): Promise<ReplicaFreshness> {
+  const [prodResult, devResult] = await Promise.all([
+    runLocalPsql('prod-postgres', 'postgres', 'select pg_current_wal_lsn()'),
+    runLocalPsql('dev-postgres', 'postgres', "select pg_current_wal_lsn(), now() - interval '1 millisecond'"),
+  ]);
+  const replayState = parseReplayState(devResult);
+
+  return buildReplicaFreshness(prodResult.trim(), replayState.devReplayLsn, replayState.replayedAt);
+}
+
+async function runLocalPsql(service: string, database: string, query: string): Promise<string> {
+  const result = await runCommand([
+    'sh',
+    '-lc',
+    `docker compose -f ${shellQuote(process.env.VELO_LOCAL_COMPOSE_FILE || 'docker-compose.local.yml')} exec -T ${shellQuote(service)} psql -U postgres -d ${shellQuote(database)} -tA -c ${shellQuote(query)}`,
+  ]);
+
+  if (result.exitCode !== 0 || !result.stdout) {
+    throw new Error(result.stderr || result.stdout || `could not query ${service}`);
+  }
+
+  return result.stdout.trim();
+}
+
+export function buildReplicaFreshness(
+  prodCurrentLsn: string,
+  devReplayLsn: string | null,
+  replayedAt: string | null,
+  now = new Date()
+): ReplicaFreshness {
+  const lagMs = getReplayLagMs(replayedAt, now);
+
+  return {
+    prodCurrentLsn,
+    devReplayLsn,
+    replayedAt,
+    lagMs,
+    byteLag: getWalByteLag(prodCurrentLsn, devReplayLsn),
+    stale: lagMs === null ? false : lagMs > STALE_REPLICA_MS,
+  };
+}
+
+function parseReplayState(output: string): { devReplayLsn: string | null; replayedAt: string | null } {
+  const [devReplayLsn, replayedAt] = output.trim().split('|');
+
+  return {
+    devReplayLsn: devReplayLsn || null,
+    replayedAt: replayedAt || null,
+  };
+}
+
+function getReplayLagMs(replayedAt: string | null, now: Date): number | null {
+  if (!replayedAt) {
+    return null;
+  }
+
+  const replayedTime = new Date(replayedAt).getTime();
+
+  if (Number.isNaN(replayedTime)) {
+    return null;
+  }
+
+  return Math.max(0, now.getTime() - replayedTime);
+}
+
+function getWalByteLag(prodCurrentLsn: string, devReplayLsn: string | null): number | null {
+  if (!devReplayLsn) {
+    return null;
+  }
+
+  const prod = parseWalLsn(prodCurrentLsn);
+  const dev = parseWalLsn(devReplayLsn);
+
+  if (prod === null || dev === null) {
+    return null;
+  }
+
+  return Math.max(0, prod - dev);
+}
+
+function parseWalLsn(value: string): number | null {
+  const parts = value.split('/');
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const high = Number.parseInt(parts[0] || '', 16);
+  const low = Number.parseInt(parts[1] || '', 16);
+
+  if (!Number.isFinite(high) || !Number.isFinite(low)) {
+    return null;
+  }
+
+  return high * 0x100000000 + low;
 }
 
 async function runBaseBackup(options: {

--- a/src/server/services/setup-state-service.ts
+++ b/src/server/services/setup-state-service.ts
@@ -7,6 +7,7 @@ import { getBackupAvailability, type BackupAvailability } from './backup-availab
 import { getBackupSettings, getSetting, type BackupSettings } from './settings-service';
 import { checkLocalDocker, isLocalDockerMode } from './local-docker-service';
 import { getProdAllowedCidr, saveProdAllowedCidr } from './prod-network-service';
+import { getReplicaFreshness, type ReplicaFreshness } from './replica-service';
 
 export interface ServerInput {
   role: 'prod' | 'dev';
@@ -41,13 +42,14 @@ export interface ControlPlaneState {
   jobs: JobRecord[];
   backup: BackupSettings;
   backupAvailability: BackupAvailability;
+  replicaFreshness: ReplicaFreshness | null;
   prodConnectionUrl: string | null;
   prodAllowedCidr: string | null;
 }
 
 export async function getControlPlaneState(): Promise<ControlPlaneState> {
   const db = getDb();
-  const [servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl, prodAllowedCidr] = await Promise.all([
+  const [servers, setupSteps, branches, jobs, backup, backupAvailability, replicaFreshness, prodConnectionUrl, prodAllowedCidr] = await Promise.all([
     db.selectFrom('servers').selectAll().orderBy('role').execute(),
     db
       .selectFrom('setupSteps')
@@ -76,13 +78,16 @@ export async function getControlPlaneState(): Promise<ControlPlaneState> {
     listJobs(10),
     getBackupSettings(),
     getBackupAvailability(),
+    getReplicaFreshness().catch(function ignoreReplicaFreshnessError() {
+      return null;
+    }),
     getSetting('prod.connectionUrl'),
     getProdAllowedCidr().catch(function ignoreMissingCidr() {
       return null;
     }),
   ]);
 
-  return { servers, setupSteps, branches, jobs, backup, backupAvailability, prodConnectionUrl, prodAllowedCidr };
+  return { servers, setupSteps, branches, jobs, backup, backupAvailability, replicaFreshness, prodConnectionUrl, prodAllowedCidr };
 }
 
 export async function saveServer(input: ServerInput): Promise<Server> {

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -73,6 +73,7 @@ function HomePage() {
     setBranchName('');
     setParentBranchId('production');
     setTtlHours('none');
+    void dashboard.refetch();
     setCreateModalOpen(true);
   }
 
@@ -159,6 +160,11 @@ function HomePage() {
                   })}
                 </SelectContent>
               </Select>
+              {parentBranchId === 'production' && shouldShowReplicaFreshnessWarning(state.replicaFreshness) ? (
+                <p className="text-sm text-amber-700">
+                  {formatReplicaFreshnessWarning(state.replicaFreshness)}
+                </p>
+              ) : null}
             </div>
 
             <div className="mt-4 grid gap-2">
@@ -221,4 +227,30 @@ function LoadingPage(props: Readonly<{ message: string }>) {
       </div>
     </main>
   );
+}
+
+function shouldShowReplicaFreshnessWarning(freshness: Readonly<{ lagMs: number | null }> | null | undefined): freshness is Readonly<{ lagMs: number }> {
+  return Boolean(freshness?.lagMs && freshness.lagMs > 60_000);
+}
+
+function formatReplicaFreshnessWarning(freshness: Readonly<{ lagMs: number }>): string {
+  return `Warning: new branch will be from production state about ${formatDuration(freshness.lagMs)} ago.`;
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round(minutes / 60);
+
+  return `${hours}h`;
 }


### PR DESCRIPTION
## Summary
- add best-effort replica freshness to dashboard state
- show production base freshness in the create branch modal
- add coverage for replica freshness lag and WAL byte math

## API routes / procedures / contracts
- Updated `dashboard.retrieve` response with `replicaFreshness`.
- No API routes or procedures added/deleted.

## Validation
- `bun run typecheck`
- `bun run test`
- `bun run web:build`

Closes #96
