### PR TITLE
feat(jobs): improve operation history recovery

### DIFF
--- a/src/api/jobs.ts
+++ b/src/api/jobs.ts
@@ -1,14 +1,38 @@
 import { z } from 'zod';
 import { publicProcedure } from './context';
-import { getJob, listJobs } from '#server/services/job-service';
+import { cancelJobById, getJob, listJobs, retryJobById } from '#server/services/job-service';
+
+const jobStatusInput = z.enum(['queued', 'running', 'done', 'error', 'cancelled']);
+const jobIdInput = z.object({ id: z.number().int().positive() });
 
 export const jobsRouter = {
-  list: publicProcedure.handler(async function listJobsQuery() {
-    return listJobs();
-  }),
+  list: publicProcedure
+    .input(z.object({
+      limit: z.number().int().positive().max(100).optional(),
+      offset: z.number().int().min(0).optional(),
+      status: jobStatusInput.optional(),
+      type: z.string().min(1).optional(),
+    }).optional())
+    .handler(async function listJobsQuery({ input }) {
+      return listJobs(input?.limit ?? 20, {
+        offset: input?.offset,
+        status: input?.status,
+        type: input?.type,
+      });
+    }),
   retrieve: publicProcedure
-    .input(z.object({ id: z.number().int().positive() }))
+    .input(jobIdInput)
     .handler(async function retrieveJob({ input }) {
       return getJob(input.id);
+    }),
+  retry: publicProcedure
+    .input(jobIdInput)
+    .handler(async function retryJob({ input }) {
+      return retryJobById(input.id);
+    }),
+  cancel: publicProcedure
+    .input(jobIdInput)
+    .handler(async function cancelJob({ input }) {
+      return cancelJobById(input.id);
     }),
 };

--- a/src/db/migrations/008_job_recovery_links.sql
+++ b/src/db/migrations/008_job_recovery_links.sql
@@ -1,0 +1,88 @@
+alter table setup_steps add column failed_job_id integer;
+
+alter table job_logs rename to job_logs_old;
+alter table jobs rename to jobs_old;
+
+create table jobs (
+  id integer primary key autoincrement,
+  type text not null,
+  status text not null default 'queued' check (status in ('queued', 'running', 'done', 'error', 'cancelled')),
+  input_json text,
+  error text,
+  attempts integer not null default 0,
+  max_attempts integer not null default 1,
+  run_after text,
+  locked_at text,
+  locked_by text,
+  heartbeat_at text,
+  created_at text not null default (datetime('now')),
+  started_at text,
+  finished_at text,
+  updated_at text not null default (datetime('now'))
+);
+
+create table job_logs (
+  id integer primary key autoincrement,
+  job_id integer not null references jobs(id) on delete cascade,
+  level text not null default 'info' check (level in ('info', 'error')),
+  message text not null,
+  created_at text not null default (datetime('now'))
+);
+
+insert into jobs (
+  id,
+  type,
+  status,
+  input_json,
+  error,
+  attempts,
+  max_attempts,
+  run_after,
+  locked_at,
+  locked_by,
+  heartbeat_at,
+  created_at,
+  started_at,
+  finished_at,
+  updated_at
+)
+select
+  id,
+  type,
+  status,
+  input_json,
+  error,
+  attempts,
+  max_attempts,
+  run_after,
+  locked_at,
+  locked_by,
+  heartbeat_at,
+  created_at,
+  started_at,
+  finished_at,
+  updated_at
+from jobs_old;
+
+insert into job_logs (
+  id,
+  job_id,
+  level,
+  message,
+  created_at
+)
+select
+  id,
+  job_id,
+  level,
+  message,
+  created_at
+from job_logs_old;
+
+drop table job_logs_old;
+drop table jobs_old;
+
+create index if not exists job_logs_job_id_created_at_idx on job_logs(job_id, created_at);
+create index if not exists jobs_status_created_at_idx on jobs(status, created_at);
+create index if not exists jobs_queue_idx on jobs(status, run_after, id);
+create index if not exists jobs_running_heartbeat_idx on jobs(status, heartbeat_at);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -28,6 +28,7 @@ export interface SetupStepsTable {
   label: string;
   status: 'pending' | 'running' | 'done' | 'error' | 'stale';
   message: string | null;
+  failedJobId: number | null;
   updatedAt: Timestamp;
 }
 
@@ -60,7 +61,7 @@ export interface BranchesTable {
 export interface JobsTable {
   id: Generated<number>;
   type: string;
-  status: 'queued' | 'running' | 'done' | 'error';
+  status: 'queued' | 'running' | 'done' | 'error' | 'cancelled';
   inputJson: string | null;
   error: string | null;
   attempts: Generated<number>;

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -7,12 +7,21 @@ import { sql } from 'kysely';
 import { createApiClient } from '../api/router';
 import { closeDb, getDb } from '../db/client';
 import { migrateDatabase } from '../db/migrate';
-import { createJob, getActiveJob, getJob, listJobs, startJobWorker, type JobHandlers } from './services/job-service';
+import {
+  cancelJobById,
+  createJob,
+  getActiveJob,
+  getJob,
+  listJobs,
+  retryJobById,
+  startJobWorker,
+  type JobHandlers,
+} from './services/job-service';
 import { parseCreateBranchJobInput } from './services/job-handlers';
 import { createBranchFromBase, replaceBranchWithReadyBranch, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
-import { getControlPlaneState, invalidateDevReplicaBase, saveServer } from './services/setup-state-service';
+import { getControlPlaneState, invalidateDevReplicaBase, saveServer, setStepStatus } from './services/setup-state-service';
 import { defaultCidrForHost, getProdAllowedCidr, normalizeAllowedCidr } from './services/prod-network-service';
 import { buildReplicaBaseHealth, buildReplicaFreshness } from './services/replica-service';
 
@@ -109,6 +118,9 @@ describe('control plane database', function controlPlaneDatabase() {
       const job = db
         .query('select type, attempts, max_attempts, run_after from jobs where type = ?')
         .get('old-job') as { type: string; attempts: number; max_attempts: number; run_after: string | null };
+      const log = db
+        .query('select message from job_logs where job_id = (select id from jobs where type = ?)')
+        .get('old-job') as { message: string } | null;
       db.close();
 
       expect(job).toMatchObject({
@@ -117,6 +129,7 @@ describe('control plane database', function controlPlaneDatabase() {
         max_attempts: 1,
       });
       expect(job.run_after).toBeTruthy();
+      expect(log?.message).toBe('old log');
     } finally {
       await closeDb();
       process.env.VELO_DB = originalDb;
@@ -637,7 +650,8 @@ function createPreQueueDatabase(databasePath: string): void {
     db.prepare('insert into schema_migrations (id) values (?)').run(id);
   }
 
-  db.prepare('insert into jobs (type, status) values (?, ?)').run('old-job', 'running');
+  const job = db.prepare('insert into jobs (type, status) values (?, ?)').run('old-job', 'running');
+  db.prepare('insert into job_logs (job_id, level, message) values (?, ?, ?)').run(Number(job.lastInsertRowid), 'info', 'old log');
   db.close();
 }
 
@@ -683,6 +697,70 @@ describe('control plane jobs', function controlPlaneJobs() {
     expect(record.error).toContain('access_key_id=***');
     expect(record.error).toContain('password=***');
     expect(jobs[0]?.id).toBe(job.id);
+  });
+
+  test('redacts job input returned to API callers', async function testRedactedJobInput() {
+    const job = await createJob('test-job', {
+      branch: 'preview-1',
+      password: 'secret-value',
+      connectionUrl: 'postgresql://postgres:bad@localhost:5432/postgres',
+    });
+    const record = await getJob(job.id);
+
+    expect(JSON.stringify(record.input)).toContain('preview-1');
+    expect(JSON.stringify(record.input)).not.toContain('secret-value');
+    expect(JSON.stringify(record.input)).not.toContain('bad@localhost');
+  });
+
+  test('cancels queued jobs', async function testCancelQueuedJob() {
+    const job = await createJob('create-branch', { name: 'preview-1' });
+    const record = await cancelJobById(job.id);
+
+    expect(record.status).toBe('cancelled');
+    expect(record.error).toBe('cancelled by user');
+    expect(record.canCancel).toBe(false);
+  });
+
+  test('requeues only safe failed jobs', async function testManualRetryRules() {
+    const safe = await createJob('create-branch', { name: 'preview-1' });
+    const unsafe = await createJob('restore-branch', {
+      targetBranch: 'production',
+      sourceBranch: 'production',
+      restoreTime: new Date().toISOString(),
+    });
+
+    await getDb()
+      .updateTable('jobs')
+      .set({ status: 'error', error: 'failed' })
+      .where('id', 'in', [safe.id, unsafe.id])
+      .execute();
+
+    const retried = await retryJobById(safe.id);
+
+    expect(retried.status).toBe('queued');
+    expect(retried.attempts).toBe(0);
+    await expect(retryJobById(unsafe.id)).rejects.toThrow('Job cannot be retried');
+  });
+
+  test('links setup step errors to the running job', async function testSetupFailedJobLink() {
+    const job = await createJob('setup-step-job');
+    const worker = startTestWorker({
+      'setup-step-job': async function handleJob() {
+        await setStepStatus('prod-check', 'error', 'prod failed');
+        throw new Error('prod failed');
+      },
+    });
+
+    await worker.tick();
+    await waitForJob(job.id);
+    worker.stop();
+
+    const state = await getControlPlaneState();
+    const step = state.setupSteps.find(function findProdCheck(item) {
+      return item.key === 'prod-check';
+    });
+
+    expect(step?.failedJobId).toBe(job.id);
   });
 
   test('finds only queued or running jobs by type', async function testActiveJob() {
@@ -828,7 +906,7 @@ async function waitForJob(jobId: number) {
   while (Date.now() - startedAt < 2000) {
     const job = await getJob(jobId);
 
-    if (job.status === 'done' || job.status === 'error') {
+    if (job.status === 'done' || job.status === 'error' || job.status === 'cancelled') {
       return job;
     }
 

--- a/src/server/services/job-handlers.ts
+++ b/src/server/services/job-handlers.ts
@@ -158,7 +158,11 @@ async function runSetupJob(context: JobContext): Promise<void> {
 
   if (!(await isStepDone('prod-check'))) {
     await context.log('checking prod server');
-    await checkServer('prod');
+    const server = await checkServer('prod');
+
+    if (server.status !== 'ok') {
+      throw new Error(server.statusMessage || 'prod server check failed');
+    }
   }
 
   if (!(await isStepDone('prod-setup')) || !(await isStepDone('backups'))) {

--- a/src/server/services/job-service.ts
+++ b/src/server/services/job-service.ts
@@ -1,13 +1,28 @@
 import { sql } from 'kysely';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { getDb } from '../../db/client';
 import type { Job, JobLog } from '../../db/schema';
 
-export type JobStatus = 'queued' | 'running' | 'done' | 'error';
+export type JobStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled';
 export type JobHandler = (input: unknown, context: JobContext) => Promise<void>;
 export type JobHandlers = Record<string, JobHandler>;
 
 const DEFAULT_STALE_TIMEOUT_SECONDS = 5 * 60;
 const DEFAULT_POLL_INTERVAL_MS = 1000;
+const SAFE_MANUAL_RETRY_JOB_TYPES = [
+  'dev-bootstrap',
+  'prod-bootstrap',
+  'setup',
+  'replica-base',
+  'create-branch',
+  'delete-branch',
+  'branch-cleanup',
+];
+const AUTO_RETRY_JOB_TYPES = [
+  ...SAFE_MANUAL_RETRY_JOB_TYPES,
+  'restore-branch',
+];
+const currentJobId = new AsyncLocalStorage<number>();
 
 export interface JobRecord {
   id: number;
@@ -25,6 +40,9 @@ export interface JobRecord {
   startedAt: string | null;
   finishedAt: string | null;
   updatedAt: string;
+  durationMs: number | null;
+  canRetry: boolean;
+  canCancel: boolean;
   logs: Array<{
     id: number;
     level: 'info' | 'error';
@@ -42,6 +60,12 @@ export interface JobContext {
 
 export interface CreateJobOptions {
   maxAttempts?: number;
+}
+
+export interface ListJobsOptions {
+  offset?: number;
+  status?: JobStatus;
+  type?: string;
 }
 
 export interface JobWorker {
@@ -70,6 +94,10 @@ export async function createJob(type: string, input?: unknown, options: CreateJo
     })
     .returningAll()
     .executeTakeFirstOrThrow();
+}
+
+export function getCurrentJobId(): number | null {
+  return currentJobId.getStore() ?? null;
 }
 
 export function startJobWorker(handlers: JobHandlers, options: StartJobWorkerOptions = {}): JobWorker {
@@ -119,13 +147,23 @@ export function startJobWorker(handlers: JobHandlers, options: StartJobWorkerOpt
   return { tick, stop };
 }
 
-export async function listJobs(limit = 20): Promise<JobRecord[]> {
-  const jobs = await getDb()
+export async function listJobs(limit = 20, options: ListJobsOptions = {}): Promise<JobRecord[]> {
+  let query = getDb()
     .selectFrom('jobs')
     .selectAll()
     .orderBy('createdAt', 'desc')
     .limit(limit)
-    .execute();
+    .offset(options.offset ?? 0);
+
+  if (options.status) {
+    query = query.where('status', '=', options.status);
+  }
+
+  if (options.type) {
+    query = query.where('type', '=', options.type);
+  }
+
+  const jobs = await query.execute();
 
   const result: JobRecord[] = [];
 
@@ -146,6 +184,70 @@ export async function getJob(jobId: number): Promise<JobRecord> {
   const logs = await getJobLogs(job.id, 100);
 
   return mapJob(job, logs);
+}
+
+export async function retryJobById(jobId: number): Promise<JobRecord> {
+  const job = await getDb()
+    .selectFrom('jobs')
+    .selectAll()
+    .where('id', '=', jobId)
+    .executeTakeFirstOrThrow();
+
+  if (!canRetryJob(job)) {
+    throw new Error(`Job cannot be retried: ${job.type}`);
+  }
+
+  await appendJobLog(job.id, 'info', `queued retry for ${job.type}`);
+  await getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'queued',
+      error: null,
+      attempts: 0,
+      runAfter: sql<string>`datetime('now')`,
+      lockedAt: null,
+      lockedBy: null,
+      heartbeatAt: null,
+      startedAt: null,
+      finishedAt: null,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .where('id', '=', job.id)
+    .where('status', '=', 'error')
+    .execute();
+
+  return getJob(job.id);
+}
+
+export async function cancelJobById(jobId: number): Promise<JobRecord> {
+  const job = await getDb()
+    .selectFrom('jobs')
+    .selectAll()
+    .where('id', '=', jobId)
+    .executeTakeFirstOrThrow();
+
+  if (job.status !== 'queued') {
+    throw new Error('Only queued jobs can be cancelled');
+  }
+
+  await appendJobLog(job.id, 'info', `cancelled ${job.type}`);
+  await getDb()
+    .updateTable('jobs')
+    .set({
+      status: 'cancelled',
+      error: 'cancelled by user',
+      runAfter: null,
+      lockedAt: null,
+      lockedBy: null,
+      heartbeatAt: null,
+      finishedAt: sql<string>`datetime('now')`,
+      updatedAt: sql<string>`datetime('now')`,
+    })
+    .where('id', '=', job.id)
+    .where('status', '=', 'queued')
+    .execute();
+
+  return getJob(job.id);
 }
 
 export async function getActiveJob(type: string): Promise<Job | undefined> {
@@ -227,7 +329,9 @@ async function runClaimedJob(
     }
 
     await appendJobLog(job.id, 'info', `attempt ${job.attempts} started ${job.type}`);
-    await handler(parseJobInput(job), context);
+    await currentJobId.run(job.id, async function runJobWithContext() {
+      await handler(parseJobInput(job), context);
+    });
     await appendJobLog(job.id, 'info', `attempt ${job.attempts} finished ${job.type}`);
     await finishJob(job.id, workerId);
   } catch (error: any) {
@@ -386,7 +490,7 @@ function mapJob(job: Job, logs: JobLog[]): JobRecord {
     id: job.id,
     type: job.type,
     status: job.status,
-    input: parseJobInput(job),
+    input: redactValue(parseJobInput(job)),
     error: job.error,
     attempts: job.attempts,
     maxAttempts: job.maxAttempts,
@@ -398,6 +502,9 @@ function mapJob(job: Job, logs: JobLog[]): JobRecord {
     startedAt: job.startedAt,
     finishedAt: job.finishedAt,
     updatedAt: job.updatedAt,
+    durationMs: getJobDurationMs(job),
+    canRetry: canRetryJob(job),
+    canCancel: job.status === 'queued',
     logs: logs.map(function mapLog(log) {
       return {
         id: log.id,
@@ -422,20 +529,35 @@ function getDefaultMaxAttempts(type: string, input: unknown): number {
     return 1;
   }
 
-  if ([
-    'dev-bootstrap',
-    'prod-bootstrap',
-    'setup',
-    'replica-base',
-    'create-branch',
-    'delete-branch',
-    'branch-cleanup',
-    'restore-branch',
-  ].includes(type)) {
+  if (AUTO_RETRY_JOB_TYPES.includes(type)) {
     return 3;
   }
 
   return 1;
+}
+
+function canRetryJob(job: Job): boolean {
+  return job.status === 'error' && isSafeRetryJobType(job.type);
+}
+
+function isSafeRetryJobType(type: string): boolean {
+  return SAFE_MANUAL_RETRY_JOB_TYPES.includes(type);
+}
+
+function getJobDurationMs(job: Job): number | null {
+  const startedAt = job.startedAt ? new Date(job.startedAt).getTime() : null;
+
+  if (!startedAt || Number.isNaN(startedAt)) {
+    return null;
+  }
+
+  const finishedAt = job.finishedAt ? new Date(job.finishedAt).getTime() : Date.now();
+
+  if (Number.isNaN(finishedAt)) {
+    return null;
+  }
+
+  return Math.max(0, finishedAt - startedAt);
 }
 
 function isProductionRestore(input: unknown): boolean {
@@ -456,8 +578,35 @@ function getBackoffSeconds(attempt: number): number {
 
 function sanitizeLogMessage(message: string): string {
   return message
+    .replace(/postgres(?:ql)?:\/\/([^:\s/]+):([^@\s]+)@/gi, 'postgresql://$1:***@')
     .replace(/password=[^ '\n]+/gi, 'password=***')
     .replace(/secret[ _-]?access[ _-]?key(?:\s*[=:]?\s*[^ '\n]+)?/gi, 'secret_access_key=***')
     .replace(/access[ _-]?key[ _-]?id(?:\s*[=:]?\s*[^ '\n]+)?/gi, 'access_key_id=***')
     .slice(0, 4000);
+}
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return sanitizeLogMessage(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(redactValue);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+
+  for (const [key, item] of Object.entries(value)) {
+    redacted[key] = isSensitiveKey(key) ? '***' : redactValue(item);
+  }
+
+  return redacted;
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /password|secret|token|accessKey|access_key|connectionUrl|sshKeyPath/i.test(key);
 }

--- a/src/server/services/setup-state-service.ts
+++ b/src/server/services/setup-state-service.ts
@@ -2,7 +2,7 @@ import { sql } from 'kysely';
 import { getDb } from '../../db/client';
 import type { Server } from '../../db/schema';
 import { runCommand, runSshCommand } from './command-service';
-import { listJobs, type JobRecord } from './job-service';
+import { getCurrentJobId, listJobs, type JobRecord } from './job-service';
 import { getBackupAvailability, type BackupAvailability } from './backup-availability-service';
 import { getBackupSettings, getSetting, type BackupSettings } from './settings-service';
 import { checkLocalDocker, isLocalDockerMode } from './local-docker-service';
@@ -24,6 +24,7 @@ export interface ControlPlaneState {
     label: string;
     status: string;
     message: string | null;
+    failedJobId: number | null;
     updatedAt: string;
   }>;
   branches: Array<{
@@ -55,7 +56,7 @@ export async function getControlPlaneState(): Promise<ControlPlaneState> {
     db.selectFrom('servers').selectAll().orderBy('role').execute(),
     db
       .selectFrom('setupSteps')
-      .select(['key', 'label', 'status', 'message', 'updatedAt'])
+      .select(['key', 'label', 'status', 'message', 'failedJobId', 'updatedAt'])
       .orderBy('id')
       .execute(),
     db
@@ -182,11 +183,14 @@ export async function setStepStatus(
   status: SetupStepStatus,
   message: string | null
 ): Promise<void> {
+  const failedJobId = status === 'error' ? getCurrentJobId() : null;
+
   await getDb()
     .updateTable('setupSteps')
     .set({
       status,
       message,
+      failedJobId,
       updatedAt: sql`datetime('now')`,
     })
     .where('key', '=', key)

--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -6,16 +6,21 @@ import {
   Activity,
   AlertTriangle,
   ArchiveRestore,
+  Ban,
   CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
   Clock3,
   Code2,
   Copy,
   Database,
+  Eye,
   GitBranch,
   LayoutDashboard,
   Loader2,
   Menu,
   RefreshCw,
+  RotateCcw,
   Settings2,
   ShieldCheck,
   Table2,
@@ -49,6 +54,8 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '#web/components/ui/dialog';
@@ -824,73 +831,328 @@ export function BackupPanel(props: BackupPanelProps) {
 }
 
 export interface JobsPanelProps {
-  jobs: Array<{
-    id: number;
-    type: string;
-    status: string;
-    input: unknown;
-    error: string | null;
-    updatedAt: string;
-    logs: Array<{
-      id: number;
-      level: 'info' | 'error';
-      message: string;
-    }>;
-  }>;
+  jobs: JobPanelRecord[];
   activeJobs: number;
+  loading?: boolean;
+  statusFilter: string;
+  onStatusFilterChange: (status: string) => void;
+  page: number;
+  hasMore: boolean;
+  selectedJob: JobPanelRecord | null;
+  selectedJobOpen: boolean;
+  selectedJobLoading: boolean;
+  busyJobId: number | null;
+  onPreviousPage: () => void;
+  onNextPage: () => void;
+  onOpenJob: (jobId: number) => void;
+  onCloseJob: () => void;
+  onRetry: (jobId: number) => Promise<void>;
+  onCancel: (jobId: number) => Promise<void>;
 }
+
+interface JobPanelRecord {
+  id: number;
+  type: string;
+  status: string;
+  input: unknown;
+  error: string | null;
+  attempts: number;
+  maxAttempts: number;
+  updatedAt: string;
+  durationMs: number | null;
+  canRetry: boolean;
+  canCancel: boolean;
+  logs: Array<{
+    id: number;
+    level: 'info' | 'error';
+    message: string;
+    createdAt?: string;
+  }>;
+}
+
+const JOB_STATUS_FILTERS = ['all', 'queued', 'running', 'done', 'error', 'cancelled'];
 
 export function JobsPanel(props: JobsPanelProps) {
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between gap-3">
-        <div>
-          <CardTitle>Jobs</CardTitle>
-          <CardDescription>Background branch and maintenance activity</CardDescription>
-        </div>
-        <Badge variant={props.activeJobs > 0 ? 'info' : 'secondary'}>{props.activeJobs} active</Badge>
-      </CardHeader>
-      <CardContent>
-        {props.jobs.length === 0 ? (
-          <EmptyState icon={Clock3} title="No jobs yet" detail="Branch and maintenance actions will appear here." compact />
-        ) : (
-          <div className="grid gap-3">
-            {props.jobs.map(function renderJob(job) {
-              return (
-                <div className="border-t border-border pt-3 first:border-t-0 first:pt-0" key={job.id}>
-                  <div className="flex items-center justify-between gap-3">
-                    <p className="truncate text-sm font-medium">{job.type}</p>
-                    <StatusBadge status={job.status} />
-                  </div>
-                  <p className="mt-2 truncate text-xs text-muted-foreground">{job.error || job.updatedAt}</p>
-                  {job.logs.length > 0 ? (
-                    <>
-                      <Separator className="my-3" />
-                      <div className="grid gap-1">
-                        {job.logs.slice(0, 3).map(function renderLog(log) {
-                          return (
-                            <code
-                              className={cn(
-                                'block truncate text-xs text-muted-foreground',
-                                log.level === 'error' && 'text-destructive'
-                              )}
-                              key={log.id}
-                            >
-                              {log.message}
-                            </code>
-                          );
-                        })}
-                      </div>
-                    </>
-                  ) : null}
-                </div>
-              );
-            })}
+    <>
+      <Card>
+        <CardHeader className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
+          <div>
+            <CardTitle>Jobs</CardTitle>
+            <CardDescription>Background branch and maintenance activity</CardDescription>
           </div>
-        )}
-      </CardContent>
-    </Card>
+          <div className="flex items-center gap-2">
+            <Select value={props.statusFilter} onValueChange={props.onStatusFilterChange}>
+              <SelectTrigger className="h-9 w-36 bg-background">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {JOB_STATUS_FILTERS.map(function renderStatusFilter(status) {
+                  return <SelectItem key={status} value={status}>{status}</SelectItem>;
+                })}
+              </SelectContent>
+            </Select>
+            <Badge variant={props.activeJobs > 0 ? 'info' : 'secondary'}>{props.activeJobs} active</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {props.loading ? (
+            <EmptyState icon={Loader2} title="Loading jobs" detail="Fetching latest job history." compact />
+          ) : props.jobs.length === 0 ? (
+            <EmptyState icon={Clock3} title="No jobs yet" detail="Branch and maintenance actions will appear here." compact />
+          ) : (
+            <div className="grid gap-3">
+              {props.jobs.map(function renderJob(job) {
+                const busy = props.busyJobId === job.id;
+
+                return (
+                  <div className="border-t border-border pt-3 first:border-t-0 first:pt-0" key={job.id}>
+                    <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-start">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="truncate text-sm font-medium">{job.type}</p>
+                          <StatusBadge status={job.status} />
+                        </div>
+                        <p className="mt-2 truncate text-xs text-muted-foreground">
+                          {job.error || `${formatJobDuration(job.durationMs)} · ${formatLastCheck(job.updatedAt)}`}
+                        </p>
+                      </div>
+                      <JobActionButtons job={job} busy={busy} compact onOpen={props.onOpenJob} onRetry={props.onRetry} onCancel={props.onCancel} />
+                    </div>
+                    {job.logs.length > 0 ? (
+                      <>
+                        <Separator className="my-3" />
+                        <div className="grid gap-1">
+                          {job.logs.slice(0, 3).map(function renderLog(log) {
+                            return (
+                              <code
+                                className={cn(
+                                  'block truncate text-xs text-muted-foreground',
+                                  log.level === 'error' && 'text-destructive'
+                                )}
+                                key={log.id}
+                              >
+                                {log.message}
+                              </code>
+                            );
+                          })}
+                        </div>
+                      </>
+                    ) : null}
+                  </div>
+                );
+              })}
+              <div className="flex items-center justify-between gap-3 border-t border-border pt-3">
+                <Button type="button" variant="outline" size="sm" disabled={props.page === 0} onClick={props.onPreviousPage}>
+                  <ChevronLeft />
+                  Previous
+                </Button>
+                <span className="text-xs text-muted-foreground">Page {props.page + 1}</span>
+                <Button type="button" variant="outline" size="sm" disabled={!props.hasMore} onClick={props.onNextPage}>
+                  Next
+                  <ChevronRight />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <JobDetailDialog
+        job={props.selectedJob}
+        open={props.selectedJobOpen}
+        loading={props.selectedJobLoading}
+        busy={props.selectedJob ? props.busyJobId === props.selectedJob.id : false}
+        onClose={props.onCloseJob}
+        onRetry={props.onRetry}
+        onCancel={props.onCancel}
+      />
+    </>
   );
+}
+
+function JobDetailDialog(props: {
+  job: JobPanelRecord | null;
+  open: boolean;
+  loading: boolean;
+  busy: boolean;
+  onClose: () => void;
+  onRetry: (jobId: number) => Promise<void>;
+  onCancel: (jobId: number) => Promise<void>;
+}) {
+  const job = props.job;
+
+  return (
+    <Dialog open={props.open} onOpenChange={function changeJobDialog(open) {
+      if (!open) {
+        props.onClose();
+      }
+    }}>
+      <DialogContent className="max-h-[85vh] overflow-hidden sm:max-w-2xl">
+        {props.loading || !job ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="animate-spin" />
+            Loading job...
+          </div>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{job.type}</DialogTitle>
+              <DialogDescription>Job #{job.id}</DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 overflow-y-auto pr-1">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <InfoCell label="Status" value={job.status} />
+                <InfoCell label="Duration" value={formatJobDuration(job.durationMs)} />
+                <InfoCell label="Attempts" value={`${job.attempts}/${job.maxAttempts}`} />
+              </div>
+              {job.error ? (
+                <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                  {job.error}
+                </div>
+              ) : null}
+              <div>
+                <Label>Input</Label>
+                <pre className="mt-2 max-h-40 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+                  {formatJobInput(job.input)}
+                </pre>
+              </div>
+              <div>
+                <Label>Logs</Label>
+                <div className="mt-2 grid max-h-72 gap-1 overflow-auto rounded-md border border-border bg-muted/40 p-3">
+                  {job.logs.length > 0 ? job.logs.map(function renderJobLog(log) {
+                    return (
+                      <code
+                        className={cn('text-xs text-muted-foreground', log.level === 'error' && 'text-destructive')}
+                        key={log.id}
+                      >
+                        {log.createdAt ? `${formatLastCheck(log.createdAt)} ` : ''}{log.message}
+                      </code>
+                    );
+                  }) : (
+                    <p className="text-xs text-muted-foreground">No logs.</p>
+                  )}
+                </div>
+              </div>
+            </div>
+            <DialogFooter>
+              <JobActionButtons job={job} busy={props.busy} onRetry={props.onRetry} onCancel={props.onCancel} />
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function JobActionButtons(props: {
+  job: JobPanelRecord;
+  busy: boolean;
+  compact?: boolean;
+  onOpen?: (jobId: number) => void;
+  onRetry: (jobId: number) => Promise<void>;
+  onCancel: (jobId: number) => Promise<void>;
+}) {
+  return (
+    <div className="flex gap-2">
+      {props.onOpen ? (
+        <Button type="button" size="icon" variant="outline" title="View job" onClick={function openJob() {
+          props.onOpen?.(props.job.id);
+        }}>
+          <Eye />
+        </Button>
+      ) : null}
+      {props.job.canRetry ? (
+        <Button
+          type="button"
+          size={props.compact ? 'icon' : 'default'}
+          variant={props.compact ? 'outline' : 'default'}
+          title="Retry job"
+          disabled={props.busy}
+          onClick={function retryJob() {
+            void props.onRetry(props.job.id);
+          }}
+        >
+          {props.busy ? <Loader2 className="animate-spin" /> : <RotateCcw />}
+          {props.compact ? null : 'Retry'}
+        </Button>
+      ) : null}
+      {props.job.canCancel ? (
+        <Button
+          type="button"
+          size={props.compact ? 'icon' : 'default'}
+          variant="outline"
+          title="Cancel job"
+          disabled={props.busy}
+          onClick={function cancelJob() {
+            void props.onCancel(props.job.id);
+          }}
+        >
+          {props.busy ? <Loader2 className="animate-spin" /> : <Ban />}
+          {props.compact ? null : 'Cancel'}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function formatJobDuration(durationMs: number | null): string {
+  if (durationMs === null) {
+    return '-';
+  }
+
+  const seconds = Math.round(durationMs / 1000);
+
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  return `${Math.round(minutes / 60)}h`;
+}
+
+function formatJobInput(input: unknown): string {
+  if (input === undefined) {
+    return 'none';
+  }
+
+  return JSON.stringify(input, null, 2);
+}
+
+function formatLastCheck(value: string | null | undefined): string {
+  if (!value) {
+    return 'never';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const diffMs = Date.now() - date.getTime();
+  const minutes = Math.max(0, Math.round(diffMs / 60000));
+
+  if (minutes < 1) {
+    return 'just now';
+  }
+
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.round(minutes / 60);
+
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  return `${Math.round(hours / 24)}d ago`;
 }
 
 interface FieldProps {

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -32,7 +32,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '#web/components/ui/tabs';
-import { orpc } from '#web/lib/api-client';
+import { api, orpc } from '#web/lib/api-client';
 import {
   AppSidebar,
   BackupPanel,
@@ -42,6 +42,9 @@ import {
   type ServerRole,
 } from '#web/components/control-plane';
 
+const JOB_PAGE_SIZE = 20;
+type JobStatusFilter = 'all' | 'queued' | 'running' | 'done' | 'error' | 'cancelled';
+
 export const Route = createFileRoute('/settings')({
   component: SettingsPage,
 });
@@ -49,12 +52,49 @@ export const Route = createFileRoute('/settings')({
 function SettingsPage() {
   const queryClient = useQueryClient();
   const dashboard = useQuery(orpc.dashboard.retrieve.queryOptions());
+  const [settingsTab, setSettingsTab] = useState('overview');
+  const [jobStatus, setJobStatus] = useState<JobStatusFilter>('all');
+  const [jobPage, setJobPage] = useState(0);
+  const [selectedJobId, setSelectedJobId] = useState<number | null>(null);
   const saveServer = useMutation(orpc.servers.update.mutationOptions({ onSuccess: refreshDashboard }));
   const checkServer = useMutation(orpc.servers.check.mutationOptions({ onSuccess: refreshDashboard }));
   const saveBackupSettings = useMutation(orpc.backup.settings.update.mutationOptions({ onSuccess: refreshDashboard }));
+  const jobList = useQuery({
+    queryKey: ['settings-jobs', jobStatus, jobPage],
+    queryFn: function listSettingsJobs() {
+      return api.jobs.list({
+        limit: JOB_PAGE_SIZE,
+        offset: jobPage * JOB_PAGE_SIZE,
+        status: getJobStatusQuery(jobStatus),
+      });
+    },
+  });
+  const selectedJob = useQuery({
+    queryKey: ['settings-job', selectedJobId],
+    enabled: selectedJobId !== null,
+    queryFn: function retrieveSelectedJob() {
+      if (!selectedJobId) {
+        throw new Error('Missing job id');
+      }
+
+      return api.jobs.retrieve({ id: selectedJobId });
+    },
+  });
+  const retryJob = useMutation({
+    mutationFn: function retryJobMutation(id: number) {
+      return api.jobs.retry({ id });
+    },
+    onSuccess: refreshJobs,
+  });
+  const cancelJob = useMutation({
+    mutationFn: function cancelJobMutation(id: number) {
+      return api.jobs.cancel({ id });
+    },
+    onSuccess: refreshJobs,
+  });
   const busy = getBusyKey();
   const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
-    return job.status === 'queued' || job.status === 'running';
+    return isActiveJobStatus(job.status);
   }).length ?? 0;
 
   useEffect(function pollActiveJobs() {
@@ -64,6 +104,7 @@ function SettingsPage() {
 
     const interval = window.setInterval(function refreshActiveJobs() {
       void dashboard.refetch();
+      void queryClient.invalidateQueries({ queryKey: ['settings-jobs'] });
     }, 2000);
 
     return function clearPoll() {
@@ -73,6 +114,14 @@ function SettingsPage() {
 
   async function refreshDashboard() {
     await queryClient.invalidateQueries({ queryKey: orpc.dashboard.retrieve.key() });
+  }
+
+  async function refreshJobs() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: orpc.dashboard.retrieve.key() }),
+      queryClient.invalidateQueries({ queryKey: ['settings-jobs'] }),
+      queryClient.invalidateQueries({ queryKey: ['settings-job', selectedJobId] }),
+    ]);
   }
 
   function getBusyKey(): string | null {
@@ -86,6 +135,18 @@ function SettingsPage() {
 
     if (saveBackupSettings.isPending) {
       return 'save-backup';
+    }
+
+    return null;
+  }
+
+  function getBusyJobId(): number | null {
+    if (retryJob.isPending) {
+      return retryJob.variables ?? null;
+    }
+
+    if (cancelJob.isPending) {
+      return cancelJob.variables ?? null;
     }
 
     return null;
@@ -153,6 +214,38 @@ function SettingsPage() {
     }
   }
 
+  function handleJobStatusChange(status: string) {
+    if (!isJobStatusFilter(status)) {
+      return;
+    }
+
+    setJobStatus(status);
+    setJobPage(0);
+  }
+
+  function openJob(jobId: number) {
+    setSettingsTab('jobs');
+    setSelectedJobId(jobId);
+  }
+
+  async function handleRetryJob(jobId: number) {
+    try {
+      await retryJob.mutateAsync(jobId);
+      toast.success('Job queued.');
+    } catch (error: any) {
+      toast.error(error?.message || 'Could not retry job.');
+    }
+  }
+
+  async function handleCancelJob(jobId: number) {
+    try {
+      await cancelJob.mutateAsync(jobId);
+      toast.success('Job cancelled.');
+    } catch (error: any) {
+      toast.error(error?.message || 'Could not cancel job.');
+    }
+  }
+
   return (
     <main className="min-h-screen bg-background text-foreground">
       <div className="flex min-h-screen flex-col lg:grid lg:grid-cols-[244px_1fr]">
@@ -173,7 +266,7 @@ function SettingsPage() {
               </Button>
             </header>
 
-            <Tabs defaultValue="overview" orientation="vertical" className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)]">
+            <Tabs value={settingsTab} onValueChange={setSettingsTab} orientation="vertical" className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)]">
               <TabsList variant="line" className="w-full items-stretch justify-start">
                 <TabsTrigger className="pl-3 data-active:text-muted-foreground data-active:after:left-0 data-active:after:right-auto" value="overview">
                   <Activity />
@@ -198,14 +291,17 @@ function SettingsPage() {
               </TabsList>
 
               <TabsContent value="overview" className="min-w-0">
-                <SettingsOverview
-                  okServers={okServers}
-                  serverCount={state.servers.length}
-                  backupMode={backupMode}
-                  backupDetail={state.backup.bucket || 'not configured'}
-                  activeJobs={activeJobs}
-                  lastJob={lastJob}
-                />
+                <div className="grid gap-6">
+                  <SettingsOverview
+                    okServers={okServers}
+                    serverCount={state.servers.length}
+                    backupMode={backupMode}
+                    backupDetail={state.backup.bucket || 'not configured'}
+                    activeJobs={activeJobs}
+                    lastJob={lastJob}
+                  />
+                  <SetupStepsPanel steps={state.setupSteps} onOpenJob={openJob} />
+                </div>
               </TabsContent>
 
               <TabsContent value="servers" className="min-w-0">
@@ -224,7 +320,31 @@ function SettingsPage() {
               </TabsContent>
 
               <TabsContent value="jobs" className="min-w-0">
-                <JobsPanel jobs={state.jobs} activeJobs={activeJobs} />
+                <JobsPanel
+                  jobs={jobList.data || state.jobs}
+                  activeJobs={activeJobs}
+                  loading={jobList.isLoading}
+                  statusFilter={jobStatus}
+                  onStatusFilterChange={handleJobStatusChange}
+                  page={jobPage}
+                  hasMore={(jobList.data?.length || 0) === JOB_PAGE_SIZE}
+                  onPreviousPage={function previousJobPage() {
+                    setJobPage(Math.max(0, jobPage - 1));
+                  }}
+                  onNextPage={function nextJobPage() {
+                    setJobPage(jobPage + 1);
+                  }}
+                  selectedJob={selectedJob.data || null}
+                  selectedJobOpen={selectedJobId !== null}
+                  selectedJobLoading={selectedJob.isLoading}
+                  busyJobId={getBusyJobId()}
+                  onOpenJob={setSelectedJobId}
+                  onCloseJob={function closeJob() {
+                    setSelectedJobId(null);
+                  }}
+                  onRetry={handleRetryJob}
+                  onCancel={handleCancelJob}
+                />
               </TabsContent>
             </Tabs>
           </div>
@@ -232,6 +352,18 @@ function SettingsPage() {
       </div>
     </main>
   );
+}
+
+function getJobStatusQuery(status: JobStatusFilter): Exclude<JobStatusFilter, 'all'> | undefined {
+  return status === 'all' ? undefined : status;
+}
+
+function isJobStatusFilter(status: string): status is JobStatusFilter {
+  return ['all', 'queued', 'running', 'done', 'error', 'cancelled'].includes(status);
+}
+
+function isActiveJobStatus(status: string): boolean {
+  return status === 'queued' || status === 'running';
 }
 
 interface SettingsOverviewProps {
@@ -285,6 +417,56 @@ function SettingsOverview(props: SettingsOverviewProps) {
             {props.lastJob.error}
           </div>
         ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface SetupStepsPanelProps {
+  steps: Array<{
+    key: string;
+    label: string;
+    status: string;
+    message: string | null;
+    failedJobId: number | null;
+  }>;
+  onOpenJob: (jobId: number) => void;
+}
+
+function SetupStepsPanel(props: SetupStepsPanelProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Setup</CardTitle>
+        <CardDescription>Onboarding steps and failed jobs</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-3">
+        {props.steps.map(function renderStep(step) {
+          return (
+            <div className="grid gap-2 rounded-md border border-border p-3 sm:grid-cols-[1fr_auto] sm:items-center" key={step.key}>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="truncate text-sm font-medium">{step.label}</p>
+                  <StatusBadge status={step.status} />
+                </div>
+                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{step.message || 'No message yet.'}</p>
+              </div>
+              {step.failedJobId ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={function openFailedJob() {
+                    props.onOpenJob(step.failedJobId!);
+                  }}
+                >
+                  <Activity />
+                  Job #{step.failedJobId}
+                </Button>
+              ) : null}
+            </div>
+          );
+        })}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add job list filters, detail view, duration, full logs, retry, and queued cancel
- redact returned job input and strengthen log redaction
- link failed setup steps to the failed job

## API routes, procedures, contracts
- updated `jobs.list` to accept `limit`, `offset`, `status`, and `type`
- updated job records to include `durationMs`, `canRetry`, and `canCancel`
- added `jobs.retry` and `jobs.cancel` procedures
- updated dashboard setup steps to include `failedJobId`
- added migration `008_job_recovery_links` with `setup_steps.failed_job_id` and `cancelled` job status

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`