### PR TITLE
fix(replica): align replica health stale threshold

### DIFF
--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -221,7 +221,7 @@ describe('control plane database', function controlPlaneDatabase() {
       initialReplayLsn: '0/2000000',
       currentReplayLsn: '0/2000000',
       replayPaused: true,
-      replayedAt: '2026-05-16T09:59:00.000Z',
+      replayedAt: '2026-05-16T09:58:59.000Z',
       replayTimelineId: 2,
       productionTimelineId: 1,
       slotRetainedWalBytes: 2 * 1024 * 1024 * 1024,

--- a/src/server/services/replica-service.ts
+++ b/src/server/services/replica-service.ts
@@ -12,13 +12,14 @@ import { runCommand, runSshCommand } from './command-service';
 import { getSetting, setSetting } from './settings-service';
 import { setStepStatus } from './setup-state-service';
 import { createLocalDockerReplicaBase, isLocalDockerMode } from './local-docker-service';
+import { REPLICA_BRANCH_BLOCK_MS } from '#utils/replica-freshness-policy';
 
 const PROJECT_NAME = 'prod';
 const BASE_BRANCH_NAME = 'base';
 const BASE_DATASET_PREFIX = `${PROJECT_NAME}.${BASE_BRANCH_NAME}-`;
 const REPLICATION_USER = 'velo_replica';
 const REPLICATION_SLOT = 'velo_replica_base';
-const STALE_REPLICA_MS = 30_000;
+const STALE_REPLICA_MS = REPLICA_BRANCH_BLOCK_MS;
 const MAX_SLOT_RETAINED_WAL_BYTES = 1024 * 1024 * 1024;
 
 export interface ReplicaResult {


### PR DESCRIPTION
## Summary
- use the shared branch-create block threshold for replica base health checks
- keep health tests above the new stale cutoff

## API routes, procedures, contracts
- No API routes, procedures, or contracts changed

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`