### PR TITLE
fix(replica): avoid idle replay lag health failures

### DIFF
--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -221,7 +221,7 @@ describe('control plane database', function controlPlaneDatabase() {
       initialReplayLsn: '0/2000000',
       currentReplayLsn: '0/2000000',
       replayPaused: true,
-      replayedAt: '2026-05-16T09:58:59.000Z',
+      replayedAt: '2026-05-16T09:59:00.000Z',
       replayTimelineId: 2,
       productionTimelineId: 1,
       slotRetainedWalBytes: 2 * 1024 * 1024 * 1024,
@@ -233,7 +233,6 @@ describe('control plane database', function controlPlaneDatabase() {
       'WAL receiver is not streaming',
       'replay LSN is not advancing',
       'WAL replay is paused',
-      'replica replay lag is too high',
       'replica timeline does not follow production',
       'replication slot retained WAL is too large',
     ]);

--- a/src/server/services/replica-service.ts
+++ b/src/server/services/replica-service.ts
@@ -13,13 +13,12 @@ import { getSetting, setSetting } from './settings-service';
 import { setStepStatus } from './setup-state-service';
 import { createLocalDockerReplicaBase, isLocalDockerMode } from './local-docker-service';
 import { REPLICA_BRANCH_BLOCK_MS } from '#utils/replica-freshness-policy';
-
 const PROJECT_NAME = 'prod';
 const BASE_BRANCH_NAME = 'base';
 const BASE_DATASET_PREFIX = `${PROJECT_NAME}.${BASE_BRANCH_NAME}-`;
 const REPLICATION_USER = 'velo_replica';
 const REPLICATION_SLOT = 'velo_replica_base';
-const STALE_REPLICA_MS = REPLICA_BRANCH_BLOCK_MS;
+const REPLICA_REPLAY_ADVANCE_TIMEOUT_MS = 60_000;
 const MAX_SLOT_RETAINED_WAL_BYTES = 1024 * 1024 * 1024;
 
 export interface ReplicaResult {
@@ -289,10 +288,6 @@ export function buildReplicaBaseHealth(input: ReplicaBaseHealthInput): ReplicaBa
     errors.push('WAL replay is paused');
   }
 
-  if (lagMs === null || lagMs > STALE_REPLICA_MS) {
-    errors.push('replica replay lag is too high');
-  }
-
   if (
     input.productionTimelineId === null
     || input.replayTimelineId === null
@@ -421,7 +416,7 @@ async function waitForReplicaReplayAdvance(
   const start = Date.now();
   let state = await getDevBaseHealthState(docker, containerId);
 
-  while (Date.now() - start < STALE_REPLICA_MS) {
+  while (Date.now() - start < REPLICA_REPLAY_ADVANCE_TIMEOUT_MS) {
     if (state.replayLsn && state.replayLsn !== initialReplayLsn) {
       return state;
     }
@@ -601,7 +596,7 @@ export function buildReplicaFreshness(
     replayedAt,
     lagMs,
     byteLag: getWalByteLag(prodCurrentLsn, devReplayLsn),
-    stale: lagMs === null ? false : lagMs > STALE_REPLICA_MS,
+    stale: lagMs === null ? false : lagMs > REPLICA_BRANCH_BLOCK_MS,
   };
 }
 


### PR DESCRIPTION
## Summary
- stop failing replica base setup on last transaction replay timestamp lag
- keep LSN advancement, streaming, timeline, and slot checks as hard health requirements
- keep freshness stale status tied to branch-create block threshold

## API routes, procedures, contracts
- No API routes, procedures, or contracts changed

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`