### PR TITLE
feat(replica): guard stale branch creation

### DIFF
--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -5,13 +5,16 @@ import { publicProcedure } from './context';
 import { userFacingError } from './errors';
 import { createJob } from '#server/services/job-service';
 import { createPreviewBranch, normalizeBranchSlug, updateBranchExpiry } from '#server/services/branch-service';
+import { getReplicaFreshness } from '#server/services/replica-service';
 import { runBranchSql } from '#server/services/sql-editor-service';
+import { getReplicaBranchCreatePolicy, type ReplicaBranchCreatePolicy } from '#utils/replica-freshness-policy';
 
 const branchInput = z.object({
   name: z.string().min(1),
   parentBranchId: z.number().int().positive().nullable().optional(),
   ttlHours: z.number().positive().nullable().optional(),
   expiresAt: z.string().nullable().optional(),
+  forceReplicaStale: z.boolean().optional(),
 });
 
 const branchIdInput = z.object({
@@ -46,10 +49,12 @@ export const branchesRouter = {
     .handler(async function createBranch({ input }) {
       const branchSlug = normalizeBranchSlug(input.name);
       await assertBranchSlugAvailable(branchSlug);
+      const replicaPolicy = await assertReplicaCreateAllowed(input);
       const job = await createJob('create-branch', input);
       return {
         ...job,
         branchSlug,
+        replicaWarning: replicaPolicy.status === 'warn' ? formatReplicaWarning(replicaPolicy) : null,
       };
     }),
   delete: publicProcedure
@@ -128,6 +133,52 @@ async function assertBranchSlugAvailable(branchSlug: string): Promise<void> {
   if (hasActiveCreate) {
     throwDuplicateBranch(branchSlug);
   }
+}
+
+async function assertReplicaCreateAllowed(input: z.infer<typeof branchInput>): Promise<ReplicaBranchCreatePolicy> {
+  if (input.parentBranchId) {
+    return { status: 'allow', lagMs: null };
+  }
+
+  const policy = getReplicaBranchCreatePolicy(await getReplicaFreshness());
+
+  if (policy.status === 'block' && !input.forceReplicaStale) {
+    throw new ORPCError('BAD_REQUEST', {
+      message: formatReplicaBlock(policy),
+    });
+  }
+
+  return policy;
+}
+
+function formatReplicaWarning(policy: ReplicaBranchCreatePolicy): string {
+  return `Dev replica is ${formatDuration(policy.lagMs ?? 0)} behind production. Branch may start stale.`;
+}
+
+function formatReplicaBlock(policy: ReplicaBranchCreatePolicy): string {
+  if (policy.lagMs === null) {
+    return 'Dev replica freshness is unknown. Refresh the replica or force branch creation.';
+  }
+
+  return `Dev replica is ${formatDuration(policy.lagMs)} behind production. Force branch creation to use stale production state.`;
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round(minutes / 60);
+
+  return `${hours}h`;
 }
 
 function getCreateBranchSlug(inputJson: string | null): string | null {

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -25,6 +25,7 @@ import { getBackupSettings, saveBackupSettings, setSetting } from './services/se
 import { getControlPlaneState, invalidateDevReplicaBase, saveServer, setStepStatus } from './services/setup-state-service';
 import { defaultCidrForHost, getProdAllowedCidr, normalizeAllowedCidr } from './services/prod-network-service';
 import { buildReplicaBaseHealth, buildReplicaFreshness } from './services/replica-service';
+import { getReplicaBranchCreatePolicy } from '#utils/replica-freshness-policy';
 
 let testDir: string;
 
@@ -186,6 +187,12 @@ describe('control plane database', function controlPlaneDatabase() {
     expect(freshness.lagMs).toBe(3000);
     expect(freshness.byteLag).toBe(16777216);
     expect(freshness.stale).toBe(false);
+  });
+
+  test('classifies replica freshness for branch creation', function testReplicaBranchCreatePolicy() {
+    expect(getReplicaBranchCreatePolicy({ lagMs: 9000 })).toEqual({ status: 'allow', lagMs: 9000 });
+    expect(getReplicaBranchCreatePolicy({ lagMs: 10_000 })).toEqual({ status: 'warn', lagMs: 10_000 });
+    expect(getReplicaBranchCreatePolicy({ lagMs: 60_001 })).toEqual({ status: 'block', lagMs: 60_001 });
   });
 
   test('accepts healthy dev replica base signals', function testHealthyReplicaBaseSignals() {

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -11,10 +11,11 @@ import { getDb } from '../../db/client';
 import { runCommand } from './command-service';
 import { setStepStatus } from './setup-state-service';
 import { createBranchFromPgBackRest } from './pgbackrest-restore-service';
-import { cleanupOldReplicaBases, getReplicaBaseDataset } from './replica-service';
+import { cleanupOldReplicaBases, getReplicaBaseDataset, getReplicaFreshness } from './replica-service';
 import { createLocalDockerBranch, deleteLocalDockerBranch, deleteLocalDockerBranchResources, isLocalDockerMode } from './local-docker-service';
 import { createJob, getActiveJobs } from './job-service';
 import { getBranchConnectionHost } from './branch-network-service';
+import { getReplicaBranchCreatePolicy } from '#utils/replica-freshness-policy';
 
 const PROJECT_NAME = 'prod';
 
@@ -26,6 +27,7 @@ export interface CreateBranchInput {
   ttlHours?: number | null;
   branchPassword?: string | null;
   preferredPort?: number | null;
+  forceReplicaStale?: boolean;
 }
 
 export interface CreatePreviewBranchInput {
@@ -83,6 +85,7 @@ export async function createBranchFromBase(input: CreateBranchInput): Promise<Cr
   }
 
   await ensureBranchSourceReady(source.slug);
+  await ensureReplicaFreshEnough(source.slug, Boolean(input.forceReplicaStale));
   try {
     if (isLocalDockerMode()) {
       const result = await createLocalDockerBranch({
@@ -466,6 +469,26 @@ async function ensureBranchSourceReady(sourceSlug: string): Promise<void> {
   }
 }
 
+async function ensureReplicaFreshEnough(sourceSlug: string, forced: boolean): Promise<void> {
+  if (sourceSlug !== 'production') {
+    return;
+  }
+
+  const policy = getReplicaBranchCreatePolicy(await getReplicaFreshness());
+
+  if (policy.status === 'block' && !forced) {
+    throw new Error(formatReplicaStaleBlockMessage(policy.lagMs));
+  }
+}
+
+function formatReplicaStaleBlockMessage(lagMs: number | null): string {
+  if (lagMs === null) {
+    return 'Dev replica freshness is unknown. Refresh the replica or force branch creation.';
+  }
+
+  return `Dev replica is ${formatDuration(lagMs)} behind production. Force branch creation to use stale production state.`;
+}
+
 export async function deleteBranch(input: DeleteBranchInput): Promise<DeleteBranchResult> {
   const db = getDb();
   await assertBranchHasNoChildren(input.id);
@@ -769,6 +792,24 @@ function parseOptionalExpiry(value: string | null | undefined): string | null {
   }
 
   return expiresAt.toISOString();
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.round(seconds / 60);
+
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+
+  const hours = Math.round(minutes / 60);
+
+  return `${hours}h`;
 }
 
 function hasActiveBranchJob(branchId: number, branchSlug: string, jobs: Awaited<ReturnType<typeof getActiveJobs>>): boolean {

--- a/src/server/services/job-handlers.ts
+++ b/src/server/services/job-handlers.ts
@@ -12,6 +12,7 @@ const branchInput = z.object({
   parentBranchId: z.number().int().positive().nullable().optional(),
   ttlHours: z.number().positive().nullable().optional(),
   expiresAt: z.string().nullable().optional(),
+  forceReplicaStale: z.boolean().optional(),
 });
 
 const branchIdInput = z.object({

--- a/src/utils/replica-freshness-policy.ts
+++ b/src/utils/replica-freshness-policy.ts
@@ -1,0 +1,29 @@
+export const REPLICA_BRANCH_WARN_MS = 10_000;
+export const REPLICA_BRANCH_BLOCK_MS = 60_000;
+
+export type ReplicaBranchCreateStatus = 'allow' | 'warn' | 'block';
+
+export interface ReplicaBranchFreshness {
+  lagMs: number | null;
+}
+
+export interface ReplicaBranchCreatePolicy {
+  status: ReplicaBranchCreateStatus;
+  lagMs: number | null;
+}
+
+export function getReplicaBranchCreatePolicy(
+  freshness: ReplicaBranchFreshness | null | undefined
+): ReplicaBranchCreatePolicy {
+  const lagMs = freshness?.lagMs ?? null;
+
+  if (lagMs === null || lagMs < REPLICA_BRANCH_WARN_MS) {
+    return { status: 'allow', lagMs };
+  }
+
+  if (lagMs <= REPLICA_BRANCH_BLOCK_MS) {
+    return { status: 'warn', lagMs };
+  }
+
+  return { status: 'block', lagMs };
+}

--- a/src/web/routes/index.tsx
+++ b/src/web/routes/index.tsx
@@ -2,9 +2,10 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { FormEvent } from 'react';
 import { useEffect, useState } from 'react';
-import { GitBranch, Loader2 } from 'lucide-react';
+import { AlertTriangle, GitBranch, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '#web/components/ui/button';
+import { Checkbox } from '#web/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -27,6 +28,7 @@ import {
   BranchTreePanel,
 } from '#web/components/control-plane';
 import { orpc } from '#web/lib/api-client';
+import { getReplicaBranchCreatePolicy, type ReplicaBranchCreatePolicy } from '#utils/replica-freshness-policy';
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -41,6 +43,7 @@ function HomePage() {
   const [branchName, setBranchName] = useState('');
   const [parentBranchId, setParentBranchId] = useState('production');
   const [ttlHours, setTtlHours] = useState('none');
+  const [forceReplicaStale, setForceReplicaStale] = useState(false);
   const activeJobs = dashboard.data?.jobs.filter(function isActive(job) {
     return job.status === 'queued' || job.status === 'running';
   }).length ?? 0;
@@ -73,6 +76,7 @@ function HomePage() {
     setBranchName('');
     setParentBranchId('production');
     setTtlHours('none');
+    setForceReplicaStale(false);
     void dashboard.refetch();
     setCreateModalOpen(true);
   }
@@ -93,8 +97,13 @@ function HomePage() {
         name,
         parentBranchId: parentBranchId !== 'production' ? Number(parentBranchId) : null,
         ttlHours: ttlHours !== 'none' ? Number(ttlHours) : null,
+        forceReplicaStale,
       });
-      toast.info(`Creating branch ${name}.`);
+      if (result.replicaWarning) {
+        toast.warning(result.replicaWarning);
+      } else {
+        toast.info(`Creating branch ${name}.`);
+      }
       setCreateModalOpen(false);
     } catch (error: any) {
       toast.error(error?.message || 'Could not create branch.');
@@ -145,7 +154,13 @@ function HomePage() {
 
             <div className="mt-5 grid gap-2">
               <Label>Parent branch</Label>
-              <Select value={parentBranchId} onValueChange={setParentBranchId}>
+              <Select
+                value={parentBranchId}
+                onValueChange={function changeParentBranch(value) {
+                  setParentBranchId(value);
+                  setForceReplicaStale(false);
+                }}
+              >
                 <SelectTrigger className="h-9 w-full">
                   <SelectValue />
                 </SelectTrigger>
@@ -161,9 +176,11 @@ function HomePage() {
                 </SelectContent>
               </Select>
               {parentBranchId === 'production' && shouldShowReplicaFreshnessInfo(state.replicaFreshness) ? (
-                <p className="text-xs text-muted-foreground">
-                  {formatReplicaFreshnessInfo(state.replicaFreshness)}
-                </p>
+                <ReplicaFreshnessNotice
+                  policy={getReplicaBranchCreatePolicy(state.replicaFreshness)}
+                  forceReplicaStale={forceReplicaStale}
+                  onForceReplicaStaleChange={setForceReplicaStale}
+                />
               ) : null}
             </div>
 
@@ -206,7 +223,7 @@ function HomePage() {
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={createBranch.isPending || !branchName.trim()}>
+              <Button type="submit" disabled={createBranch.isPending || !branchName.trim() || isBlockedReplicaCreate(state.replicaFreshness, parentBranchId, forceReplicaStale)}>
                 {createBranch.isPending ? <Loader2 className="animate-spin" /> : <GitBranch />}
                 Create
               </Button>
@@ -229,12 +246,70 @@ function LoadingPage(props: Readonly<{ message: string }>) {
   );
 }
 
+function ReplicaFreshnessNotice(props: Readonly<{
+  policy: ReplicaBranchCreatePolicy;
+  forceReplicaStale: boolean;
+  onForceReplicaStaleChange: (value: boolean) => void;
+}>) {
+  if (props.policy.status === 'allow') {
+    if (props.policy.lagMs === null) {
+      return null;
+    }
+
+    return (
+      <p className="text-xs text-muted-foreground">
+        {formatReplicaFreshnessInfo({ lagMs: props.policy.lagMs })}
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-900 dark:text-amber-200">
+      <div className="flex gap-2">
+        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+        <p>{formatReplicaPolicyMessage(props.policy)}</p>
+      </div>
+      {props.policy.status === 'block' ? (
+        <label className="mt-3 flex items-center gap-2">
+          <Checkbox
+            checked={props.forceReplicaStale}
+            onCheckedChange={function changeForceReplicaStale(checked) {
+              props.onForceReplicaStaleChange(checked === true);
+            }}
+          />
+          Create from stale replica
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
 function shouldShowReplicaFreshnessInfo(freshness: Readonly<{ lagMs: number | null }> | null | undefined): freshness is Readonly<{ lagMs: number }> {
   return freshness?.lagMs !== null && freshness?.lagMs !== undefined;
 }
 
 function formatReplicaFreshnessInfo(freshness: Readonly<{ lagMs: number }>): string {
   return `New branch will use production state from about ${formatDuration(freshness.lagMs)} ago.`;
+}
+
+function formatReplicaPolicyMessage(policy: ReplicaBranchCreatePolicy): string {
+  if (policy.status === 'warn') {
+    return `Dev replica is ${formatDuration(policy.lagMs ?? 0)} behind production. Branch may start stale.`;
+  }
+
+  return `Dev replica is ${formatDuration(policy.lagMs ?? 0)} behind production. Create from stale replica to continue.`;
+}
+
+function isBlockedReplicaCreate(
+  freshness: Readonly<{ lagMs: number | null }> | null | undefined,
+  parentBranchId: string,
+  forceReplicaStale: boolean
+): boolean {
+  if (parentBranchId !== 'production') {
+    return false;
+  }
+
+  return getReplicaBranchCreatePolicy(freshness).status === 'block' && !forceReplicaStale;
 }
 
 function formatDuration(ms: number): string {


### PR DESCRIPTION
## Summary
- add shared replica branch-create lag policy: allow under 10s, warn 10s-60s, block over 60s unless forced
- enforce stale replica guard before branch create jobs enqueue and again when jobs run
- show create-branch warning and force checkbox in the dashboard modal

## API routes, procedures, contracts
- Updated ORPC `branches.create` input with optional `forceReplicaStale?: boolean`
- Updated `branches.create` response with nullable `replicaWarning` for warn-level lag
- No routes deleted

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`

Closes #97