### PR TITLE
feat(data): add production write guardrails

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "linux"
   ],
   "scripts": {
-    "test": "bun test src/server/control-plane.test.ts src/server/services/branch-network-service.test.ts src/managers/docker.test.ts",
+    "test": "bun test src/server/control-plane.test.ts src/server/services/branch-network-service.test.ts src/managers/docker.test.ts src/utils/prod-write-guard.test.ts",
     "build": "bun run web:build",
     "dev": "bun run web",
     "web": "bun --bun vite dev --host 0.0.0.0 --port 3000",

--- a/scripts/e2e/hetzner-suite.ts
+++ b/scripts/e2e/hetzner-suite.ts
@@ -7,6 +7,7 @@ import { runCommand, runSshCommand } from '#server/services/command-service';
 import { createReplicaBase } from '#server/services/replica-service';
 import { TABLE_ROW_ID_COLUMN } from '#server/services/table-browser-service';
 import { getContainerName, getDatasetName } from '#utils/naming';
+import { isProductionBranchId, isReadOnlySql, PRODUCTION_WRITE_CONFIRMATION } from '#utils/prod-write-guard';
 
 const api = createApiClient();
 const PROJECT_NAME = 'prod';
@@ -329,7 +330,13 @@ async function waitForJob(jobId: number, timeoutMs: number): Promise<void> {
 }
 
 async function runBranchSql(branchId: string, sql: string): Promise<QueryResult> {
-  return api.branches.sql.run({ branchId, sql });
+  return api.branches.sql.run({
+    branchId,
+    sql,
+    productionWriteConfirmation: isProductionBranchId(branchId) && !isReadOnlySql(sql)
+      ? PRODUCTION_WRITE_CONFIRMATION
+      : undefined,
+  });
 }
 
 async function assertSqlError(branchId: string, sql: string): Promise<void> {

--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -37,6 +37,7 @@ const restoreBranchInput = z.object({
 const runSqlInput = z.object({
   branchId: z.string().min(1),
   sql: z.string().min(1).max(100_000),
+  productionWriteConfirmation: z.string().optional(),
 });
 
 export const branchesRouter = {

--- a/src/api/tables.ts
+++ b/src/api/tables.ts
@@ -32,6 +32,7 @@ const tableInsertInput = z.object({
   schema: z.string().min(1),
   table: z.string().min(1),
   values: tableRowValues,
+  productionWriteConfirmation: z.string().optional(),
 });
 
 const tableUpdateInput = tableInsertInput.extend({
@@ -40,6 +41,7 @@ const tableUpdateInput = tableInsertInput.extend({
 
 const tableDeleteInput = tableRowsInput.extend({
   rowId: z.string().min(1),
+  productionWriteConfirmation: z.string().optional(),
 });
 
 export const tablesRouter = {

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -7,7 +7,7 @@ import { sql } from 'kysely';
 import { createApiClient } from '../api/router';
 import { closeDb, getDb } from '../db/client';
 import { migrateDatabase } from '../db/migrate';
-import { createJob, getActiveJob, getJob, listJobs, startJobWorker, type JobHandlers } from './services/job-service';
+import { createAuditJob, createJob, getActiveJob, getJob, listJobs, startJobWorker, type JobHandlers } from './services/job-service';
 import { parseCreateBranchJobInput } from './services/job-handlers';
 import { createBranchFromBase, replaceBranchWithReadyBranch, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
@@ -664,6 +664,19 @@ describe('control plane jobs', function controlPlaneJobs() {
     })).toBe(true);
     expect(JSON.stringify(record)).not.toContain('secret-value');
     expect(JSON.stringify(record)).not.toContain('abc');
+  });
+
+  test('stores audit jobs without queueing work', async function testAuditJob() {
+    const job = await createAuditJob('prod-write-attempt', {
+      area: 'sql',
+      allowed: false,
+    }, 'blocked production sql write');
+
+    const record = await getJob(job.id);
+    expect(record.status).toBe('done');
+    expect(record.attempts).toBe(1);
+    expect(record.logs[0]?.message).toBe('blocked production sql write');
+    expect(await getActiveJob('prod-write-attempt')).toBeUndefined();
   });
 
   test('stores sanitized job failures', async function testFailedJob() {

--- a/src/server/services/job-service.ts
+++ b/src/server/services/job-service.ts
@@ -72,6 +72,28 @@ export async function createJob(type: string, input?: unknown, options: CreateJo
     .executeTakeFirstOrThrow();
 }
 
+export async function createAuditJob(type: string, input: unknown, message: string): Promise<Job> {
+  const job = await getDb()
+    .insertInto('jobs')
+    .values({
+      type,
+      status: 'done',
+      inputJson: JSON.stringify(input),
+      error: null,
+      attempts: 1,
+      maxAttempts: 1,
+      runAfter: null,
+      startedAt: sql<string>`datetime('now')`,
+      finishedAt: sql<string>`datetime('now')`,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+
+  await appendJobLog(job.id, 'info', message);
+  return job;
+}
+
 export function startJobWorker(handlers: JobHandlers, options: StartJobWorkerOptions = {}): JobWorker {
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const staleTimeoutSeconds = options.staleTimeoutSeconds ?? DEFAULT_STALE_TIMEOUT_SECONDS;

--- a/src/server/services/prod-write-audit-service.ts
+++ b/src/server/services/prod-write-audit-service.ts
@@ -1,0 +1,20 @@
+import { createAuditJob } from './job-service';
+
+export interface ProdWriteAuditInput {
+  area: 'sql' | 'tables';
+  action: string;
+  branchId: string;
+  allowed: boolean;
+  target: string;
+}
+
+export async function auditProdWriteAttempt(input: ProdWriteAuditInput): Promise<void> {
+  const status = input.allowed ? 'allowed' : 'blocked';
+  await createAuditJob('prod-write-attempt', {
+    area: input.area,
+    action: input.action,
+    branchId: input.branchId,
+    allowed: input.allowed,
+    target: input.target,
+  }, `${status} production ${input.area} write: ${input.action} ${input.target}`);
+}

--- a/src/server/services/sql-editor-service.ts
+++ b/src/server/services/sql-editor-service.ts
@@ -1,13 +1,16 @@
 import { SQL } from 'bun';
 import { getDb } from '#db/client';
+import { isConfirmedProductionWrite, isProductionBranchId, isReadOnlySql } from '#utils/prod-write-guard';
 import { getSetting } from './settings-service';
 import { getActiveJobs } from './job-service';
+import { auditProdWriteAttempt } from './prod-write-audit-service';
 
 const STATEMENT_TIMEOUT_MS = 30_000;
 
 export interface RunBranchSqlInput {
   branchId: string;
   sql: string;
+  productionWriteConfirmation?: string | undefined;
 }
 
 export interface RunBranchSqlResult {
@@ -27,6 +30,7 @@ export async function runBranchSql(input: RunBranchSqlInput): Promise<RunBranchS
   }
 
   await assertBranchNotRestoring(input.branchId);
+  await assertProductionSqlWriteAllowed(input);
 
   const connectionUrl = await getBranchConnectionUrl(input.branchId);
   const client = new SQL({ url: connectionUrl, max: 1 });
@@ -54,7 +58,7 @@ export async function runBranchSql(input: RunBranchSqlInput): Promise<RunBranchS
 }
 
 async function getBranchConnectionUrl(branchId: string): Promise<string> {
-  if (isProductionBranch(branchId)) {
+  if (isProductionBranchId(branchId)) {
     const connectionUrl = await getSetting('prod.connectionUrl');
 
     if (!connectionUrl) {
@@ -77,14 +81,9 @@ async function getBranchConnectionUrl(branchId: string): Promise<string> {
   return branch.connectionUrl;
 }
 
-function isProductionBranch(branchId: string): boolean {
-  const normalized = branchId.trim().toLowerCase();
-  return normalized === 'production' || normalized === 'prod';
-}
-
 async function assertBranchNotRestoring(branchId: string): Promise<void> {
   const activeJobs = await getActiveJobs();
-  const normalizedBranchId = isProductionBranch(branchId) ? 'production' : branchId;
+  const normalizedBranchId = isProductionBranchId(branchId) ? 'production' : branchId;
   const activeRestore = activeJobs.some(function findActiveRestore(job) {
     if (job.type !== 'restore-branch' || !job.inputJson) {
       return false;
@@ -101,6 +100,35 @@ async function assertBranchNotRestoring(branchId: string): Promise<void> {
   if (activeRestore) {
     throw new Error(`Branch ${normalizedBranchId} is being restored. Try again after restore completes.`);
   }
+}
+
+async function assertProductionSqlWriteAllowed(input: RunBranchSqlInput): Promise<void> {
+  if (!isProductionBranchId(input.branchId) || isReadOnlySql(input.sql)) {
+    return;
+  }
+
+  const allowed = isConfirmedProductionWrite(input.productionWriteConfirmation);
+  await auditProdWriteAttempt({
+    area: 'sql',
+    action: 'run',
+    branchId: input.branchId,
+    allowed,
+    target: summarizeSql(input.sql),
+  });
+
+  if (!allowed) {
+    throw new Error('Type "write production" to run write SQL on production.');
+  }
+}
+
+function summarizeSql(sql: string): string {
+  const singleLine = sql.trim().replace(/\s+/g, ' ');
+
+  if (singleLine.length <= 120) {
+    return singleLine;
+  }
+
+  return `${singleLine.slice(0, 117)}...`;
 }
 
 function getColumns(rows: Array<Record<string, string | number | boolean | null>>): string[] {

--- a/src/server/services/table-browser-service.ts
+++ b/src/server/services/table-browser-service.ts
@@ -1,6 +1,8 @@
 import { SQL } from 'bun';
 import { getDb } from '#db/client';
+import { isConfirmedProductionWrite, isProductionBranchId } from '#utils/prod-write-guard';
 import { getSetting } from './settings-service';
+import { auditProdWriteAttempt } from './prod-write-audit-service';
 
 export interface TableBrowserInput {
   branchId: string;
@@ -23,6 +25,7 @@ export interface TableRowInsertInput {
   schema: string;
   table: string;
   values: Record<string, string | null>;
+  productionWriteConfirmation?: string | undefined;
 }
 
 export interface TableRowUpdateInput extends TableRowInsertInput {
@@ -35,6 +38,7 @@ export interface TableRowDeleteInput {
   schema: string;
   table: string;
   rowId: string;
+  productionWriteConfirmation?: string | undefined;
 }
 
 export interface TableBrowserTable {
@@ -210,6 +214,8 @@ export async function getTableRows(input: TableRowsInput): Promise<TableRowsResu
 }
 
 export async function insertTableRow(input: TableRowInsertInput): Promise<void> {
+  await assertProductionTableWriteAllowed(input, 'insert');
+
   const connectionUrl = await getBranchConnectionUrl(input.branchId);
 
   if (!connectionUrl) {
@@ -234,6 +240,8 @@ export async function insertTableRow(input: TableRowInsertInput): Promise<void> 
 }
 
 export async function updateTableRow(input: TableRowUpdateInput): Promise<void> {
+  await assertProductionTableWriteAllowed(input, 'update');
+
   const connectionUrl = await getBranchConnectionUrl(input.branchId);
 
   if (!connectionUrl) {
@@ -259,6 +267,8 @@ export async function updateTableRow(input: TableRowUpdateInput): Promise<void> 
 }
 
 export async function deleteTableRow(input: TableRowDeleteInput): Promise<void> {
+  await assertProductionTableWriteAllowed(input, 'delete');
+
   const connectionUrl = await getBranchConnectionUrl(input.branchId);
 
   if (!connectionUrl) {
@@ -277,7 +287,7 @@ export async function deleteTableRow(input: TableRowDeleteInput): Promise<void> 
 }
 
 async function getBranchConnectionUrl(branchId: string): Promise<string | null> {
-  if (isProductionBranch(branchId)) {
+  if (isProductionBranchId(branchId)) {
     return getSetting('prod.connectionUrl');
   }
 
@@ -288,11 +298,6 @@ async function getBranchConnectionUrl(branchId: string): Promise<string | null> 
     .executeTakeFirst();
 
   return branch?.connectionUrl || null;
-}
-
-function isProductionBranch(branchId: string): boolean {
-  const normalized = branchId.trim().toLowerCase();
-  return normalized === 'production' || normalized === 'prod';
 }
 
 async function listTables(sql: SQL): Promise<TableBrowserTable[]> {
@@ -317,6 +322,28 @@ async function listTables(sql: SQL): Promise<TableBrowserTable[]> {
       rowEstimate: Math.max(0, Number(row.rowEstimate) || 0),
     };
   });
+}
+
+async function assertProductionTableWriteAllowed(
+  input: TableRowInsertInput | TableRowUpdateInput | TableRowDeleteInput,
+  action: 'insert' | 'update' | 'delete'
+): Promise<void> {
+  if (!isProductionBranchId(input.branchId)) {
+    return;
+  }
+
+  const allowed = isConfirmedProductionWrite(input.productionWriteConfirmation);
+  await auditProdWriteAttempt({
+    area: 'tables',
+    action,
+    branchId: input.branchId,
+    allowed,
+    target: `${input.database}.${input.schema}.${input.table}`,
+  });
+
+  if (!allowed) {
+    throw new Error('Type "write production" to edit production rows.');
+  }
 }
 
 async function listDatabases(sql: SQL): Promise<string[]> {

--- a/src/utils/prod-write-guard.test.ts
+++ b/src/utils/prod-write-guard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { isConfirmedProductionWrite, isReadOnlySql, PRODUCTION_WRITE_CONFIRMATION } from './prod-write-guard';
+
+describe('production write guard', function productionWriteGuard() {
+  test('allows clear read-only SQL', function clearReadOnlySql() {
+    expect(isReadOnlySql('select * from users limit 1')).toBe(true);
+    expect(isReadOnlySql('show server_version')).toBe(true);
+    expect(isReadOnlySql('with rows as (select 1) select * from rows')).toBe(true);
+    expect(isReadOnlySql('explain select * from users')).toBe(true);
+  });
+
+  test('blocks SQL that can write', function writeSql() {
+    expect(isReadOnlySql('insert into users (id) values (1)')).toBe(false);
+    expect(isReadOnlySql('update users set name = name')).toBe(false);
+    expect(isReadOnlySql('select 1; delete from users')).toBe(false);
+    expect(isReadOnlySql('explain analyze update users set name = name')).toBe(false);
+  });
+
+  test('ignores write words in comments and strings', function commentsAndStrings() {
+    expect(isReadOnlySql("-- delete all rows\nselect 'update users' as note")).toBe(true);
+  });
+
+  test('requires exact production confirmation', function confirmationPhrase() {
+    expect(isConfirmedProductionWrite(PRODUCTION_WRITE_CONFIRMATION)).toBe(true);
+    expect(isConfirmedProductionWrite(` ${PRODUCTION_WRITE_CONFIRMATION.toUpperCase()} `)).toBe(true);
+    expect(isConfirmedProductionWrite('write prod')).toBe(false);
+  });
+});

--- a/src/utils/prod-write-guard.ts
+++ b/src/utils/prod-write-guard.ts
@@ -1,0 +1,293 @@
+export const PRODUCTION_WRITE_CONFIRMATION = 'write production';
+
+const READ_ONLY_KEYWORDS = new Set(['select', 'show', 'values']);
+const WRITE_KEYWORDS = /\b(alter|call|comment|copy|create|delete|drop|execute|grant|insert|merge|reindex|refresh|revoke|set|truncate|update|vacuum)\b/i;
+
+export function isProductionBranchId(branchId: string): boolean {
+  const normalized = branchId.trim().toLowerCase();
+  return normalized === 'production' || normalized === 'prod';
+}
+
+export function isConfirmedProductionWrite(value: string | null | undefined): boolean {
+  return value?.trim().toLowerCase() === PRODUCTION_WRITE_CONFIRMATION;
+}
+
+export function isReadOnlySql(sql: string): boolean {
+  const statements = splitSqlStatements(sql)
+    .map(function cleanStatement(statement) {
+      return stripCommentsAndStrings(statement).trim();
+    })
+    .filter(function keepStatement(statement) {
+      return statement.length > 0;
+    });
+
+  return statements.length > 0 && statements.every(isReadOnlyStatement);
+}
+
+function isReadOnlyStatement(statement: string): boolean {
+  const firstKeyword = getFirstKeyword(statement);
+
+  if (!firstKeyword) {
+    return false;
+  }
+
+  if (READ_ONLY_KEYWORDS.has(firstKeyword)) {
+    return true;
+  }
+
+  if (firstKeyword === 'with') {
+    return !WRITE_KEYWORDS.test(statement) && /\b(select|values)\b/i.test(statement);
+  }
+
+  if (firstKeyword === 'explain') {
+    return isReadOnlyExplain(statement);
+  }
+
+  return false;
+}
+
+function isReadOnlyExplain(statement: string): boolean {
+  if (/\banalyze\b/i.test(statement)) {
+    return false;
+  }
+
+  const explainedStatement = statement
+    .replace(/^explain\s*(\([^)]*\))?\s*/i, '')
+    .trim();
+
+  return explainedStatement.length > 0 && isReadOnlyStatement(explainedStatement);
+}
+
+function getFirstKeyword(statement: string): string | null {
+  return statement.match(/[a-z_][a-z0-9_]*/i)?.[0]?.toLowerCase() || null;
+}
+
+function splitSqlStatements(sql: string): string[] {
+  const statements: string[] = [];
+  let start = 0;
+  let index = 0;
+  let singleQuoted = false;
+  let doubleQuoted = false;
+  let lineComment = false;
+  let blockComment = false;
+  let dollarQuote: string | null = null;
+
+  while (index < sql.length) {
+    const char = sql[index];
+    const next = sql[index + 1];
+
+    if (lineComment) {
+      if (char === '\n') {
+        lineComment = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false;
+        index += 2;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (dollarQuote) {
+      if (sql.startsWith(dollarQuote, index)) {
+        index += dollarQuote.length;
+        dollarQuote = null;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (singleQuoted) {
+      if (char === "'" && next === "'") {
+        index += 2;
+        continue;
+      }
+      if (char === "'") {
+        singleQuoted = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (doubleQuoted) {
+      if (char === '"' && next === '"') {
+        index += 2;
+        continue;
+      }
+      if (char === '"') {
+        doubleQuoted = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (char === '-' && next === '-') {
+      lineComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      blockComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (char === "'") {
+      singleQuoted = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      doubleQuoted = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '$') {
+      const match = sql.slice(index).match(/^\$[a-zA-Z_][a-zA-Z0-9_]*\$|^\$\$/);
+      if (match) {
+        dollarQuote = match[0];
+        index += dollarQuote.length;
+        continue;
+      }
+    }
+
+    if (char === ';') {
+      statements.push(sql.slice(start, index));
+      start = index + 1;
+    }
+
+    index += 1;
+  }
+
+  statements.push(sql.slice(start));
+  return statements;
+}
+
+function stripCommentsAndStrings(sql: string): string {
+  let result = '';
+  let index = 0;
+  let singleQuoted = false;
+  let doubleQuoted = false;
+  let lineComment = false;
+  let blockComment = false;
+  let dollarQuote: string | null = null;
+
+  while (index < sql.length) {
+    const char = sql[index];
+    const next = sql[index + 1];
+
+    if (lineComment) {
+      result += char === '\n' ? '\n' : ' ';
+      if (char === '\n') {
+        lineComment = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (blockComment) {
+      result += ' ';
+      if (char === '*' && next === '/') {
+        result += ' ';
+        blockComment = false;
+        index += 2;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (dollarQuote) {
+      if (sql.startsWith(dollarQuote, index)) {
+        result += ' '.repeat(dollarQuote.length);
+        index += dollarQuote.length;
+        dollarQuote = null;
+        continue;
+      }
+      result += ' ';
+      index += 1;
+      continue;
+    }
+
+    if (singleQuoted) {
+      result += ' ';
+      if (char === "'" && next === "'") {
+        result += ' ';
+        index += 2;
+        continue;
+      }
+      if (char === "'") {
+        singleQuoted = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (doubleQuoted) {
+      result += ' ';
+      if (char === '"' && next === '"') {
+        result += ' ';
+        index += 2;
+        continue;
+      }
+      if (char === '"') {
+        doubleQuoted = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (char === '-' && next === '-') {
+      result += '  ';
+      lineComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      result += '  ';
+      blockComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (char === "'") {
+      result += ' ';
+      singleQuoted = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      result += ' ';
+      doubleQuoted = true;
+      index += 1;
+      continue;
+    }
+
+    if (char === '$') {
+      const match = sql.slice(index).match(/^\$[a-zA-Z_][a-zA-Z0-9_]*\$|^\$\$/);
+      if (match) {
+        dollarQuote = match[0];
+        result += ' '.repeat(dollarQuote.length);
+        index += dollarQuote.length;
+        continue;
+      }
+    }
+
+    result += char;
+    index += 1;
+  }
+
+  return result;
+}

--- a/src/web/routes/branch/$branchId/sql.tsx
+++ b/src/web/routes/branch/$branchId/sql.tsx
@@ -6,13 +6,16 @@ import {
   Database,
   Loader2,
   Play,
+  ShieldAlert,
   Terminal,
 } from 'lucide-react';
 import { Button } from '#web/components/ui/button';
+import { Input } from '#web/components/ui/input';
 import { orpc, type ControlPlaneState } from '#web/lib/api-client';
 import {
   AppSidebar,
 } from '#web/components/control-plane';
+import { isConfirmedProductionWrite, isProductionBranchId, isReadOnlySql, PRODUCTION_WRITE_CONFIRMATION } from '#utils/prod-write-guard';
 
 export const Route = createFileRoute('/branch/$branchId/sql')({
   component: SqlEditorPage,
@@ -28,6 +31,7 @@ function SqlEditorPage() {
   const [sql, setSql] = useState(function getInitialSql() {
     return readSavedSql(params.branchId);
   });
+  const [productionWriteConfirmation, setProductionWriteConfirmation] = useState('');
   const [result, setResult] = useState<SqlResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,6 +39,7 @@ function SqlEditorPage() {
     currentBranchIdRef.current = params.branchId;
     skipNextSaveRef.current = true;
     setSql(readSavedSql(params.branchId));
+    setProductionWriteConfirmation('');
     setResult(null);
     setError(null);
   }, [params.branchId]);
@@ -55,9 +60,19 @@ function SqlEditorPage() {
   const state = dashboard.data;
 
   const branch = getBranchView(state, params.branchId);
+  const isProduction = isProductionBranchId(params.branchId);
+  const isProductionWrite = isProduction && Boolean(sql.trim()) && !isReadOnlySql(sql);
+  const productionWriteUnlocked = isConfirmedProductionWrite(productionWriteConfirmation);
+  const runDisabled = runSql.isPending
+    || !sql.trim()
+    || branch.status === 'missing'
+    || (isProductionWrite && !productionWriteUnlocked);
 
   async function runCurrentSql() {
-    if (runSql.isPending || !sql.trim() || branch.status === 'missing') {
+    if (runDisabled) {
+      if (isProductionWrite && !productionWriteUnlocked) {
+        setError(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to run write SQL on production.`);
+      }
       return;
     }
 
@@ -68,6 +83,7 @@ function SqlEditorPage() {
       const nextResult = await runSql.mutateAsync({
         branchId,
         sql,
+        productionWriteConfirmation: isProduction ? productionWriteConfirmation : undefined,
       });
 
       if (currentBranchIdRef.current !== branchId) {
@@ -109,14 +125,30 @@ function SqlEditorPage() {
                   type="submit"
                   size="sm"
                   className="h-8"
-                  disabled={runSql.isPending || !sql.trim() || branch.status === 'missing'}
+                  disabled={runDisabled}
                 >
                   {runSql.isPending ? <Loader2 className="animate-spin" /> : <Play />}
                   Run
                 </Button>
               </div>
 
-              <div className="relative h-[calc(100%-3rem)] min-h-0 bg-background">
+              {isProduction ? (
+                <div className="flex flex-wrap items-center gap-2 border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-200">
+                  <ShieldAlert className="size-4" />
+                  <span className="font-medium">{isProductionWrite ? 'production writes locked' : 'production read-only'}</span>
+                  <Input
+                    value={productionWriteConfirmation}
+                    onChange={function updateProductionWriteConfirmation(event) {
+                      setProductionWriteConfirmation(event.target.value);
+                    }}
+                    className="h-8 w-48 bg-background font-mono text-xs text-foreground"
+                    placeholder={PRODUCTION_WRITE_CONFIRMATION}
+                    aria-label="Production write confirmation"
+                  />
+                </div>
+              ) : null}
+
+              <div className={isProduction ? 'relative h-[calc(100%-6.25rem)] min-h-0 bg-background' : 'relative h-[calc(100%-3rem)] min-h-0 bg-background'}>
                 <pre
                   ref={highlightRef}
                   aria-hidden="true"

--- a/src/web/routes/branch/$branchId/tables.tsx
+++ b/src/web/routes/branch/$branchId/tables.tsx
@@ -11,6 +11,7 @@ import {
   Plus,
   RefreshCw,
   Search,
+  ShieldAlert,
   Table2,
   Trash2,
 } from 'lucide-react';
@@ -48,6 +49,7 @@ import {
 } from '#web/components/ui/select';
 import { orpc } from '#web/lib/api-client';
 import { cn } from '#lib/utils';
+import { isConfirmedProductionWrite, isProductionBranchId, PRODUCTION_WRITE_CONFIRMATION } from '#utils/prod-write-guard';
 
 export const Route = createFileRoute('/branch/$branchId/tables')({
   component: BranchTablesPage,
@@ -62,6 +64,7 @@ function BranchTablesPage() {
   const [search, setSearch] = useState('');
   const [editor, setEditor] = useState<RowEditorState | null>(null);
   const [rowToDelete, setRowToDelete] = useState<DeleteRowState | null>(null);
+  const [productionWriteConfirmation, setProductionWriteConfirmation] = useState('');
   const metadata = useQuery({
     ...orpc.tables.browse.queryOptions({
       input: {
@@ -105,6 +108,7 @@ function BranchTablesPage() {
     setSearch('');
     setEditor(null);
     setRowToDelete(null);
+    setProductionWriteConfirmation('');
   }, [params.branchId]);
 
   useEffect(function setInitialTable() {
@@ -174,6 +178,11 @@ function BranchTablesPage() {
   }
 
   function openAddRow() {
+    if (!productionWritesUnlocked) {
+      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
+      return;
+    }
+
     const target = getCurrentRowsTarget();
 
     if (!rows.data || !target) {
@@ -189,6 +198,11 @@ function BranchTablesPage() {
   }
 
   function openEditRow(row: Record<string, unknown>) {
+    if (!productionWritesUnlocked) {
+      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
+      return;
+    }
+
     const target = getCurrentRowsTarget();
 
     if (!rows.data || !target) {
@@ -204,6 +218,11 @@ function BranchTablesPage() {
   }
 
   function openDeleteRow(row: Record<string, unknown>) {
+    if (!productionWritesUnlocked) {
+      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
+      return;
+    }
+
     const target = getCurrentRowsTarget();
 
     if (!rows.data || !target) {
@@ -250,6 +269,7 @@ function BranchTablesPage() {
         schema: rowToDelete.target.schema,
         table: rowToDelete.target.table,
         rowId: rowToDelete.rowId,
+        productionWriteConfirmation: isProduction ? productionWriteConfirmation : undefined,
       });
       setRowToDelete(null);
       toast.success('Row deleted.');
@@ -302,6 +322,7 @@ function BranchTablesPage() {
           schema: editor.target.schema,
           table: editor.target.table,
           values,
+          productionWriteConfirmation: isProduction ? productionWriteConfirmation : undefined,
         });
       } else if (editor.rowId) {
         await updateRow.mutateAsync({
@@ -311,6 +332,7 @@ function BranchTablesPage() {
           table: editor.target.table,
           rowId: editor.rowId,
           values,
+          productionWriteConfirmation: isProduction ? productionWriteConfirmation : undefined,
         });
       }
 
@@ -329,6 +351,9 @@ function BranchTablesPage() {
   const saving = insertRow.isPending || updateRow.isPending;
   const deleting = deleteRow.isPending;
   const rowsReady = Boolean(rows.data && rowDataMatches(rows.data, params.branchId, selectedDatabase, selectedSchema, selectedTable));
+  const isProduction = isProductionBranchId(params.branchId);
+  const productionWritesUnlocked = !isProduction || isConfirmedProductionWrite(productionWriteConfirmation);
+  const tableActionsDisabled = !rowsReady || !productionWritesUnlocked;
 
   return (
     <>
@@ -430,6 +455,21 @@ function BranchTablesPage() {
             </aside>
 
             <div className="grid min-h-0 grid-rows-[auto_1fr]">
+              {isProduction ? (
+                <div className="flex flex-wrap items-center gap-2 border-b border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  <ShieldAlert className="size-4" />
+                  <span className="font-medium">{productionWritesUnlocked ? 'production writes unlocked' : 'production rows read-only'}</span>
+                  <Input
+                    value={productionWriteConfirmation}
+                    onChange={function updateProductionWriteConfirmation(event) {
+                      setProductionWriteConfirmation(event.target.value);
+                    }}
+                    className="h-8 w-48 bg-background font-mono text-xs text-foreground"
+                    placeholder={PRODUCTION_WRITE_CONFIRMATION}
+                    aria-label="Production write confirmation"
+                  />
+                </div>
+              ) : null}
               <div className="flex flex-wrap items-center justify-end gap-2 border-b border-border px-3 py-2">
                 <div className="text-xs text-muted-foreground">
                   {rows.data ? `${rows.data.rowLimit} rows · ${rows.data.elapsedMs}ms` : 'Loading...'}
@@ -439,7 +479,7 @@ function BranchTablesPage() {
                   variant="outline"
                   size="sm"
                   className="h-8"
-                  disabled={!rowsReady || !rows.data || rows.data.columns.length === 0}
+                  disabled={tableActionsDisabled || !rows.data || rows.data.columns.length === 0}
                   onClick={openAddRow}
                 >
                   <Plus className="size-3.5" />
@@ -495,7 +535,7 @@ function BranchTablesPage() {
                 data={rows.data}
                 loading={rows.isLoading}
                 error={rows.error}
-                actionsDisabled={!rowsReady}
+                actionsDisabled={tableActionsDisabled}
                 onEditRow={openEditRow}
                 onDeleteRow={openDeleteRow}
               />


### PR DESCRIPTION
## Summary
- add shared production write detection and confirmation phrase
- require typed confirmation for production SQL writes and table row mutations
- record allowed and blocked production write attempts as completed job audit entries
- default production SQL/table UI to read-only with an unlock input

## API routes, procedures, contracts
- updated `branches.sql.run` input: optional `productionWriteConfirmation`; production write SQL requires `write production`
- updated `tables.insert`, `tables.update`, and `tables.delete` inputs: optional `productionWriteConfirmation`; production row edits require `write production`
- no routes or procedures deleted

## Validation
- `bun run typecheck`
- `bun run test`
- `bun run web:build`

Closes #94