### PR TITLE
feat(auth): add single password login

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "@tanstack/react-start": "^1.167.53",
         "@tanstack/router-plugin": "^1.167.30",
         "@vitejs/plugin-react": "^6.0.1",
-        "better-auth": "^1.6.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -108,24 +107,6 @@
 
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
-    "@better-auth/core": ["@better-auth/core@1.6.9", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w=="],
-
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-Lcco5hOGrMgc4XKAkvB6x72eQm4wCcya8IevMg4wBHY9W9GVg8pu23rpRX6VsVQSO4Ux13S7lFwUWtF7/r9aKw=="],
-
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "kysely": "^0.28.14" }, "optionalPeers": ["kysely"] }, "sha512-gyjuuxJtZ4o9G9z9q4kqn24X2kvMSp7F+KHogYxF03SnXY/2WleAcuj57iC4wP3e9mGDbjPOrnM5K6Kr3Ktdpw=="],
-
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0" } }, "sha512-XmIG4tUnOXZ+KEcWjHUjOI9Z5donD09dC2t/AQTXifAUIqx7cySg86w0KTM09ArzAxRx1fCqO36Wkt5nULnrkQ=="],
-
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-h+AiRJ/TsBSi+ZDjySASBpbJ/9QCXBre34PSKgCz7QmTHrFM9Cg2EM4AM7LjR5lPXipEE+2rWPBc9wfnUBjhcw=="],
-
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-XHks01ntK20orqK/jICq8wmEbJ/zT6dct49Fk8zTQKN9QNGDc+Ix5+7z/Kvui0DXGFf790GfvRozquzaLtXa8Q=="],
-
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.9", "", { "peerDependencies": { "@better-auth/core": "^1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21" } }, "sha512-0u5zkhSCAQFoN3DHvUkLHOF6MBbVTDAa6mU8mhPwiysdz1x21vMzhzfaAKN/ZGWaQ09v91/F+2qu42G/bhUV4A=="],
-
-    "@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
-
-    "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
-
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.64.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.4", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-6+xRpZaWuHXEqnhBjae+VmQI9Uaqw5Uzu/ScpO+W7ww9Zp3lHSNBoNjFcUxhrCyc7pRGQzyDjhKzloqrPHERiQ=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
@@ -184,11 +165,11 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
-    "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
-    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -209,8 +190,6 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
-
-    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
     "@orpc/client": ["@orpc/client@1.14.0", "", { "dependencies": { "@orpc/shared": "1.14.0", "@orpc/standard-server": "1.14.0", "@orpc/standard-server-fetch": "1.14.0", "@orpc/standard-server-peer": "1.14.0" } }, "sha512-TYVcj1s5bN9adggeqIXFdIdoBBUAMUxQwMNv6YagjiaZkGtqWUYd1Y1vU0Rn/9xHWF2+0hBZNUKUmP5qrQhIAw=="],
 
@@ -562,10 +541,6 @@
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
-    "better-auth": ["better-auth@1.6.9", "", { "dependencies": { "@better-auth/core": "1.6.9", "@better-auth/drizzle-adapter": "1.6.9", "@better-auth/kysely-adapter": "1.6.9", "@better-auth/memory-adapter": "1.6.9", "@better-auth/mongo-adapter": "1.6.9", "@better-auth/prisma-adapter": "1.6.9", "@better-auth/telemetry": "1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA=="],
-
-    "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
-
     "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
@@ -679,8 +654,6 @@
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
-
-    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1004,8 +977,6 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
-
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -1138,7 +1109,7 @@
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
-    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+    "rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -1346,13 +1317,9 @@
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
-    "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
-
-    "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -1386,15 +1353,9 @@
 
     "dotenv-expand/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
-    "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
-    "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "h3-v2/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 

--- a/install.md
+++ b/install.md
@@ -25,7 +25,6 @@ Ask once for missing values:
 
 Generate if missing:
 
-- app username: `admin`
 - app password: random 24+ chars
 - install dir: `/opt/velo`
 - port: `3000`
@@ -73,7 +72,6 @@ VELO_DIR="${VELO_DIR:-/opt/velo}"
 VELO_PORT="${VELO_PORT:-3000}"
 VELO_PUBLIC_URL="${VELO_PUBLIC_URL:-http://$DEV_HOST:$VELO_PORT}"
 REMOTE_KEY_PATH="${REMOTE_KEY_PATH:-/root/.ssh/velo-prod}"
-APP_USERNAME="${APP_USERNAME:-admin}"
 APP_PASSWORD="${APP_PASSWORD:-$(openssl rand -base64 24)}"
 BACKUP_MODE="${BACKUP_MODE:-local}"
 ```
@@ -220,6 +218,7 @@ git reset --hard '$VELO_REF'
 git clean -fd -e node_modules -e .velo
 bun install --frozen-lockfile
 VELO_DB='$VELO_DIR/.velo/velo.sqlite' bun run db:migrate
+APP_PASSWORD='$APP_PASSWORD' VELO_DB='$VELO_DIR/.velo/velo.sqlite' bun run auth:set-password
 bun run web:build
 "
 ```
@@ -232,13 +231,8 @@ bun run web:build
 ssh -i "$SSH_KEY" "$SSH_USER@$DEV_HOST" "
 set -euo pipefail
 umask 077
-if [ ! -f /etc/velo.env ]; then
-  printf 'BETTER_AUTH_SECRET=%s\n' \"\$(openssl rand -base64 48)\" >/etc/velo.env
-fi
-grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' '$VELO_PUBLIC_URL' >>/etc/velo.env
-sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
-printf 'VELO_BASIC_AUTH_USERNAME=%s\n' '$APP_USERNAME' >>/etc/velo.env
-printf 'VELO_BASIC_AUTH_PASSWORD=%s\n' '$APP_PASSWORD' >>/etc/velo.env
+touch /etc/velo.env
+chmod 600 /etc/velo.env
 "
 ```
 
@@ -358,13 +352,13 @@ systemctl restart velo-web
 
 ```bash
 ssh -i "$SSH_KEY" "$SSH_USER@$DEV_HOST" \
-  "systemctl is-active --quiet velo-web && curl -fsS -u '$APP_USERNAME:$APP_PASSWORD' -I 'http://127.0.0.1:$VELO_PORT' >/dev/null"
+  "systemctl is-active --quiet velo-web && curl -fsS -I 'http://127.0.0.1:$VELO_PORT/login' >/dev/null"
 
 ssh -i "$SSH_KEY" "$SSH_USER@$DEV_HOST" \
   "curl -fsS 'http://127.0.0.1:$VELO_PORT/healthz?ready=1' >/dev/null"
 
 ssh -i "$SSH_KEY" "$SSH_USER@$DEV_HOST" \
-  "curl -fsS -u '$APP_USERNAME:$APP_PASSWORD' -H 'content-type: application/json' -d '{}' 'http://127.0.0.1:$VELO_PORT/api/v1/dashboard/retrieve' >/dev/null"
+  "curl -fsS -c /tmp/velo-cookie -H 'content-type: application/json' -d '{\"password\":\"'$APP_PASSWORD'\"}' 'http://127.0.0.1:$VELO_PORT/api/auth/login' >/dev/null && curl -fsS -b /tmp/velo-cookie -H 'content-type: application/json' -d '{}' 'http://127.0.0.1:$VELO_PORT/api/v1/dashboard/retrieve' >/dev/null"
 
 ssh -i "$SSH_KEY" "$SSH_USER@$PROD_HOST" \
   "systemctl is-active --quiet postgresql && sudo -u postgres pg_isready -d postgres && sudo -u postgres pgbackrest --stanza=main info >/dev/null"
@@ -400,7 +394,6 @@ Expected:
 Return:
 
 - Velo URL
-- app username
 - app password
 - prod connection URL
 - dev branch connection URL

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "deploy:main": "scripts/deploy-main.sh",
     "deploy:dev": "scripts/deploy-dev.sh",
     "e2e:hetzner": "scripts/e2e-hetzner.sh",
+    "auth:set-password": "bun run src/server/auth-cli.ts",
     "db:migrate": "bun run src/db/migrate.ts",
     "db:generate": "bun run db:migrate && kysely-codegen --camel-case --dialect bun-sqlite --url ${VELO_DB:-$HOME/.velo/velo.sqlite} --out-file src/db/generated.ts",
     "typecheck": "tsgo --noEmit"
@@ -95,7 +96,6 @@
     "@tanstack/react-start": "^1.167.53",
     "@tanstack/router-plugin": "^1.167.30",
     "@vitejs/plugin-react": "^6.0.1",
-    "better-auth": "^1.6.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -9,6 +9,7 @@ VELO_HOST="${VELO_HOST:-0.0.0.0}"
 VELO_PORT="${VELO_PORT:-3000}"
 VELO_DB="${VELO_DB:-$VELO_DEPLOY_DIR/.velo/velo.sqlite}"
 VELO_PUBLIC_URL="${VELO_PUBLIC_URL:-http://$VELO_DEPLOY_HOST:$VELO_PORT}"
+VELO_APP_PASSWORD="${VELO_APP_PASSWORD:-$(openssl rand -base64 24)}"
 
 SSH_ARGS=(
   -i "$VELO_DEPLOY_KEY"
@@ -45,15 +46,12 @@ VELO_STATE_DIR=\"${VELO_DB%/*}\"
 mkdir -p -m 700 \"\$VELO_STATE_DIR\"
 chmod 700 \"\$VELO_STATE_DIR\"
 VELO_DB='$VELO_DB' bun run db:migrate
+APP_PASSWORD='$VELO_APP_PASSWORD' VELO_DB='$VELO_DB' bun run auth:set-password
 bun run web:build
 
-if [ ! -f /etc/velo.env ]; then
-  umask 077
-  printf 'BETTER_AUTH_SECRET=%s\n' \"\$(openssl rand -base64 48)\" >/etc/velo.env
-fi
-
-grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' '$VELO_PUBLIC_URL' >>/etc/velo.env
-sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
+umask 077
+touch /etc/velo.env
+chmod 600 /etc/velo.env
 
 cat >/etc/systemd/system/velo-web.service <<SERVICE
 [Unit]
@@ -94,3 +92,4 @@ systemctl is-active --quiet velo-web
 
 ssh "${SSH_ARGS[@]}" "$REMOTE" "curl -fsS -I 'http://127.0.0.1:$VELO_PORT' >/dev/null"
 echo "Deployed: http://$VELO_DEPLOY_HOST:$VELO_PORT"
+echo "App password: $VELO_APP_PASSWORD"

--- a/scripts/deploy-hetzner.sh
+++ b/scripts/deploy-hetzner.sh
@@ -11,6 +11,7 @@ VELO_PORT="${VELO_PORT:-3000}"
 VELO_DEPLOY_DIR="${VELO_DEPLOY_DIR:-${VELO_DEV_DIR:-/opt/velo}}"
 VELO_REMOTE_KEY_PATH="${VELO_REMOTE_KEY_PATH:-/root/.ssh/frost-e2e-ci}"
 VELO_SSH_KNOWN_HOSTS_FILE="${VELO_SSH_KNOWN_HOSTS_FILE:-$HOME/.ssh/known_hosts}"
+VELO_APP_PASSWORD="${VELO_APP_PASSWORD:-$(openssl rand -base64 24)}"
 
 SSH_ARGS=(
   -i "$VELO_DEPLOY_KEY"
@@ -119,14 +120,12 @@ git reset --hard $(shell_quote "$VELO_REF")
 git clean -fd -e node_modules -e .velo
 bun install --frozen-lockfile
 VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") bun run db:migrate
+APP_PASSWORD=$(shell_quote "$VELO_APP_PASSWORD") VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") bun run auth:set-password
 bun run web:build
 
 umask 077
-if [ ! -f /etc/velo.env ]; then
-  printf 'BETTER_AUTH_SECRET=%s\n' \"\$(openssl rand -base64 48)\" >/etc/velo.env
-fi
-grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' $(shell_quote "http://$VELO_DEPLOY_DEV_HOST:$VELO_PORT") >>/etc/velo.env
-sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
+touch /etc/velo.env
+chmod 600 /etc/velo.env
 
 cat >/etc/systemd/system/velo-web.service <<SERVICE
 [Unit]
@@ -288,6 +287,7 @@ main() {
   check_servers
 
   echo "Deployed Velo: http://$VELO_DEPLOY_DEV_HOST:$VELO_PORT"
+  echo "App password: $VELO_APP_PASSWORD"
 }
 
 main "$@"

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -40,8 +40,7 @@ VELO_LOCAL_DEV_PORT=$VELO_LOCAL_DEV_PORT
 VELO_LOCAL_MINIO_PORT=$VELO_LOCAL_MINIO_PORT
 VELO_LOCAL_MINIO_CONSOLE_PORT=$VELO_LOCAL_MINIO_CONSOLE_PORT
 VELO_LOCAL_WEB_PORT=$VELO_LOCAL_WEB_PORT
-BETTER_AUTH_URL=$BETTER_AUTH_URL
-BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET
+VELO_LOCAL_APP_PASSWORD=$VELO_LOCAL_APP_PASSWORD
 EOF
   chmod 600 "$LOCAL_ENV_FILE"
 }
@@ -83,8 +82,7 @@ ensure_ports() {
       export VELO_LOCAL_WEB_PORT="$(get_free_port)"
     fi
   fi
-  export BETTER_AUTH_URL="${BETTER_AUTH_URL:-http://localhost:$VELO_LOCAL_WEB_PORT}"
-  export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-$(openssl rand -base64 48)}"
+  export VELO_LOCAL_APP_PASSWORD="${VELO_LOCAL_APP_PASSWORD:-velo-local-password}"
   save_env_file
 }
 
@@ -435,6 +433,7 @@ up() {
   seed_prod
   seed_pgbackrest
   bun run db:migrate
+  APP_PASSWORD="$VELO_LOCAL_APP_PASSWORD" bun run auth:set-password
   bun run src/server/local-docker-seed.ts
 }
 
@@ -469,6 +468,7 @@ case "${1:-up}" in
     ensure_ports
     compose ps
     printf '\napp: http://localhost:%s\n' "$VELO_LOCAL_WEB_PORT"
+    printf 'password: %s\n' "$VELO_LOCAL_APP_PASSWORD"
     printf 'prod: postgresql://postgres:postgres@localhost:%s/postgres?sslmode=disable\n' "$VELO_LOCAL_PROD_PORT"
     printf 'dev:  postgresql://postgres:postgres@localhost:%s/postgres?sslmode=disable\n' "$VELO_LOCAL_DEV_PORT"
     printf 's3:   https://localhost:%s\n' "$VELO_LOCAL_MINIO_PORT"

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -468,7 +468,7 @@ case "${1:-up}" in
     ensure_ports
     compose ps
     printf '\napp: http://localhost:%s\n' "$VELO_LOCAL_WEB_PORT"
-    printf 'password: %s\n' "$VELO_LOCAL_APP_PASSWORD"
+    printf 'auth: skipped on localhost\n'
     printf 'prod: postgresql://postgres:postgres@localhost:%s/postgres?sslmode=disable\n' "$VELO_LOCAL_PROD_PORT"
     printf 'dev:  postgresql://postgres:postgres@localhost:%s/postgres?sslmode=disable\n' "$VELO_LOCAL_DEV_PORT"
     printf 's3:   https://localhost:%s\n' "$VELO_LOCAL_MINIO_PORT"

--- a/scripts/remote-dev.sh
+++ b/scripts/remote-dev.sh
@@ -10,6 +10,7 @@ VELO_HOST="${VELO_HOST:-0.0.0.0}"
 VELO_PORT="${VELO_PORT:-3000}"
 VELO_DB="${VELO_DB:-$VELO_DATA_DIR/.velo/velo.sqlite}"
 VELO_PUBLIC_URL="${VELO_PUBLIC_URL:-http://$VELO_REMOTE_HOST:$VELO_PORT}"
+VELO_APP_PASSWORD="${VELO_APP_PASSWORD:-velo-dev-password}"
 
 SSH_ARGS=(
   -i "$VELO_REMOTE_KEY"
@@ -36,13 +37,11 @@ VELO_STATE_DIR=\"${VELO_DB%/*}\"
 mkdir -p -m 700 \"\$VELO_STATE_DIR\"
 chmod 700 \"\$VELO_STATE_DIR\"
 VELO_DB='$VELO_DB' bun run db:migrate
+APP_PASSWORD='$VELO_APP_PASSWORD' VELO_DB='$VELO_DB' bun run auth:set-password
 
-if [ ! -f /etc/velo.env ]; then
-  umask 077
-  printf 'BETTER_AUTH_SECRET=%s\n' \"\$(openssl rand -base64 48)\" >/etc/velo.env
-fi
-
-grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' '$VELO_PUBLIC_URL' >>/etc/velo.env
+umask 077
+touch /etc/velo.env
+chmod 600 /etc/velo.env
 
 cat >/etc/systemd/system/velo-web-dev.service <<SERVICE
 [Unit]
@@ -86,3 +85,4 @@ exit 1
 
 curl -fsS -I "http://$VELO_REMOTE_HOST:$VELO_PORT" >/dev/null
 echo "Remote dev ready: http://$VELO_REMOTE_HOST:$VELO_PORT"
+echo "App password: $VELO_APP_PASSWORD"

--- a/scripts/test-release-artifact.sh
+++ b/scripts/test-release-artifact.sh
@@ -43,6 +43,7 @@ test -f dist/server/assets/migrations/001_initial.sql
 bun install --production --frozen-lockfile
 VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run db:migrate
 VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run db:migrate
+APP_PASSWORD=test-password VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run auth:set-password
 test "$(file_mode "$WORK_DIR/app/.velo")" = "700"
 test "$(file_mode "$WORK_DIR/app/.velo/velo.sqlite")" = "600"
 
@@ -50,10 +51,6 @@ HOST=127.0.0.1 \
 PORT="$PORT" \
 NODE_ENV=production \
 VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" \
-VELO_BASIC_AUTH_USERNAME=test \
-VELO_BASIC_AUTH_PASSWORD=test \
-BETTER_AUTH_SECRET=testtesttesttesttesttesttesttest \
-BETTER_AUTH_URL="http://127.0.0.1:$PORT" \
 bun src/server/web-runtime.ts >"$WORK_DIR/server.log" 2>&1 &
 SERVER_PID="$!"
 
@@ -87,11 +84,11 @@ assert_status() {
 }
 
 assert_status 200 "http://127.0.0.1:$PORT/healthz"
-assert_status 401 -I "http://127.0.0.1:$PORT"
-assert_status 401 -u bad:bad -I "http://127.0.0.1:$PORT"
-assert_status 200 -u test:test -I "http://127.0.0.1:$PORT"
+assert_status 302 -I "http://127.0.0.1:$PORT"
+assert_status 200 -I "http://127.0.0.1:$PORT/login"
 assert_status 401 -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
-assert_status 401 -u bad:bad -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
-assert_status 200 -u test:test -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
+assert_status 401 -H 'content-type: application/json' -d '{"password":"bad-password"}' "http://127.0.0.1:$PORT/api/auth/login"
+curl -fsS -c "$WORK_DIR/cookie" -H 'content-type: application/json' -d '{"password":"test-password"}' "http://127.0.0.1:$PORT/api/auth/login" >/dev/null
+assert_status 200 -b "$WORK_DIR/cookie" -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
 
 echo "release artifact smoke passed"

--- a/src/server/auth-cli.ts
+++ b/src/server/auth-cli.ts
@@ -1,0 +1,10 @@
+import { setPassword } from './auth';
+
+const password = process.env.APP_PASSWORD || process.argv[2] || '';
+
+if (!password) {
+  throw new Error('Set APP_PASSWORD or pass password as the first argument.');
+}
+
+await setPassword(password);
+console.log('app password set');

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,17 +1,230 @@
-import { betterAuth } from 'better-auth';
-import { tanstackStartCookies } from 'better-auth/tanstack-start';
-import { getDb } from '../db/client';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { getSetting, setSetting } from './services/settings-service';
 
-export const auth = betterAuth({
-  baseURL: process.env.BETTER_AUTH_URL,
-  database: {
-    db: getDb(),
-    type: 'sqlite',
-    casing: 'snake',
-  },
-  secret: process.env.BETTER_AUTH_SECRET || 'velo-dev-secret-change-me',
-  emailAndPassword: {
-    enabled: true,
-  },
-  plugins: [tanstackStartCookies()],
-});
+const PASSWORD_HASH_KEY = 'auth.passwordHash';
+const SESSION_SECRET_KEY = 'auth.sessionSecret';
+const SESSION_COOKIE = 'velo_session';
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+const MIN_PASSWORD_LENGTH = 8;
+
+export interface AuthState {
+  configured: boolean;
+  authenticated: boolean;
+}
+
+interface SessionPayload {
+  exp: number;
+}
+
+export async function getAuthState(request: Request): Promise<AuthState> {
+  const configured = await isAuthConfigured();
+
+  if (!configured) {
+    return { configured, authenticated: false };
+  }
+
+  return {
+    configured,
+    authenticated: await isAuthenticated(request),
+  };
+}
+
+export async function isAuthConfigured(): Promise<boolean> {
+  return Boolean(await getSetting(PASSWORD_HASH_KEY));
+}
+
+export async function isAuthenticated(request: Request): Promise<boolean> {
+  const token = getCookie(request, SESSION_COOKIE);
+
+  if (!token) {
+    return false;
+  }
+
+  const secret = await getSetting(SESSION_SECRET_KEY);
+
+  if (!secret) {
+    return false;
+  }
+
+  return verifySessionToken(token, secret);
+}
+
+export async function setupPassword(password: string): Promise<string> {
+  if (await isAuthConfigured()) {
+    throw new Error('Auth is already configured.');
+  }
+
+  return setPassword(password);
+}
+
+export async function setPassword(password: string): Promise<string> {
+  validatePassword(password);
+
+  const [hash, secret] = await Promise.all([
+    Bun.password.hash(password),
+    rotateSessionSecret(),
+  ]);
+
+  await setSetting(PASSWORD_HASH_KEY, hash);
+
+  return createSessionToken(secret);
+}
+
+export async function verifyPassword(password: string): Promise<boolean> {
+  const hash = await getSetting(PASSWORD_HASH_KEY);
+
+  if (!hash) {
+    return false;
+  }
+
+  return Bun.password.verify(password, hash);
+}
+
+export async function createSession(password: string): Promise<string | null> {
+  if (!(await verifyPassword(password))) {
+    return null;
+  }
+
+  const secret = await ensureSessionSecret();
+
+  return createSessionToken(secret);
+}
+
+export function sessionCookie(token: string): string {
+  return serializeCookie(SESSION_COOKIE, token, {
+    httpOnly: true,
+    maxAge: SESSION_MAX_AGE_SECONDS,
+    path: '/',
+    sameSite: 'Lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
+}
+
+export function clearSessionCookie(): string {
+  return serializeCookie(SESSION_COOKIE, '', {
+    httpOnly: true,
+    maxAge: 0,
+    path: '/',
+    sameSite: 'Lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
+}
+
+export function validatePassword(password: string): void {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    throw new Error(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+  }
+}
+
+async function ensureSessionSecret(): Promise<string> {
+  const existing = await getSetting(SESSION_SECRET_KEY);
+
+  if (existing) {
+    return existing;
+  }
+
+  const secret = randomBytes(32).toString('base64url');
+  await setSetting(SESSION_SECRET_KEY, secret);
+
+  return secret;
+}
+
+async function rotateSessionSecret(): Promise<string> {
+  const secret = randomBytes(32).toString('base64url');
+  await setSetting(SESSION_SECRET_KEY, secret);
+
+  return secret;
+}
+
+function createSessionToken(secret: string): string {
+  const payload = encodeJson({
+    exp: Math.floor(Date.now() / 1000) + SESSION_MAX_AGE_SECONDS,
+  });
+  const signature = sign(payload, secret);
+
+  return `${payload}.${signature}`;
+}
+
+function verifySessionToken(token: string, secret: string): boolean {
+  const [payload, signature] = token.split('.');
+
+  if (!payload || !signature) {
+    return false;
+  }
+
+  if (!safeEqual(signature, sign(payload, secret))) {
+    return false;
+  }
+
+  const session = decodeJson(payload);
+
+  return Boolean(session && session.exp > Math.floor(Date.now() / 1000));
+}
+
+function sign(value: string, secret: string): string {
+  return createHmac('sha256', secret).update(value).digest('base64url');
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function encodeJson(value: SessionPayload): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function decodeJson(value: string): SessionPayload | null {
+  try {
+    return JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as SessionPayload;
+  } catch {
+    return null;
+  }
+}
+
+function getCookie(request: Request, name: string): string | null {
+  const cookie = request.headers.get('cookie') || '';
+
+  for (const part of cookie.split(';')) {
+    const [rawKey, ...rawValue] = part.trim().split('=');
+
+    if (rawKey === name) {
+      return rawValue.join('=');
+    }
+  }
+
+  return null;
+}
+
+interface CookieOptions {
+  httpOnly: boolean;
+  maxAge: number;
+  path: string;
+  sameSite: 'Lax';
+  secure: boolean;
+}
+
+function serializeCookie(name: string, value: string, options: CookieOptions): string {
+  const parts = [
+    `${name}=${value}`,
+    `Max-Age=${options.maxAge}`,
+    `Path=${options.path}`,
+    `SameSite=${options.sameSite}`,
+  ];
+
+  if (options.httpOnly) {
+    parts.push('HttpOnly');
+  }
+
+  if (options.secure) {
+    parts.push('Secure');
+  }
+
+  return parts.join('; ');
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -17,6 +17,10 @@ interface SessionPayload {
 }
 
 export async function getAuthState(request: Request): Promise<AuthState> {
+  if (isLocalAuthBypass(request)) {
+    return { configured: true, authenticated: true };
+  }
+
   const configured = await isAuthConfigured();
 
   if (!configured) {
@@ -34,6 +38,10 @@ export async function isAuthConfigured(): Promise<boolean> {
 }
 
 export async function isAuthenticated(request: Request): Promise<boolean> {
+  if (isLocalAuthBypass(request)) {
+    return true;
+  }
+
   const token = getCookie(request, SESSION_COOKIE);
 
   if (!token) {
@@ -80,7 +88,11 @@ export async function verifyPassword(password: string): Promise<boolean> {
   return Bun.password.verify(password, hash);
 }
 
-export async function createSession(password: string): Promise<string | null> {
+export async function createSession(password: string, request?: Request): Promise<string | null> {
+  if (request && isLocalAuthBypass(request)) {
+    return createSessionToken(await ensureSessionSecret());
+  }
+
   if (!(await verifyPassword(password))) {
     return null;
   }
@@ -88,6 +100,23 @@ export async function createSession(password: string): Promise<string | null> {
   const secret = await ensureSessionSecret();
 
   return createSessionToken(secret);
+}
+
+export function isLocalAuthBypass(request: Request): boolean {
+  if (process.env.VELO_AUTH_ALLOW_ANY_PASSWORD === '1') {
+    return true;
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+
+  const hostname = new URL(request.url).hostname;
+
+  return hostname === 'localhost'
+    || hostname === '127.0.0.1'
+    || hostname === '::1'
+    || hostname === '[::1]';
 }
 
 export function sessionCookie(token: string): string {

--- a/src/server/web-runtime.ts
+++ b/src/server/web-runtime.ts
@@ -3,6 +3,7 @@ import { join, normalize, relative } from 'node:path';
 import { Database } from 'bun:sqlite';
 import { getMigrationsDirectory, migrateDatabase } from '#db/migrate';
 import { getDatabasePath } from '#db/paths';
+import { getAuthState } from '#server/auth';
 import { getControlPlaneState } from '#server/services/setup-state-service';
 import { persistUpdateResult } from '#server/services/update-service';
 import { startUpdateScheduler } from '#server/services/update-scheduler';
@@ -37,16 +38,16 @@ Bun.serve({
       return healthResponse;
     }
 
-    const authResponse = requireBasicAuth(request);
-
-    if (authResponse) {
-      return authResponse;
-    }
-
     const staticResponse = await serveStaticAsset(request);
 
     if (staticResponse) {
       return staticResponse;
+    }
+
+    const authResponse = await requireAppAuth(request);
+
+    if (authResponse) {
+      return authResponse;
     }
 
     return serverEntry.default.fetch(request);
@@ -129,53 +130,61 @@ async function handleHealthCheck(request: Request): Promise<Response | null> {
   }, { status: ok ? 200 : 503 });
 }
 
-function requireBasicAuth(request: Request): Response | null {
-  const username = process.env.VELO_BASIC_AUTH_USERNAME || '';
-  const password = process.env.VELO_BASIC_AUTH_PASSWORD || '';
-
-  if (!username || !password) {
-    return null;
-  }
-
-  const header = request.headers.get('authorization') || '';
-  const prefix = 'Basic ';
-
-  if (!header.startsWith(prefix)) {
-    return unauthorizedResponse();
-  }
-
-  const decoded = Buffer.from(header.slice(prefix.length), 'base64').toString('utf8');
-  const separator = decoded.indexOf(':');
-
-  if (separator === -1) {
-    return unauthorizedResponse();
-  }
-
-  const providedUsername = decoded.slice(0, separator);
-  const providedPassword = decoded.slice(separator + 1);
-
-  if (providedUsername !== username || providedPassword !== password) {
-    return unauthorizedResponse();
-  }
-
-  return null;
-}
-
-function unauthorizedResponse(): Response {
-  return new Response('Unauthorized', {
-    status: 401,
-    headers: {
-      'WWW-Authenticate': 'Basic realm="Velo"',
-    },
-  });
-}
-
 function errorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
   }
 
   return String(error);
+}
+
+async function requireAppAuth(request: Request): Promise<Response | null> {
+  const url = new URL(request.url);
+
+  if (isPublicPath(url.pathname)) {
+    return null;
+  }
+
+  const auth = await getAuthState(request);
+
+  if (!auth.configured) {
+    if (url.pathname.startsWith('/api/')) {
+      return Response.json({ error: 'Auth setup required.' }, { status: 401 });
+    }
+
+    return redirect('/setup');
+  }
+
+  if (auth.authenticated) {
+    if (url.pathname === '/login' || url.pathname === '/setup') {
+      return redirect('/');
+    }
+
+    return null;
+  }
+
+  if (url.pathname.startsWith('/api/')) {
+    return Response.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  return redirect(`/login?next=${encodeURIComponent(url.pathname + url.search)}`);
+}
+
+function isPublicPath(pathname: string): boolean {
+  return pathname === '/healthz'
+    || pathname.startsWith('/api/auth/')
+    || pathname === '/api/auth'
+    || pathname === '/login'
+    || pathname === '/setup';
+}
+
+function redirect(pathname: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: pathname,
+    },
+  });
 }
 
 async function serveStaticAsset(request: Request): Promise<Response | null> {

--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -18,6 +18,7 @@ import {
   GitBranch,
   LayoutDashboard,
   Loader2,
+  LogOut,
   Menu,
   RefreshCw,
   RotateCcw,
@@ -70,6 +71,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '#web/components/ui/select';
+import { logout } from '#web/lib/auth-client';
 
 export type ServerRole = 'prod' | 'dev';
 
@@ -224,6 +226,11 @@ function SidebarContent(props: SidebarContentProps) {
     void navigate({ to: '/branch/$branchId/overview', params: { branchId: value } });
   }
 
+  async function handleLogout() {
+    await logout();
+    window.location.assign('/login');
+  }
+
   return (
     <div className={props.className}>
       <div className="hidden lg:block">
@@ -264,6 +271,13 @@ function SidebarContent(props: SidebarContentProps) {
           <NavItem icon={ArchiveRestore} label="Backup & Restore" href={backupHref} active={props.activeBranchPage === 'backup'} onNavigate={props.onNavigate} />
         </div>
       </SidebarSection>
+
+      <div className="mt-8">
+        <Button type="button" variant="outline" className="w-full justify-start" onClick={handleLogout}>
+          <LogOut />
+          Sign out
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/web/lib/auth-client.ts
+++ b/src/web/lib/auth-client.ts
@@ -1,0 +1,58 @@
+export interface AuthState {
+  configured: boolean;
+  authenticated: boolean;
+}
+
+export async function getAuthState(): Promise<AuthState> {
+  const response = await fetch('/api/auth/state', {
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Could not load auth state.');
+  }
+
+  return response.json() as Promise<AuthState>;
+}
+
+export async function setupAuth(password: string): Promise<void> {
+  await postAuth('/api/auth/setup', { password });
+}
+
+export async function login(password: string): Promise<void> {
+  await postAuth('/api/auth/login', { password });
+}
+
+export async function logout(): Promise<void> {
+  await postAuth('/api/auth/logout', {});
+}
+
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  await postAuth('/api/auth/password', { currentPassword, newPassword });
+}
+
+async function postAuth(url: string, body: Record<string, string>): Promise<void> {
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const error = await readError(response);
+    throw new Error(error);
+  }
+}
+
+async function readError(response: Response): Promise<string> {
+  try {
+    const body = await response.json() as { error?: string };
+
+    return body.error || 'Request failed.';
+  } catch {
+    return 'Request failed.';
+  }
+}

--- a/src/web/routeTree.gen.ts
+++ b/src/web/routeTree.gen.ts
@@ -9,7 +9,9 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SetupRouteImport } from './routes/setup'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as BranchBranchIdTablesRouteImport } from './routes/branch/$branchId/tables'
 import { Route as BranchBranchIdSqlRouteImport } from './routes/branch/$branchId/sql'
@@ -18,9 +20,19 @@ import { Route as BranchBranchIdBackupRestoreRouteImport } from './routes/branch
 import { Route as ApiV1SplatRouteImport } from './routes/api/v1/$'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 
+const SetupRoute = SetupRouteImport.update({
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SettingsRoute = SettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -62,7 +74,9 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
+  '/setup': typeof SetupRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
@@ -72,7 +86,9 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
+  '/setup': typeof SetupRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
@@ -83,7 +99,9 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
+  '/setup': typeof SetupRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
@@ -95,7 +113,9 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/login'
     | '/settings'
+    | '/setup'
     | '/api/auth/$'
     | '/api/v1/$'
     | '/branch/$branchId/backup-restore'
@@ -105,7 +125,9 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/login'
     | '/settings'
+    | '/setup'
     | '/api/auth/$'
     | '/api/v1/$'
     | '/branch/$branchId/backup-restore'
@@ -115,7 +137,9 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/login'
     | '/settings'
+    | '/setup'
     | '/api/auth/$'
     | '/api/v1/$'
     | '/branch/$branchId/backup-restore'
@@ -126,7 +150,9 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  LoginRoute: typeof LoginRoute
   SettingsRoute: typeof SettingsRoute
+  SetupRoute: typeof SetupRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiV1SplatRoute: typeof ApiV1SplatRoute
   BranchBranchIdBackupRestoreRoute: typeof BranchBranchIdBackupRestoreRoute
@@ -137,11 +163,25 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/settings': {
       id: '/settings'
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -198,7 +238,9 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  LoginRoute: LoginRoute,
   SettingsRoute: SettingsRoute,
+  SetupRoute: SetupRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiV1SplatRoute: ApiV1SplatRoute,
   BranchBranchIdBackupRestoreRoute: BranchBranchIdBackupRestoreRoute,

--- a/src/web/routes/__root.tsx
+++ b/src/web/routes/__root.tsx
@@ -1,13 +1,17 @@
 import type { ReactNode } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   Outlet,
   createRootRoute,
   HeadContent,
   Scripts,
+  useLocation,
+  useNavigate,
 } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
 import { Toaster } from '#web/components/ui/sonner';
+import { getAuthState, type AuthState } from '#web/lib/auth-client';
 import '../styles.css';
 
 export const Route = createRootRoute({
@@ -32,7 +36,9 @@ function RootComponent() {
   return (
     <QueryClientProvider client={queryClient}>
       <RootDocument>
-        <Outlet />
+        <AuthGate>
+          <Outlet />
+        </AuthGate>
       </RootDocument>
     </QueryClientProvider>
   );
@@ -50,5 +56,78 @@ function RootDocument(props: Readonly<{ children: ReactNode }>) {
         <Scripts />
       </body>
     </html>
+  );
+}
+
+function AuthGate(props: Readonly<{ children: ReactNode }>) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [auth, setAuth] = useState<AuthState | null>(null);
+  const pathname = location.pathname;
+  const isPublic = pathname === '/login' || pathname === '/setup';
+
+  useEffect(function loadAuthState() {
+    let active = true;
+
+    getAuthState()
+      .then(function setLoadedAuthState(nextAuth) {
+        if (active) {
+          setAuth(nextAuth);
+        }
+      })
+      .catch(function setFailedAuthState() {
+        if (active) {
+          setAuth({ configured: false, authenticated: false });
+        }
+      });
+
+    return function cancelLoadAuthState() {
+      active = false;
+    };
+  }, [pathname]);
+
+  useEffect(function redirectForAuthState() {
+    if (!auth) {
+      return;
+    }
+
+    if (!auth.configured && pathname !== '/setup') {
+      void navigate({ to: '/setup', replace: true });
+      return;
+    }
+
+    if (auth.configured && auth.authenticated && isPublic) {
+      void navigate({ to: '/', replace: true });
+      return;
+    }
+
+    if (auth.configured && !auth.authenticated && !isPublic) {
+      void navigate({ to: '/login', search: { next: pathname }, replace: true });
+    }
+  }, [auth, isPublic, navigate, pathname]);
+
+  if (!auth) {
+    return <RootLoading />;
+  }
+
+  if (!auth.configured && pathname !== '/setup') {
+    return <RootLoading />;
+  }
+
+  if (auth.configured && !auth.authenticated && !isPublic) {
+    return <RootLoading />;
+  }
+
+  return props.children;
+}
+
+function RootLoading() {
+  return (
+    <main className="grid min-h-screen place-items-center bg-background px-4 text-foreground">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="animate-spin" />
+        Loading...
+      </div>
+    </main>
   );
 }

--- a/src/web/routes/api/auth/$.ts
+++ b/src/web/routes/api/auth/$.ts
@@ -72,7 +72,7 @@ async function handleSetup(request: Request): Promise<Response> {
 
 async function handleLogin(request: Request): Promise<Response> {
   const { password } = await readPasswordBody(request);
-  const token = await createSession(password);
+  const token = await createSession(password, request);
 
   if (!token) {
     return Response.json({ error: 'Wrong password.' }, { status: 401 });

--- a/src/web/routes/api/auth/$.ts
+++ b/src/web/routes/api/auth/$.ts
@@ -1,5 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { auth } from '#server/auth';
+import {
+  clearSessionCookie,
+  createSession,
+  getAuthState,
+  isAuthenticated,
+  sessionCookie,
+  setPassword,
+  setupPassword,
+  verifyPassword,
+} from '#server/auth';
 
 export const Route = createFileRoute('/api/auth/$')({
   server: {
@@ -11,5 +20,115 @@ export const Route = createFileRoute('/api/auth/$')({
 });
 
 async function handleAuthRequest(context: { request: Request }) {
-  return auth.handler(context.request);
+  const url = new URL(context.request.url);
+  const action = url.pathname.replace(/^\/api\/auth\/?/, '') || 'state';
+
+  if (context.request.method === 'GET' && action === 'state') {
+    return Response.json(await getAuthState(context.request));
+  }
+
+  if (context.request.method !== 'POST') {
+    return Response.json({ error: 'Not found.' }, { status: 404 });
+  }
+
+  if (action === 'setup') {
+    return handleSetup(context.request);
+  }
+
+  if (action === 'login') {
+    return handleLogin(context.request);
+  }
+
+  if (action === 'logout') {
+    return Response.json({ ok: true }, {
+      headers: {
+        'Set-Cookie': clearSessionCookie(),
+      },
+    });
+  }
+
+  if (action === 'password') {
+    return handlePasswordChange(context.request);
+  }
+
+  return Response.json({ error: 'Not found.' }, { status: 404 });
+}
+
+async function handleSetup(request: Request): Promise<Response> {
+  const { password } = await readPasswordBody(request);
+
+  try {
+    const token = await setupPassword(password);
+
+    return Response.json({ ok: true }, {
+      headers: {
+        'Set-Cookie': sessionCookie(token),
+      },
+    });
+  } catch (error) {
+    return authError(error, 409);
+  }
+}
+
+async function handleLogin(request: Request): Promise<Response> {
+  const { password } = await readPasswordBody(request);
+  const token = await createSession(password);
+
+  if (!token) {
+    return Response.json({ error: 'Wrong password.' }, { status: 401 });
+  }
+
+  return Response.json({ ok: true }, {
+    headers: {
+      'Set-Cookie': sessionCookie(token),
+    },
+  });
+}
+
+async function handlePasswordChange(request: Request): Promise<Response> {
+  if (!(await isAuthenticated(request))) {
+    return Response.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
+
+  const body = await readJsonBody(request);
+  const currentPassword = String(body.currentPassword || '');
+  const newPassword = String(body.newPassword || '');
+
+  if (!(await verifyPassword(currentPassword))) {
+    return Response.json({ error: 'Current password is wrong.' }, { status: 401 });
+  }
+
+  try {
+    const token = await setPassword(newPassword);
+
+    return Response.json({ ok: true }, {
+      headers: {
+        'Set-Cookie': sessionCookie(token),
+      },
+    });
+  } catch (error) {
+    return authError(error, 400);
+  }
+}
+
+async function readPasswordBody(request: Request): Promise<{ password: string }> {
+  const body = await readJsonBody(request);
+
+  return {
+    password: String(body.password || ''),
+  };
+}
+
+async function readJsonBody(request: Request): Promise<Record<string, unknown>> {
+  try {
+    return await request.json() as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function authError(error: unknown, status: number): Response {
+  return Response.json({
+    error: error instanceof Error ? error.message : String(error),
+  }, { status });
 }

--- a/src/web/routes/api/v1/$.ts
+++ b/src/web/routes/api/v1/$.ts
@@ -3,6 +3,7 @@ import { onError } from '@orpc/server';
 import { createFileRoute } from '@tanstack/react-router';
 import { appRouter } from '#api/router';
 import { createOrpcContext } from '#api/context';
+import { getAuthState } from '#server/auth';
 import { jobHandlers } from '#server/services/job-handlers';
 import { startJobWorker, type JobWorker } from '#server/services/job-service';
 
@@ -24,6 +25,16 @@ export const Route = createFileRoute('/api/v1/$')({
 
 async function handleRpcRequest(context: { request: Request }) {
   startDevJobWorker();
+
+  const auth = await getAuthState(context.request);
+
+  if (!auth.configured) {
+    return Response.json({ error: 'Auth setup required.' }, { status: 401 });
+  }
+
+  if (!auth.authenticated) {
+    return Response.json({ error: 'Unauthorized.' }, { status: 401 });
+  }
 
   const { response } = await handler.handle(context.request, {
     prefix: '/api/v1',

--- a/src/web/routes/login.tsx
+++ b/src/web/routes/login.tsx
@@ -1,0 +1,81 @@
+import { createFileRoute, useSearch } from '@tanstack/react-router';
+import type { FormEvent, ReactNode } from 'react';
+import { useState } from 'react';
+import { Loader2, LogIn } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '#web/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '#web/components/ui/card';
+import { Input } from '#web/components/ui/input';
+import { Label } from '#web/components/ui/label';
+import { login } from '#web/lib/auth-client';
+
+export const Route = createFileRoute('/login')({
+  component: LoginPage,
+});
+
+function LoginPage() {
+  const search = useSearch({ from: '/login' }) as { next?: string };
+  const [password, setPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy(true);
+
+    try {
+      await login(password);
+      window.location.assign(safeNextPath(search.next));
+    } catch (error: any) {
+      toast.error(error?.message || 'Could not sign in.');
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AuthPage>
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Sign in</CardTitle>
+          <CardDescription>Enter the Velo password.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                autoFocus
+                value={password}
+                onChange={function updatePassword(event) {
+                  setPassword(event.target.value);
+                }}
+              />
+            </div>
+            <Button type="submit" disabled={busy || !password}>
+              {busy ? <Loader2 className="animate-spin" /> : <LogIn />}
+              Sign in
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </AuthPage>
+  );
+}
+
+function AuthPage(props: Readonly<{ children: ReactNode }>) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-background px-4 text-foreground">
+      {props.children}
+    </main>
+  );
+}
+
+function safeNextPath(next: string | undefined): string {
+  if (!next || !next.startsWith('/') || next.startsWith('//')) {
+    return '/';
+  }
+
+  return next;
+}

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
+import type { FormEvent, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
-import { Activity, AlertTriangle, ArchiveRestore, CheckCircle2, Database, ExternalLink, Loader2, RefreshCw } from 'lucide-react';
+import { Activity, AlertTriangle, ArchiveRestore, CheckCircle2, Database, ExternalLink, KeyRound, Loader2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   AlertDialog,
@@ -18,6 +18,7 @@ import { Badge } from '#web/components/ui/badge';
 import { Button } from '#web/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '#web/components/ui/card';
 import { Checkbox } from '#web/components/ui/checkbox';
+import { Input } from '#web/components/ui/input';
 import { Label } from '#web/components/ui/label';
 import {
   Select,
@@ -33,6 +34,7 @@ import {
   TabsTrigger,
 } from '#web/components/ui/tabs';
 import { api, orpc } from '#web/lib/api-client';
+import { changePassword } from '#web/lib/auth-client';
 import {
   AppSidebar,
   BackupPanel,
@@ -284,6 +286,10 @@ function SettingsPage() {
                   <RefreshCw />
                   Updates
                 </TabsTrigger>
+                <TabsTrigger className="pl-3 data-active:text-muted-foreground data-active:after:left-0 data-active:after:right-auto" value="security">
+                  <KeyRound />
+                  Security
+                </TabsTrigger>
                 <TabsTrigger className="pl-3 data-active:text-muted-foreground data-active:after:left-0 data-active:after:right-auto" value="jobs">
                   <Activity />
                   Jobs
@@ -317,6 +323,10 @@ function SettingsPage() {
 
               <TabsContent value="updates" className="min-w-0">
                 <UpdatePanel />
+              </TabsContent>
+
+              <TabsContent value="security" className="min-w-0">
+                <PasswordPanel />
               </TabsContent>
 
               <TabsContent value="jobs" className="min-w-0">
@@ -484,6 +494,89 @@ function OverviewRow(props: Readonly<{ icon: ReactNode; label: string; value: st
       </div>
       <StatusBadge status={props.status} />
     </div>
+  );
+}
+
+function PasswordPanel() {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (newPassword !== confirmPassword) {
+      toast.error('Passwords do not match.');
+      return;
+    }
+
+    setBusy(true);
+
+    try {
+      await changePassword(currentPassword, newPassword);
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      toast.success('Password changed.');
+    } catch (error: any) {
+      toast.error(error?.message || 'Could not change password.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Password</CardTitle>
+        <CardDescription>Change the app password</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="grid max-w-sm gap-4" onSubmit={handleSubmit}>
+          <div className="grid gap-2">
+            <Label htmlFor="current-password">Current password</Label>
+            <Input
+              id="current-password"
+              type="password"
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={function updateCurrentPassword(event) {
+                setCurrentPassword(event.target.value);
+              }}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="new-password">New password</Label>
+            <Input
+              id="new-password"
+              type="password"
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={function updateNewPassword(event) {
+                setNewPassword(event.target.value);
+              }}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="confirm-password">Confirm password</Label>
+            <Input
+              id="confirm-password"
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={function updateConfirmPassword(event) {
+                setConfirmPassword(event.target.value);
+              }}
+            />
+          </div>
+          <Button type="submit" disabled={busy || !currentPassword || !newPassword || !confirmPassword}>
+            {busy ? <Loader2 className="animate-spin" /> : <KeyRound />}
+            Change password
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/web/routes/setup.tsx
+++ b/src/web/routes/setup.tsx
@@ -1,0 +1,91 @@
+import { createFileRoute } from '@tanstack/react-router';
+import type { FormEvent, ReactNode } from 'react';
+import { useState } from 'react';
+import { Loader2, ShieldCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '#web/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '#web/components/ui/card';
+import { Input } from '#web/components/ui/input';
+import { Label } from '#web/components/ui/label';
+import { setupAuth } from '#web/lib/auth-client';
+
+export const Route = createFileRoute('/setup')({
+  component: SetupPage,
+});
+
+function SetupPage() {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (password !== confirmPassword) {
+      toast.error('Passwords do not match.');
+      return;
+    }
+
+    setBusy(true);
+
+    try {
+      await setupAuth(password);
+      window.location.assign('/');
+    } catch (error: any) {
+      toast.error(error?.message || 'Could not set password.');
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AuthPage>
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Protect Velo</CardTitle>
+          <CardDescription>Set one password for this install.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-4" onSubmit={handleSubmit}>
+            <div className="grid gap-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                autoFocus
+                value={password}
+                onChange={function updatePassword(event) {
+                  setPassword(event.target.value);
+                }}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="confirm-password">Confirm password</Label>
+              <Input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                value={confirmPassword}
+                onChange={function updateConfirmPassword(event) {
+                  setConfirmPassword(event.target.value);
+                }}
+              />
+            </div>
+            <Button type="submit" disabled={busy || !password || !confirmPassword}>
+              {busy ? <Loader2 className="animate-spin" /> : <ShieldCheck />}
+              Save password
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </AuthPage>
+  );
+}
+
+function AuthPage(props: Readonly<{ children: ReactNode }>) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-background px-4 text-foreground">
+      {props.children}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- replace Better Auth with a local single-password auth flow
- add setup, login, logout, and password change UI
- seed app password during install/deploy/local dev and keep only hashes in SQLite
- skip auth on localhost in non-production, or when `VELO_AUTH_ALLOW_ANY_PASSWORD=1`

## API routes and contracts
- added `GET /api/auth/state` returning `{ configured, authenticated }`
- added `POST /api/auth/setup` with `{ password }`, sets initial password and session cookie
- added `POST /api/auth/login` with `{ password }`, sets session cookie
- added `POST /api/auth/logout`, clears session cookie
- added `POST /api/auth/password` with `{ currentPassword, newPassword }`, requires session and rotates sessions
- updated `/api/v1/*` to return `401` unless auth is configured and session is valid, except local auth bypass
- removed Better Auth handler behavior from `/api/auth/*`

## Checks
- `bun run typecheck`
- `bun run web:build`
- `bun run test`
- `scripts/test-release-artifact.sh`
- local auth bypass smoke with temp DB
