### PR TITLE
fix(restore): invalidate stale replica base

### DIFF
--- a/scripts/e2e/hetzner-suite.ts
+++ b/scripts/e2e/hetzner-suite.ts
@@ -73,7 +73,9 @@ async function testReplicaBase(): Promise<void> {
 
   const state = await api.dashboard.retrieve();
   assert(hasDoneStep(state.setupSteps, 'replica'), 'replica step should be done');
-  await assertZfsDatasetExists(getDatasetName(PROJECT_NAME, 'base'));
+  const baseDataset = await getSetting('replica.baseDataset');
+  assert(baseDataset, 'replica base dataset setting should be set');
+  await assertZfsDatasetExists(baseDataset);
 }
 
 async function testBranchLifecycle(): Promise<void> {
@@ -224,6 +226,8 @@ async function testBranchPitr(): Promise<void> {
 async function testProductionPitrRestore(): Promise<void> {
   const table = `e2e_prod_pitr_${RUN_ID}`;
   const targetTime = await preparePitrFixture(table);
+  const blockedBranchName = `e2e_stale_block_${RUN_ID}`;
+  const rebuiltBranchName = `e2e_after_rebuild_${RUN_ID}`;
 
   const job = await api.branches.restore({
     targetBranch: 'production',
@@ -237,6 +241,19 @@ async function testProductionPitrRestore(): Promise<void> {
   assert(rows.rows.map(function getLabel(row) {
     return row.label;
   }).join(',') === 'before', `production restore should keep before row only: ${JSON.stringify(rows.rows)}`);
+
+  const staleState = await api.dashboard.retrieve();
+  assert(hasStepStatus(staleState.setupSteps, 'replica', 'stale'), 'production restore should mark replica base stale');
+
+  await assertBranchCreateFails(blockedBranchName, 'Production was restored. Rebuild the dev replica before creating a branch');
+
+  const rebuild = await createReplicaBase();
+  assert(rebuild.ok, rebuild.message);
+
+  const rebuiltState = await api.dashboard.retrieve();
+  assert(hasDoneStep(rebuiltState.setupSteps, 'replica'), 'replica step should be done after rebuild');
+
+  await createBranch(rebuiltBranchName);
 }
 
 async function preparePitrFixture(table: string): Promise<string> {
@@ -460,9 +477,26 @@ function assertSingleValue(result: QueryResult, column: string, expected: string
 }
 
 function hasDoneStep(steps: Array<{ key: string; status: string }>, key: string): boolean {
+  return hasStepStatus(steps, key, 'done');
+}
+
+function hasStepStatus(steps: Array<{ key: string; status: string }>, key: string, status: string): boolean {
   return steps.some(function hasMatchingStep(step) {
-    return step.key === key && step.status === 'done';
+    return step.key === key && step.status === status;
   });
+}
+
+async function assertBranchCreateFails(name: string, expectedMessage: string): Promise<void> {
+  const job = await api.branches.create({ name });
+
+  try {
+    await waitForJob(job.id, JOB_TIMEOUT_MS);
+  } catch (error: any) {
+    assert(String(error?.message || error).includes(expectedMessage), `expected branch create to fail with ${expectedMessage}`);
+    return;
+  }
+
+  throw new Error(`expected branch create to fail: ${name}`);
 }
 
 function assert(value: unknown, message: string): asserts value {

--- a/src/db/migrations/001_initial.sql
+++ b/src/db/migrations/001_initial.sql
@@ -28,7 +28,7 @@ create table if not exists setup_steps (
   id integer primary key autoincrement,
   key text not null unique,
   label text not null,
-  status text not null default 'pending' check (status in ('pending', 'running', 'done', 'error')),
+  status text not null default 'pending' check (status in ('pending', 'running', 'done', 'error', 'stale')),
   message text,
   updated_at text not null default (datetime('now'))
 );

--- a/src/db/migrations/007_setup_step_stale_status.sql
+++ b/src/db/migrations/007_setup_step_stale_status.sql
@@ -1,0 +1,16 @@
+alter table setup_steps rename to setup_steps_old;
+
+create table setup_steps (
+  id integer primary key autoincrement,
+  key text not null unique,
+  label text not null,
+  status text not null default 'pending' check (status in ('pending', 'running', 'done', 'error', 'stale')),
+  message text,
+  updated_at text not null default (datetime('now'))
+);
+
+insert into setup_steps (id, key, label, status, message, updated_at)
+select id, key, label, status, message, updated_at
+from setup_steps_old;
+
+drop table setup_steps_old;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,7 +26,7 @@ export interface SetupStepsTable {
   id: Generated<number>;
   key: string;
   label: string;
-  status: 'pending' | 'running' | 'done' | 'error';
+  status: 'pending' | 'running' | 'done' | 'error' | 'stale';
   message: string | null;
   updatedAt: Timestamp;
 }

--- a/src/managers/zfs.ts
+++ b/src/managers/zfs.ts
@@ -100,6 +100,10 @@ export class ZFSManager {
     }
   }
 
+  async destroyDatasetWithSnapshots(name: string): Promise<void> {
+    await $`zfs destroy -r ${this.getFullPath(name)}`;
+  }
+
   async datasetExists(name: string): Promise<boolean> {
     try {
       const fullName = this.getFullPath(name);

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -12,7 +12,7 @@ import { parseCreateBranchJobInput } from './services/job-handlers';
 import { createBranchFromBase, replaceBranchWithReadyBranch, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
-import { getControlPlaneState, saveServer } from './services/setup-state-service';
+import { getControlPlaneState, invalidateDevReplicaBase, saveServer } from './services/setup-state-service';
 import { defaultCidrForHost, getProdAllowedCidr, normalizeAllowedCidr } from './services/prod-network-service';
 import { buildReplicaFreshness } from './services/replica-service';
 
@@ -250,6 +250,24 @@ describe('control plane database', function controlPlaneDatabase() {
       .executeTakeFirst();
 
     expect(firstBranchStep).toBeUndefined();
+  });
+
+  test('blocks prod branch create when replica base is stale', async function testStaleReplicaBlocksBranch() {
+    const message = 'Production was restored. Rebuild the dev replica before creating a branch';
+    await invalidateDevReplicaBase(message);
+
+    await expect(createBranchFromBase({ name: 'dev' })).rejects.toThrow(message);
+
+    const replicaStep = await getDb()
+      .selectFrom('setupSteps')
+      .select(['status', 'message'])
+      .where('key', '=', 'replica')
+      .executeTakeFirstOrThrow();
+
+    expect(replicaStep).toEqual({
+      status: 'stale',
+      message,
+    });
   });
 
   test('rejects duplicate branch create requests before enqueue', async function testDuplicateBranchCreate() {

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -11,12 +11,12 @@ import { getDb } from '../../db/client';
 import { runCommand } from './command-service';
 import { setStepStatus } from './setup-state-service';
 import { createBranchFromPgBackRest } from './pgbackrest-restore-service';
+import { cleanupOldReplicaBases, getReplicaBaseDataset } from './replica-service';
 import { createLocalDockerBranch, deleteLocalDockerBranch, deleteLocalDockerBranchResources, isLocalDockerMode } from './local-docker-service';
 import { createJob, getActiveJobs } from './job-service';
 import { getBranchConnectionHost } from './branch-network-service';
 
 const PROJECT_NAME = 'prod';
-const BASE_BRANCH_NAME = 'base';
 
 export interface CreateBranchInput {
   name: string;
@@ -425,7 +425,7 @@ async function resolveBranchSource(parentBranchId: number | null | undefined): P
     return {
       id: null,
       slug: 'production',
-      dataset: getDatasetName(PROJECT_NAME, BASE_BRANCH_NAME),
+      dataset: await getReplicaBaseDataset(),
     };
   }
 
@@ -453,9 +453,13 @@ async function ensureBranchSourceReady(sourceSlug: string): Promise<void> {
 
   const replicaStep = await getDb()
     .selectFrom('setupSteps')
-    .select(['status'])
+    .select(['status', 'message'])
     .where('key', '=', 'replica')
     .executeTakeFirst();
+
+  if (replicaStep?.status === 'stale') {
+    throw new Error(replicaStep.message || 'Production was restored. Rebuild the dev replica before creating a branch');
+  }
 
   if (replicaStep?.status !== 'done') {
     throw new Error('Create the dev replica before creating a branch');
@@ -548,6 +552,7 @@ async function deleteBranchResources(branch: {
   }
 
   await wal.deleteArchiveDir(branch.dataset);
+  await cleanupOldReplicaBases();
 }
 
 async function getBranchContainerId(docker: DockerManager, branch: {

--- a/src/server/services/local-docker-service.ts
+++ b/src/server/services/local-docker-service.ts
@@ -3,6 +3,7 @@ import { getDb } from '../../db/client';
 import { generatePassword } from '../../utils/helpers';
 import { runCommand } from './command-service';
 import { saveBackupSettings, setSetting } from './settings-service';
+import type { SetupStepStatus } from './setup-state-service';
 
 const COMPOSE_FILE = process.env.VELO_LOCAL_COMPOSE_FILE || 'docker-compose.local.yml';
 const LOCAL_PGBACKREST_IMAGE = 'velo-local-postgres-pgbackrest:17';
@@ -343,7 +344,7 @@ async function saveLocalServer(input: {
 
 async function setLocalStepStatus(
   key: string,
-  status: 'pending' | 'running' | 'done' | 'error',
+  status: SetupStepStatus,
   message: string | null
 ): Promise<void> {
   await getDb()

--- a/src/server/services/pgbackrest-restore-service.ts
+++ b/src/server/services/pgbackrest-restore-service.ts
@@ -15,6 +15,7 @@ import { getBackupAvailability } from './backup-availability-service';
 import { buildPgBackRestConfig } from './bootstrap-service';
 import { runCommand, runSshCommand } from './command-service';
 import { getBackupSettings, setSetting } from './settings-service';
+import { invalidateDevReplicaBase } from './setup-state-service';
 import { createLocalDockerPitrBranch, isLocalDockerMode, restoreLocalDockerProduction } from './local-docker-service';
 import { getBranchConnectionHost } from './branch-network-service';
 
@@ -252,6 +253,7 @@ export async function restoreProductionFromPgBackRest(input: RestoreBranchInput)
   }
 
   await setSetting('prod.lastRestoreAt', restoreTime.toISOString());
+  await invalidateDevReplicaBase('Production was restored. Rebuild the dev replica before creating a branch');
 }
 
 async function restorePgBackRestLocally(pgdata: string, restoreTime: Date): Promise<void> {

--- a/src/server/services/replica-service.ts
+++ b/src/server/services/replica-service.ts
@@ -4,7 +4,7 @@ import { WALManager } from '../../managers/wal';
 import { CertManager } from '../../managers/cert';
 import { formatPostgresOwner, resolvePostgresOwner, type PostgresOwner } from '../../managers/postgres-owner';
 import { DEFAULTS } from '../../config/defaults';
-import { generatePassword } from '../../utils/helpers';
+import { formatTimestamp, generatePassword } from '../../utils/helpers';
 import { getZFSPool } from '../../utils/zfs-pool';
 import { getContainerName, getDatasetName } from '../../utils/naming';
 import { getDb } from '../../db/client';
@@ -15,6 +15,7 @@ import { createLocalDockerReplicaBase, isLocalDockerMode } from './local-docker-
 
 const PROJECT_NAME = 'prod';
 const BASE_BRANCH_NAME = 'base';
+const BASE_DATASET_PREFIX = `${PROJECT_NAME}.${BASE_BRANCH_NAME}-`;
 const REPLICATION_USER = 'velo_replica';
 const STALE_REPLICA_MS = 30_000;
 
@@ -36,6 +37,13 @@ export async function createReplicaBase(): Promise<ReplicaResult> {
   if (isLocalDockerMode()) {
     return createLocalDockerReplicaBase();
   }
+
+  const setupStep = await getDb()
+    .selectFrom('setupSteps')
+    .select(['status'])
+    .where('key', '=', 'replica')
+    .executeTakeFirst();
+  const shouldRebuildBase = setupStep?.status === 'stale';
 
   await setStepStatus('replica', 'running', 'creating base replica');
 
@@ -71,71 +79,137 @@ export async function createReplicaBase(): Promise<ReplicaResult> {
   const docker = new DockerManager();
   const wal = new WALManager();
   const cert = new CertManager();
-  const baseDataset = getDatasetName(PROJECT_NAME, BASE_BRANCH_NAME);
-
-  if (!(await zfs.datasetExists(baseDataset))) {
-    await zfs.createDataset(baseDataset, {
-      compression: DEFAULTS.zfs.compression,
-      recordsize: DEFAULTS.zfs.recordsize,
-      atime: DEFAULTS.zfs.atime,
-    });
-    await zfs.mountDataset(baseDataset);
-    const mountpoint = await zfs.getMountpoint(baseDataset);
-    await runBaseBackup({
-      prodHost: prod.host,
-      replicationPassword,
-      targetDir: `${mountpoint}/pgdata`,
-    });
-  } else {
-    await zfs.mountDataset(baseDataset);
-  }
-
-  const mountpoint = await zfs.getMountpoint(baseDataset);
-  const pgdata = `${mountpoint}/pgdata`;
-  const pgVersion = await readPgVersion(pgdata);
-  const image = `postgres:${pgVersion}-alpine`;
   const containerName = getContainerName(PROJECT_NAME, BASE_BRANCH_NAME);
+  const currentBaseDataset = await getReplicaBaseDataset();
+  const currentBaseExists = await zfs.datasetExists(currentBaseDataset);
+  const shouldCreateNewBase = shouldRebuildBase || !currentBaseExists;
+  const baseDataset = shouldCreateNewBase ? buildReplicaBaseDatasetName(new Date()) : currentBaseDataset;
+  let createdDataset = false;
+  let containerId: string | null = null;
 
   const existingContainerId = await docker.getContainerByName(containerName);
   if (existingContainerId) {
     await docker.removeContainer(existingContainerId);
   }
 
-  if (!(await docker.imageExists(image))) {
-    await docker.pullImage(image);
+  try {
+    if (shouldCreateNewBase) {
+      await zfs.createDataset(baseDataset, {
+        compression: DEFAULTS.zfs.compression,
+        recordsize: DEFAULTS.zfs.recordsize,
+        atime: DEFAULTS.zfs.atime,
+      });
+      createdDataset = true;
+      await zfs.mountDataset(baseDataset);
+      const targetMountpoint = await zfs.getMountpoint(baseDataset);
+      await runBaseBackup({
+        prodHost: prod.host,
+        replicationPassword,
+        targetDir: `${targetMountpoint}/pgdata`,
+      });
+    } else {
+      await zfs.mountDataset(baseDataset);
+    }
+
+    const mountpoint = await zfs.getMountpoint(baseDataset);
+    const pgdata = `${mountpoint}/pgdata`;
+    const pgVersion = await readPgVersion(pgdata);
+    const image = `postgres:${pgVersion}-alpine`;
+
+    if (!(await docker.imageExists(image))) {
+      await docker.pullImage(image);
+    }
+
+    const postgresOwner = await resolvePostgresOwner(image);
+    await setPostgresDataOwner(pgdata, postgresOwner);
+    await ensurePortablePostgresConfig(pgdata, postgresOwner);
+
+    const certPaths = await cert.generateCerts(PROJECT_NAME, postgresOwner);
+    await wal.ensureArchiveDir(baseDataset, postgresOwner);
+
+    containerId = await docker.createContainer({
+      name: containerName,
+      image,
+      port: 0,
+      dataPath: mountpoint,
+      walArchivePath: wal.getArchivePath(baseDataset),
+      sslCertDir: certPaths.certDir,
+      password: generatePassword(),
+      username: 'postgres',
+      database: 'postgres',
+      publicAccess: false,
+    });
+
+    await docker.startContainer(containerId);
+    await docker.waitForHealthy(containerId);
+
+    await setSetting('replica.baseDataset', baseDataset);
+    await setSetting('replica.postgresImage', image);
+    await setStepStatus('replica', 'done', `base replica ready on ${baseDataset}`);
+    await cleanupOldReplicaBases(baseDataset);
+  } catch (error) {
+    if (containerId) {
+      await docker.removeContainer(containerId).catch(function ignoreContainerCleanupError() {});
+    }
+
+    if (createdDataset) {
+      await zfs.unmountDataset(baseDataset).catch(function ignoreUnmountCleanupError() {});
+      await zfs.destroyDataset(baseDataset, true).catch(function ignoreDatasetCleanupError() {});
+      await wal.deleteArchiveDir(baseDataset).catch(function ignoreWalCleanupError() {});
+    }
+
+    throw error;
   }
-
-  const postgresOwner = await resolvePostgresOwner(image);
-  await setPostgresDataOwner(pgdata, postgresOwner);
-  await ensurePortablePostgresConfig(pgdata, postgresOwner);
-
-  const certPaths = await cert.generateCerts(PROJECT_NAME, postgresOwner);
-  await wal.ensureArchiveDir(baseDataset, postgresOwner);
-
-  const containerId = await docker.createContainer({
-    name: containerName,
-    image,
-    port: 0,
-    dataPath: mountpoint,
-    walArchivePath: wal.getArchivePath(baseDataset),
-    sslCertDir: certPaths.certDir,
-    password: generatePassword(),
-    username: 'postgres',
-    database: 'postgres',
-    publicAccess: false,
-  });
-
-  await docker.startContainer(containerId);
-  await docker.waitForHealthy(containerId);
-
-  await setSetting('replica.baseDataset', baseDataset);
-  await setSetting('replica.postgresImage', image);
-  await setStepStatus('replica', 'done', `base replica ready on ${baseDataset}`);
 
   return {
     ok: true,
     message: `base replica ready on ${baseDataset}`,
   };
+}
+
+export async function getReplicaBaseDataset(): Promise<string> {
+  const configured = await getSetting('replica.baseDataset');
+
+  if (configured) {
+    return configured;
+  }
+
+  return getDatasetName(PROJECT_NAME, BASE_BRANCH_NAME);
+}
+
+export async function cleanupOldReplicaBases(currentBaseDataset?: string): Promise<void> {
+  if (isLocalDockerMode()) {
+    return;
+  }
+
+  const current = currentBaseDataset ?? await getReplicaBaseDataset();
+  const pool = await getZFSPool();
+  const zfs = new ZFSManager(pool, DEFAULTS.zfs.datasetBase);
+  const wal = new WALManager();
+  const prefix = `${pool}/${DEFAULTS.zfs.datasetBase}/`;
+  const datasets = await zfs.listDatasets();
+
+  for (const dataset of datasets) {
+    const name = dataset.name.startsWith(prefix) ? dataset.name.slice(prefix.length) : dataset.name;
+
+    if (name === current || !isReplicaBaseDataset(name)) {
+      continue;
+    }
+
+    await zfs.destroyDatasetWithSnapshots(name).catch(function ignoreDependentBase() {});
+
+    if (!(await zfs.datasetExists(name))) {
+      await wal.deleteArchiveDir(name).catch(function ignoreWalCleanupError() {});
+    }
+  }
+}
+
+function buildReplicaBaseDatasetName(date: Date): string {
+  return `${BASE_DATASET_PREFIX}${formatTimestamp(date).toLowerCase()}`;
+}
+
+function isReplicaBaseDataset(name: string): boolean {
+  return name === getDatasetName(PROJECT_NAME, BASE_BRANCH_NAME) || name.startsWith(BASE_DATASET_PREFIX);
 }
 
 export async function getReplicaFreshness(): Promise<ReplicaFreshness | null> {

--- a/src/server/services/setup-state-service.ts
+++ b/src/server/services/setup-state-service.ts
@@ -47,6 +47,8 @@ export interface ControlPlaneState {
   prodAllowedCidr: string | null;
 }
 
+export type SetupStepStatus = 'pending' | 'running' | 'done' | 'error' | 'stale';
+
 export async function getControlPlaneState(): Promise<ControlPlaneState> {
   const db = getDb();
   const [servers, setupSteps, branches, jobs, backup, backupAvailability, replicaFreshness, prodConnectionUrl, prodAllowedCidr] = await Promise.all([
@@ -177,7 +179,7 @@ export async function checkServer(role: 'prod' | 'dev'): Promise<Server> {
 
 export async function setStepStatus(
   key: string,
-  status: 'pending' | 'running' | 'done' | 'error',
+  status: SetupStepStatus,
   message: string | null
 ): Promise<void> {
   await getDb()
@@ -189,4 +191,8 @@ export async function setStepStatus(
     })
     .where('key', '=', key)
     .execute();
+}
+
+export async function invalidateDevReplicaBase(message: string): Promise<void> {
+  await setStepStatus('replica', 'stale', message);
 }


### PR DESCRIPTION
## Summary
- add a stale setup state for the dev replica base
- mark the replica base stale after production PITR succeeds
- block new prod-based branch creates until replica rebuild
- rebuild stale base by moving old ZFS dataset aside and taking a fresh base backup

## API routes, procedures, contracts
- none

Closes #102

## Checks
- bun run typecheck
- bun run test
- bun run web:build