### PR TITLE
test(v2): add auth and branch access smoke

### DIFF
--- a/scripts/e2e/hetzner-suite.ts
+++ b/scripts/e2e/hetzner-suite.ts
@@ -605,6 +605,25 @@ async function assertBranchPostgresPrivate(branch: Branch): Promise<void> {
 
   await assertCommandOk(result, `docker inspect branch port ${branch.slug}`);
   assert(result.stdout === '127.0.0.1', `${branch.slug} Postgres should bind localhost, got ${result.stdout}`);
+
+  await assertBranchPostgresRejectsBadPassword(branch);
+}
+
+async function assertBranchPostgresRejectsBadPassword(branch: Branch): Promise<void> {
+  assert(branch.connectionUrl, `${branch.slug} connection URL should be set`);
+  const url = new URL(branch.connectionUrl);
+  url.password = `wrong-${RUN_ID}`;
+
+  const result = await runCommand([
+    'psql',
+    url.toString(),
+    '-v',
+    'ON_ERROR_STOP=1',
+    '-c',
+    'select 1',
+  ], 30000);
+
+  assert(result.exitCode !== 0, `${branch.slug} PostgreSQL should reject bad password`);
 }
 
 async function assertZfsDatasetExists(dataset: string): Promise<void> {

--- a/scripts/test-release-artifact.sh
+++ b/scripts/test-release-artifact.sh
@@ -50,20 +50,48 @@ HOST=127.0.0.1 \
 PORT="$PORT" \
 NODE_ENV=production \
 VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" \
+VELO_BASIC_AUTH_USERNAME=test \
+VELO_BASIC_AUTH_PASSWORD=test \
 BETTER_AUTH_SECRET=testtesttesttesttesttesttesttest \
 BETTER_AUTH_URL="http://127.0.0.1:$PORT" \
 bun src/server/web-runtime.ts >"$WORK_DIR/server.log" 2>&1 &
 SERVER_PID="$!"
 
-for _ in $(seq 1 30); do
-  if curl -fsS -I "http://127.0.0.1:$PORT" >/dev/null \
-    && curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null \
-    && curl -fsS -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve" >/dev/null; then
-    echo "release artifact smoke passed"
-    exit 0
+for attempt in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    break
   fi
+
+  if [ "$attempt" = "30" ]; then
+    cat "$WORK_DIR/server.log"
+    exit 1
+  fi
+
   sleep 1
 done
 
-cat "$WORK_DIR/server.log"
-exit 1
+http_status() {
+  curl -sS -o /dev/null -w '%{http_code}' "$@"
+}
+
+assert_status() {
+  expected="$1"
+  shift
+  actual="$(http_status "$@")"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "expected HTTP $expected, got $actual: $*"
+    cat "$WORK_DIR/server.log"
+    exit 1
+  fi
+}
+
+assert_status 200 "http://127.0.0.1:$PORT/healthz"
+assert_status 401 -I "http://127.0.0.1:$PORT"
+assert_status 401 -u bad:bad -I "http://127.0.0.1:$PORT"
+assert_status 200 -u test:test -I "http://127.0.0.1:$PORT"
+assert_status 401 -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
+assert_status 401 -u bad:bad -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
+assert_status 200 -u test:test -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
+
+echo "release artifact smoke passed"


### PR DESCRIPTION
## Summary
- add release artifact smoke checks for Basic Auth on web and dashboard API routes
- add Hetzner E2E check that branch Postgres rejects bad direct credentials

## API routes / procedures / contracts
- no API routes, procedures, or contracts changed
- smoke coverage now asserts `/api/v1/dashboard/retrieve` rejects unauthenticated and bad-auth requests when Basic Auth is configured

## Checks
- `bun run typecheck`
- `bun run test`
- `bash -n scripts/test-release-artifact.sh scripts/e2e-hetzner.sh scripts/ci-hetzner.sh`
- `scripts/test-release-artifact.sh`

Closes #95