### PR TITLE
feat(proxy): add branch tcp proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ It starts:
 - MinIO: `localhost:59000`
 - real pgBackRest backups and WAL archive to MinIO
 
-Local Docker is prod-like for backup and PITR work. Startup creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and can restore a temporary Postgres container from PITR. Local branch clones still use simple database copies unless they come from PITR. It does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev for that.
+Local Docker is prod-like for backup and PITR work. Startup creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and can restore a temporary Postgres container from PITR. Local branch clones run as separate Postgres containers and copy source data with `pg_dump`. It does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev for that.
 
 Each git branch gets one local environment by default. Ports are assigned once and stored in `.velo/local/<branch>/env`, so branches can run in parallel without port collisions. Use `VELO_LOCAL_INSTANCE=<name>` only when you need more than one environment for the same git branch.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ It starts:
 - MinIO: `localhost:59000`
 - real pgBackRest backups and WAL archive to MinIO
 
-Local Docker is prod-like for backup and PITR work. Startup creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and can restore a temporary Postgres container from PITR. Local branch clones run as separate Postgres containers and copy source data with `pg_dump`. It does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev for that.
+Local Docker is prod-like for backup and PITR work. Startup creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and can restore a temporary Postgres container from PITR. Local branch clones run as separate Postgres containers and copy source data with `pg_dump`. Branch connection strings point at the Go TCP proxy, which wakes stopped branches and stops idle ones. It does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev for that.
 
 Each git branch gets one local environment by default. Ports are assigned once and stored in `.velo/local/<branch>/env`, so branches can run in parallel without port collisions. Use `VELO_LOCAL_INSTANCE=<name>` only when you need more than one environment for the same git branch.
 
@@ -61,6 +61,13 @@ Useful commands:
 bun run local:up
 bun run local:status
 bun run local:down
+```
+
+Run the proxy manually when not using `local:dev`:
+
+```sh
+set -a; source .velo/local/<instance>/env; set +a
+VELO_INTERNAL_API_URL=http://127.0.0.1:$VELO_LOCAL_WEB_PORT/internal bun run proxy
 ```
 
 ### Remote Dev

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This starts:
 - local SQLite at `.velo/local-docker.sqlite`
 - real pgBackRest backups and WAL archive to MinIO
 
-Local Docker is prod-like for backup and PITR work. It creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and runs each local branch as its own Postgres container with source data copied by `pg_dump`. It still does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev before merging infra-sensitive work.
+Local Docker is prod-like for backup and PITR work. It creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and runs each local branch as its own Postgres container with source data copied by `pg_dump`. Branch connection strings point at the Go TCP proxy, which wakes stopped branches and stops idle ones. It still does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev before merging infra-sensitive work.
 
 Each git branch gets one local environment by default. Ports are assigned once and stored in `.velo/local/<branch>/env`, so multiple branches can run on the same computer without port collisions.
 
@@ -89,6 +89,13 @@ Useful local stack commands:
 bun run local:up
 bun run local:status
 bun run local:down
+```
+
+`bun run local:dev` starts the proxy. For a manual stack, start the web app, then run:
+
+```bash
+set -a; source .velo/local/<instance>/env; set +a
+VELO_INTERNAL_API_URL=http://127.0.0.1:$VELO_LOCAL_WEB_PORT/internal bun run proxy
 ```
 
 Useful checks:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This starts:
 - local SQLite at `.velo/local-docker.sqlite`
 - real pgBackRest backups and WAL archive to MinIO
 
-Local Docker is prod-like for backup and PITR work. It creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and runs each local branch as its own Postgres container with source data copied by `pg_dump`. Branch connection strings point at the Go TCP proxy, which wakes stopped branches and stops idle ones. It still does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev before merging infra-sensitive work.
+Local Docker is prod-like for backup and PITR work. It creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and runs each local branch as its own Postgres container with source data copied by `pg_dump`. Branch connection strings point at the Go TCP proxy, which wakes stopped branches and stops idle ones. In local timing runs, an idle-stopped branch woke and answered queries in about 256-268 ms. It still does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev before merging infra-sensitive work.
 
 Each git branch gets one local environment by default. Ports are assigned once and stored in `.velo/local/<branch>/env`, so multiple branches can run on the same computer without port collisions.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This starts:
 - local SQLite at `.velo/local-docker.sqlite`
 - real pgBackRest backups and WAL archive to MinIO
 
-Local Docker is prod-like for backup and PITR work. It creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and can restore a temporary Postgres container from PITR. It still does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev before merging infra-sensitive work.
+Local Docker is prod-like for backup and PITR work. It creates a pgBackRest stanza, checks WAL archiving, runs a full backup, and runs each local branch as its own Postgres container with source data copied by `pg_dump`. It still does not prove SSH, systemd, Hetzner networking, R2, or ZFS COW. Use remote dev before merging infra-sensitive work.
 
 Each git branch gets one local environment by default. Ports are assigned once and stored in `.velo/local/<branch>/env`, so multiple branches can run on the same computer without port collisions.
 

--- a/cmd/velo-proxy/main.go
+++ b/cmd/velo-proxy/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/elitan/velo/internal/proxy"
+)
+
+func main() {
+	apiURL := flag.String("api", envString("VELO_INTERNAL_API_URL", "http://127.0.0.1:3000/internal"), "internal Velo API URL")
+	token := flag.String("token", envString("VELO_INTERNAL_TOKEN", ""), "internal API token")
+	bind := flag.String("bind", envString("VELO_PROXY_BIND", "127.0.0.1"), "proxy listen address")
+	refreshSeconds := flag.Int("refresh-seconds", envInt("VELO_PROXY_REFRESH_SECONDS", 2), "branch map refresh interval")
+	idleSeconds := flag.Int("idle-seconds", envInt("VELO_PROXY_IDLE_SECONDS", 1800), "idle stop timeout, 0 disables")
+	flag.Parse()
+
+	if *token == "" {
+		log.Fatal("VELO_INTERNAL_TOKEN is required")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := proxy.NewServer(proxy.Config{
+		APIURL:          *apiURL,
+		Token:           *token,
+		BindAddress:     *bind,
+		RefreshInterval: time.Duration(*refreshSeconds) * time.Second,
+		IdleTimeout:     time.Duration(*idleSeconds) * time.Second,
+		Logger:          log.Default(),
+	})
+
+	if err := server.Run(ctx); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func envString(name string, fallback string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}
+
+func envInt(name string, fallback int) int {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	var parsed int
+	if _, err := fmt.Sscanf(value, "%d", &parsed); err != nil {
+		return fallback
+	}
+
+	return parsed
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/elitan/velo
+
+go 1.23

--- a/internal/proxy/client.go
+++ b/internal/proxy/client.go
@@ -1,0 +1,117 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Branch struct {
+	ID           int    `json:"id"`
+	Slug         string `json:"slug"`
+	Status       string `json:"status"`
+	ProxyPort    int    `json:"proxyPort"`
+	BackendPort  int    `json:"backendPort"`
+	LastActiveAt string `json:"lastActiveAt"`
+}
+
+type APIClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func NewAPIClient(baseURL string, token string) *APIClient {
+	return &APIClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http: &http.Client{
+			Timeout: 2 * time.Minute,
+		},
+	}
+}
+
+func (client *APIClient) ListBranches(ctx context.Context) ([]Branch, error) {
+	var response struct {
+		Branches []Branch `json:"branches"`
+	}
+
+	if err := client.request(ctx, http.MethodGet, "/proxy/branches", nil, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Branches, nil
+}
+
+func (client *APIClient) StartBranch(ctx context.Context, branchID int) (int, error) {
+	var response struct {
+		BackendPort int `json:"backendPort"`
+	}
+
+	if err := client.request(ctx, http.MethodPost, fmt.Sprintf("/branches/%d/start", branchID), nil, &response); err != nil {
+		return 0, err
+	}
+
+	if response.BackendPort == 0 {
+		return 0, fmt.Errorf("branch %d returned empty backend port", branchID)
+	}
+
+	return response.BackendPort, nil
+}
+
+func (client *APIClient) StopBranch(ctx context.Context, branchID int) error {
+	return client.request(ctx, http.MethodPost, fmt.Sprintf("/branches/%d/stop", branchID), nil, nil)
+}
+
+func (client *APIClient) TouchBranch(ctx context.Context, branchID int) error {
+	return client.request(ctx, http.MethodPost, fmt.Sprintf("/branches/%d/touch", branchID), nil, nil)
+}
+
+func (client *APIClient) request(ctx context.Context, method string, path string, input any, output any) error {
+	var body *bytes.Reader
+
+	if input == nil {
+		body = bytes.NewReader(nil)
+	} else {
+		payload, err := json.Marshal(input)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(payload)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, client.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("authorization", "Bearer "+client.token)
+	request.Header.Set("content-type", "application/json")
+
+	response, err := client.http.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		var errorResponse struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(response.Body).Decode(&errorResponse)
+		if errorResponse.Error != "" {
+			return fmt.Errorf("%s %s: %s", method, path, errorResponse.Error)
+		}
+		return fmt.Errorf("%s %s: HTTP %d", method, path, response.StatusCode)
+	}
+
+	if output == nil {
+		return nil
+	}
+
+	return json.NewDecoder(response.Body).Decode(output)
+}

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -1,0 +1,407 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"sync"
+	"time"
+)
+
+type Config struct {
+	APIURL          string
+	Token           string
+	BindAddress     string
+	RefreshInterval time.Duration
+	IdleTimeout     time.Duration
+	Logger          *log.Logger
+}
+
+type Server struct {
+	config    Config
+	client    *APIClient
+	logger    *log.Logger
+	mu        sync.Mutex
+	branches  map[int]Branch
+	ports     map[int]int
+	listeners map[int]net.Listener
+	active    map[int]int
+	lastSeen  map[int]time.Time
+	wakeLocks map[int]*sync.Mutex
+	stopping  map[int]bool
+}
+
+func NewServer(config Config) *Server {
+	if config.RefreshInterval <= 0 {
+		config.RefreshInterval = 2 * time.Second
+	}
+	if config.BindAddress == "" {
+		config.BindAddress = "127.0.0.1"
+	}
+	if config.Logger == nil {
+		config.Logger = log.Default()
+	}
+
+	return &Server{
+		config:    config,
+		client:    NewAPIClient(config.APIURL, config.Token),
+		logger:    config.Logger,
+		branches:  map[int]Branch{},
+		ports:     map[int]int{},
+		listeners: map[int]net.Listener{},
+		active:    map[int]int{},
+		lastSeen:  map[int]time.Time{},
+		wakeLocks: map[int]*sync.Mutex{},
+		stopping:  map[int]bool{},
+	}
+}
+
+func (server *Server) Run(ctx context.Context) error {
+	if err := server.refresh(ctx); err != nil {
+		server.logger.Printf("initial refresh failed: %v", err)
+	}
+
+	refreshTicker := time.NewTicker(server.config.RefreshInterval)
+	defer refreshTicker.Stop()
+
+	idleTicker := time.NewTicker(server.idleCheckInterval())
+	defer idleTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			server.closeListeners()
+			return nil
+		case <-refreshTicker.C:
+			if err := server.refresh(ctx); err != nil {
+				server.logger.Printf("refresh failed: %v", err)
+			}
+		case <-idleTicker.C:
+			server.checkIdleBranches(ctx)
+		}
+	}
+}
+
+func (server *Server) refresh(ctx context.Context) error {
+	branches, err := server.client.ListBranches(ctx)
+	if err != nil {
+		return err
+	}
+
+	nextPorts := map[int]bool{}
+
+	server.mu.Lock()
+	for _, branch := range branches {
+		server.branches[branch.ID] = branch
+		server.ports[branch.ProxyPort] = branch.ID
+		nextPorts[branch.ProxyPort] = true
+
+		if _, ok := server.lastSeen[branch.ID]; !ok {
+			server.lastSeen[branch.ID] = parseBranchTime(branch.LastActiveAt)
+		}
+		if _, ok := server.wakeLocks[branch.ID]; !ok {
+			server.wakeLocks[branch.ID] = &sync.Mutex{}
+		}
+	}
+
+	for port, listener := range server.listeners {
+		if !nextPorts[port] {
+			_ = listener.Close()
+			delete(server.listeners, port)
+			delete(server.ports, port)
+		}
+	}
+
+	var listenPorts []int
+	for _, branch := range branches {
+		if _, ok := server.listeners[branch.ProxyPort]; !ok {
+			listenPorts = append(listenPorts, branch.ProxyPort)
+		}
+	}
+	server.mu.Unlock()
+
+	for _, port := range listenPorts {
+		if err := server.startListener(port); err != nil {
+			server.logger.Printf("listen %d failed: %v", port, err)
+		}
+	}
+
+	return nil
+}
+
+func (server *Server) startListener(port int) error {
+	address := fmt.Sprintf("%s:%d", server.config.BindAddress, port)
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return err
+	}
+
+	server.mu.Lock()
+	server.listeners[port] = listener
+	server.mu.Unlock()
+
+	server.logger.Printf("listening on %s", address)
+
+	go server.acceptLoop(port, listener)
+	return nil
+}
+
+func (server *Server) acceptLoop(port int, listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+
+		go server.handleConnection(port, conn)
+	}
+}
+
+func (server *Server) handleConnection(port int, clientConn net.Conn) {
+	branch, ok := server.branchByPort(port)
+	if !ok {
+		_ = clientConn.Close()
+		return
+	}
+
+	server.markActive(branch.ID)
+	defer server.markInactive(branch.ID)
+	defer clientConn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if err := server.client.TouchBranch(ctx, branch.ID); err != nil {
+		server.logger.Printf("touch branch %s failed: %v", branch.Slug, err)
+	}
+
+	backendPort := branch.BackendPort
+	dialTimeout := 2 * time.Second
+	if branch.Status == "stopped" {
+		startedPort, err := server.startBranch(ctx, branch, false)
+		if err != nil {
+			server.logger.Printf("start branch %s failed: %v", branch.Slug, err)
+			return
+		}
+		backendPort = startedPort
+		dialTimeout = 30 * time.Second
+	}
+
+	backendConn, err := dialBackend(backendPort, dialTimeout)
+	if err != nil {
+		startedPort, startErr := server.startBranch(ctx, branch, true)
+		if startErr != nil {
+			server.logger.Printf("start branch %s after dial failure failed: %v", branch.Slug, startErr)
+			return
+		}
+
+		backendConn, err = dialBackend(startedPort, 30*time.Second)
+		if err != nil {
+			server.logger.Printf("dial branch %s backend failed: %v", branch.Slug, err)
+			return
+		}
+	}
+	defer backendConn.Close()
+
+	copyBoth(clientConn, backendConn)
+}
+
+func (server *Server) startBranch(ctx context.Context, branch Branch, force bool) (int, error) {
+	lock := server.branchLock(branch.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	current, ok := server.branchByID(branch.ID)
+	if !force && ok && current.Status != "stopped" {
+		return current.BackendPort, nil
+	}
+
+	backendPort, err := server.client.StartBranch(ctx, branch.ID)
+	if err != nil {
+		return 0, err
+	}
+
+	server.mu.Lock()
+	branch.Status = "running"
+	branch.BackendPort = backendPort
+	server.branches[branch.ID] = branch
+	server.mu.Unlock()
+
+	return backendPort, nil
+}
+
+func (server *Server) checkIdleBranches(ctx context.Context) {
+	if server.config.IdleTimeout <= 0 {
+		return
+	}
+
+	now := time.Now()
+	var targets []Branch
+
+	server.mu.Lock()
+	for _, branch := range server.branches {
+		if branch.Status != "running" || server.active[branch.ID] > 0 || server.stopping[branch.ID] {
+			continue
+		}
+
+		lastSeen := server.lastSeen[branch.ID]
+		if lastSeen.IsZero() {
+			lastSeen = parseBranchTime(branch.LastActiveAt)
+		}
+		if lastSeen.IsZero() || now.Sub(lastSeen) < server.config.IdleTimeout {
+			continue
+		}
+
+		server.stopping[branch.ID] = true
+		targets = append(targets, branch)
+	}
+	server.mu.Unlock()
+
+	for _, branch := range targets {
+		go server.stopBranch(ctx, branch)
+	}
+}
+
+func (server *Server) stopBranch(ctx context.Context, branch Branch) {
+	stopCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	err := server.client.StopBranch(stopCtx, branch.ID)
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	delete(server.stopping, branch.ID)
+
+	if err != nil {
+		server.logger.Printf("stop branch %s failed: %v", branch.Slug, err)
+		return
+	}
+
+	branch.Status = "stopped"
+	server.branches[branch.ID] = branch
+	server.logger.Printf("stopped idle branch %s", branch.Slug)
+}
+
+func (server *Server) branchByPort(port int) (Branch, bool) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	branchID, ok := server.ports[port]
+	if !ok {
+		return Branch{}, false
+	}
+
+	branch, ok := server.branches[branchID]
+	return branch, ok
+}
+
+func (server *Server) branchByID(branchID int) (Branch, bool) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	branch, ok := server.branches[branchID]
+	return branch, ok
+}
+
+func (server *Server) branchLock(branchID int) *sync.Mutex {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	lock, ok := server.wakeLocks[branchID]
+	if !ok {
+		lock = &sync.Mutex{}
+		server.wakeLocks[branchID] = lock
+	}
+
+	return lock
+}
+
+func (server *Server) markActive(branchID int) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	server.active[branchID]++
+	server.lastSeen[branchID] = time.Now()
+}
+
+func (server *Server) markInactive(branchID int) {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	if server.active[branchID] > 0 {
+		server.active[branchID]--
+	}
+	server.lastSeen[branchID] = time.Now()
+}
+
+func (server *Server) closeListeners() {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+
+	for port, listener := range server.listeners {
+		_ = listener.Close()
+		delete(server.listeners, port)
+	}
+}
+
+func (server *Server) idleCheckInterval() time.Duration {
+	if server.config.IdleTimeout > 0 && server.config.IdleTimeout < 10*time.Second {
+		return server.config.IdleTimeout / 2
+	}
+
+	return 10 * time.Second
+}
+
+func dialBackend(port int, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	address := fmt.Sprintf("127.0.0.1:%d", port)
+	var lastErr error
+
+	for {
+		conn, err := net.DialTimeout("tcp", address, time.Second)
+		if err == nil {
+			return conn, nil
+		}
+
+		lastErr = err
+		if time.Now().After(deadline) {
+			return nil, lastErr
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func parseBranchTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}
+	}
+
+	return parsed
+}
+
+func copyBoth(first net.Conn, second net.Conn) {
+	done := make(chan struct{}, 2)
+
+	go func() {
+		_, _ = io.Copy(first, second)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		_, _ = io.Copy(second, first)
+		done <- struct{}{}
+	}()
+
+	<-done
+	_ = first.Close()
+	_ = second.Close()
+	<-done
+}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -1,0 +1,219 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestProxyWakesStoppedBranchAndForwardsTraffic(t *testing.T) {
+	backendPort := startEchoBackend(t)
+	proxyPort := freePort(t)
+	state := &fakeState{
+		branch: Branch{
+			ID:           7,
+			Slug:         "dev",
+			Status:       "stopped",
+			ProxyPort:    proxyPort,
+			BackendPort:  backendPort,
+			LastActiveAt: time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
+		},
+	}
+	api := startFakeAPI(t, state)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := NewServer(Config{
+		APIURL:          api.URL + "/internal",
+		Token:           "test-token",
+		BindAddress:     "127.0.0.1",
+		RefreshInterval: 20 * time.Millisecond,
+		IdleTimeout:     0,
+		Logger:          log.New(io.Discard, "", 0),
+	})
+	go func() {
+		_ = server.Run(ctx)
+	}()
+
+	waitForDial(t, proxyPort)
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	buffer := make([]byte, 5)
+	if _, err := io.ReadFull(conn, buffer); err != nil {
+		t.Fatal(err)
+	}
+
+	if string(buffer) != "hello" {
+		t.Fatalf("expected echo, got %q", string(buffer))
+	}
+	if state.startCount == 0 {
+		t.Fatal("expected proxy to start stopped branch")
+	}
+	if state.touchCount == 0 {
+		t.Fatal("expected proxy to touch branch activity")
+	}
+}
+
+func TestProxyStopsIdleBranch(t *testing.T) {
+	proxyPort := freePort(t)
+	state := &fakeState{
+		branch: Branch{
+			ID:           8,
+			Slug:         "idle",
+			Status:       "running",
+			ProxyPort:    proxyPort,
+			BackendPort:  freePort(t),
+			LastActiveAt: time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
+		},
+	}
+	api := startFakeAPI(t, state)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := NewServer(Config{
+		APIURL:          api.URL + "/internal",
+		Token:           "test-token",
+		BindAddress:     "127.0.0.1",
+		RefreshInterval: 20 * time.Millisecond,
+		IdleTimeout:     20 * time.Millisecond,
+		Logger:          log.New(io.Discard, "", 0),
+	})
+	go func() {
+		_ = server.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if state.stopCount > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatal("expected proxy to stop idle branch")
+}
+
+type fakeState struct {
+	mu         sync.Mutex
+	branch     Branch
+	startCount int
+	stopCount  int
+	touchCount int
+}
+
+func startFakeAPI(t *testing.T, state *fakeState) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/internal/proxy/branches":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"branches": []Branch{state.branch},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/internal/branches/%d/start", state.branch.ID):
+			state.startCount++
+			state.branch.Status = "running"
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          state.branch.ID,
+				"backendPort": state.branch.BackendPort,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/internal/branches/%d/stop", state.branch.ID):
+			state.stopCount++
+			state.branch.Status = "stopped"
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      state.branch.ID,
+				"stopped": true,
+			})
+		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/internal/branches/%d/touch", state.branch.ID):
+			state.touchCount++
+			state.branch.LastActiveAt = time.Now().Format(time.RFC3339Nano)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      state.branch.ID,
+				"touched": true,
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func startEchoBackend(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForDial(t *testing.T, port int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 20*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("proxy did not listen on port %d", port)
+}

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -70,6 +70,64 @@ func TestProxyWakesStoppedBranchAndForwardsTraffic(t *testing.T) {
 	}
 }
 
+func TestProxyRetriesStartWhenRunningBackendIsStale(t *testing.T) {
+	staleBackendPort := freePort(t)
+	nextBackendPort := startEchoBackend(t)
+	proxyPort := freePort(t)
+	state := &fakeState{
+		branch: Branch{
+			ID:           9,
+			Slug:         "stale",
+			Status:       "running",
+			ProxyPort:    proxyPort,
+			BackendPort:  staleBackendPort,
+			LastActiveAt: time.Now().Format(time.RFC3339Nano),
+		},
+		startBackendPort: nextBackendPort,
+	}
+	api := startFakeAPI(t, state)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := NewServer(Config{
+		APIURL:          api.URL + "/internal",
+		Token:           "test-token",
+		BindAddress:     "127.0.0.1",
+		RefreshInterval: 20 * time.Millisecond,
+		IdleTimeout:     0,
+		Logger:          log.New(io.Discard, "", 0),
+	})
+	go func() {
+		_ = server.Run(ctx)
+	}()
+
+	waitForDial(t, proxyPort)
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	buffer := make([]byte, 5)
+	if _, err := io.ReadFull(conn, buffer); err != nil {
+		t.Fatal(err)
+	}
+
+	if string(buffer) != "hello" {
+		t.Fatalf("expected echo, got %q", string(buffer))
+	}
+	if state.startCount == 0 {
+		t.Fatal("expected proxy to start branch after stale backend dial failure")
+	}
+	if state.branch.BackendPort != nextBackendPort {
+		t.Fatalf("expected backend port %d, got %d", nextBackendPort, state.branch.BackendPort)
+	}
+}
+
 func TestProxyStopsIdleBranch(t *testing.T) {
 	proxyPort := freePort(t)
 	state := &fakeState{
@@ -109,12 +167,60 @@ func TestProxyStopsIdleBranch(t *testing.T) {
 	t.Fatal("expected proxy to stop idle branch")
 }
 
+func TestProxyDoesNotStopActiveBranch(t *testing.T) {
+	backendPort := startBlockingBackend(t)
+	proxyPort := freePort(t)
+	state := &fakeState{
+		branch: Branch{
+			ID:           10,
+			Slug:         "active",
+			Status:       "running",
+			ProxyPort:    proxyPort,
+			BackendPort:  backendPort,
+			LastActiveAt: time.Now().Format(time.RFC3339Nano),
+		},
+	}
+	api := startFakeAPI(t, state)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server := NewServer(Config{
+		APIURL:          api.URL + "/internal",
+		Token:           "test-token",
+		BindAddress:     "127.0.0.1",
+		RefreshInterval: 20 * time.Millisecond,
+		IdleTimeout:     50 * time.Millisecond,
+		Logger:          log.New(io.Discard, "", 0),
+	})
+	go func() {
+		_ = server.Run(ctx)
+	}()
+
+	waitForDial(t, proxyPort)
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("keepalive")); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if state.stopCount != 0 {
+		t.Fatalf("expected active branch not to stop, stopped %d times", state.stopCount)
+	}
+}
+
 type fakeState struct {
-	mu         sync.Mutex
-	branch     Branch
-	startCount int
-	stopCount  int
-	touchCount int
+	mu               sync.Mutex
+	branch           Branch
+	startBackendPort int
+	startCount       int
+	stopCount        int
+	touchCount       int
 }
 
 func startFakeAPI(t *testing.T, state *fakeState) *httptest.Server {
@@ -137,6 +243,9 @@ func startFakeAPI(t *testing.T, state *fakeState) *httptest.Server {
 		case r.Method == http.MethodPost && r.URL.Path == fmt.Sprintf("/internal/branches/%d/start", state.branch.ID):
 			state.startCount++
 			state.branch.Status = "running"
+			if state.startBackendPort != 0 {
+				state.branch.BackendPort = state.startBackendPort
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":          state.branch.ID,
 				"backendPort": state.branch.BackendPort,
@@ -183,6 +292,33 @@ func startEchoBackend(t *testing.T) int {
 			go func() {
 				defer conn.Close()
 				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func startBlockingBackend(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_, _ = io.Copy(io.Discard, conn)
 			}()
 		}
 	}()

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "web": "bun --bun vite dev --host 0.0.0.0 --port 3000",
     "web:build": "bun --bun vite build",
     "web:start": "bun src/server/web-runtime.ts",
+    "proxy": "go run ./cmd/velo-proxy",
+    "proxy:test": "go test ./cmd/velo-proxy ./internal/proxy",
     "local:up": "scripts/local-dev.sh up",
     "local:dev": "scripts/local-dev.sh dev",
     "local:down": "scripts/local-dev.sh down",

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -39,6 +39,10 @@ export PATH=\"\$BUN_INSTALL/bin:\$PATH\"
 if ! command -v bun >/dev/null 2>&1; then
   curl -fsSL https://bun.sh/install | bash
 fi
+if ! command -v go >/dev/null 2>&1; then
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y golang-go
+fi
 
 bun install --frozen-lockfile
 VELO_STATE_DIR=\"${VELO_DB%/*}\"
@@ -46,6 +50,7 @@ mkdir -p -m 700 \"\$VELO_STATE_DIR\"
 chmod 700 \"\$VELO_STATE_DIR\"
 VELO_DB='$VELO_DB' bun run db:migrate
 bun run web:build
+go build -o /usr/local/bin/velo-proxy ./cmd/velo-proxy
 
 if [ ! -f /etc/velo.env ]; then
   umask 077
@@ -53,6 +58,7 @@ if [ ! -f /etc/velo.env ]; then
 fi
 
 grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' '$VELO_PUBLIC_URL' >>/etc/velo.env
+grep -q '^VELO_INTERNAL_TOKEN=' /etc/velo.env || printf 'VELO_INTERNAL_TOKEN=%s\n' \"\$(openssl rand -base64 48)\" >>/etc/velo.env
 sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
 
 cat >/etc/systemd/system/velo-web.service <<SERVICE
@@ -77,9 +83,33 @@ RestartSec=3
 WantedBy=multi-user.target
 SERVICE
 
+cat >/etc/systemd/system/velo-proxy.service <<SERVICE
+[Unit]
+Description=Velo branch TCP proxy
+After=network-online.target docker.service velo-web.service
+Wants=network-online.target
+Requires=velo-web.service
+
+[Service]
+Type=simple
+WorkingDirectory=$VELO_DEPLOY_DIR
+Environment=VELO_INTERNAL_API_URL=http://127.0.0.1:$VELO_PORT/internal
+Environment=VELO_PROXY_BIND=127.0.0.1
+Environment=VELO_PROXY_IDLE_SECONDS=1800
+EnvironmentFile=/etc/velo.env
+ExecStart=/usr/local/bin/velo-proxy
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
 systemctl daemon-reload
 systemctl enable velo-web >/dev/null
+systemctl enable velo-proxy >/dev/null
 systemctl stop velo-web || true
+systemctl stop velo-proxy || true
 
 if ss -ltnp | grep -q ':$VELO_PORT '; then
   ss -ltnp | awk '/:$VELO_PORT / { print \$0 }'
@@ -88,8 +118,10 @@ if ss -ltnp | grep -q ':$VELO_PORT '; then
 fi
 
 systemctl start velo-web
+systemctl start velo-proxy
 sleep 1
 systemctl is-active --quiet velo-web
+systemctl is-active --quiet velo-proxy
 "
 
 ssh "${SSH_ARGS[@]}" "$REMOTE" "curl -fsS -I 'http://127.0.0.1:$VELO_PORT' >/dev/null"

--- a/scripts/deploy-hetzner.sh
+++ b/scripts/deploy-hetzner.sh
@@ -45,9 +45,9 @@ copy_file() {
 reset_app_server() {
   ssh_run "$APP_REMOTE" "
 set -e
-systemctl stop velo-web velo-web-dev >/dev/null 2>&1 || true
-systemctl disable velo-web velo-web-dev >/dev/null 2>&1 || true
-rm -f /etc/systemd/system/velo-web.service /etc/systemd/system/velo-web-dev.service
+systemctl stop velo-web velo-web-dev velo-proxy >/dev/null 2>&1 || true
+systemctl disable velo-web velo-web-dev velo-proxy >/dev/null 2>&1 || true
+rm -f /etc/systemd/system/velo-web.service /etc/systemd/system/velo-web-dev.service /etc/systemd/system/velo-proxy.service
 systemctl daemon-reload
 if ss -ltnp | grep -q ':$VELO_PORT '; then
   ss -ltnp | awk '/:$VELO_PORT / { match(\$0, /pid=[0-9]+/); if (RSTART) print substr(\$0, RSTART + 4, RLENGTH - 4) }' | xargs -r kill
@@ -92,7 +92,7 @@ install_app_server() {
 set -e
 chmod 600 $(shell_quote "$VELO_REMOTE_KEY_PATH")
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y curl git unzip openssl docker.io zfsutils-linux postgresql-client pgbackrest
+DEBIAN_FRONTEND=noninteractive apt-get install -y curl git unzip openssl docker.io zfsutils-linux postgresql-client pgbackrest golang-go
 systemctl enable --now docker || true
 
 export BUN_INSTALL=/root/.bun
@@ -120,12 +120,14 @@ git clean -fd -e node_modules -e .velo
 bun install --frozen-lockfile
 VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") bun run db:migrate
 bun run web:build
+go build -o /usr/local/bin/velo-proxy ./cmd/velo-proxy
 
 umask 077
 if [ ! -f /etc/velo.env ]; then
   printf 'BETTER_AUTH_SECRET=%s\n' \"\$(openssl rand -base64 48)\" >/etc/velo.env
 fi
 grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' $(shell_quote "http://$VELO_DEPLOY_DEV_HOST:$VELO_PORT") >>/etc/velo.env
+grep -q '^VELO_INTERNAL_TOKEN=' /etc/velo.env || printf 'VELO_INTERNAL_TOKEN=%s\n' \"\$(openssl rand -base64 48)\" >>/etc/velo.env
 sed -i '/^VELO_BASIC_AUTH_USERNAME=/d; /^VELO_BASIC_AUTH_PASSWORD=/d' /etc/velo.env
 
 cat >/etc/systemd/system/velo-web.service <<SERVICE
@@ -150,8 +152,31 @@ RestartSec=3
 [Install]
 WantedBy=multi-user.target
 SERVICE
+
+cat >/etc/systemd/system/velo-proxy.service <<SERVICE
+[Unit]
+Description=Velo branch TCP proxy
+After=network-online.target docker.service velo-web.service
+Wants=network-online.target
+Requires=velo-web.service
+
+[Service]
+Type=simple
+WorkingDirectory=$VELO_DEPLOY_DIR
+Environment=VELO_INTERNAL_API_URL=http://127.0.0.1:$VELO_PORT/internal
+Environment=VELO_PROXY_BIND=127.0.0.1
+Environment=VELO_PROXY_IDLE_SECONDS=1800
+EnvironmentFile=/etc/velo.env
+ExecStart=/usr/local/bin/velo-proxy
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
 systemctl daemon-reload
 systemctl enable --now velo-web
+systemctl enable --now velo-proxy
 "
 }
 
@@ -209,7 +234,7 @@ assertOk(await runDevBootstrap());
 assertOk(await runProdBootstrap());
 assertOk(await createReplicaBase());
 '
-systemctl restart velo-web
+systemctl restart velo-web velo-proxy
 "
 }
 
@@ -231,6 +256,7 @@ check_servers() {
   ssh_run "$APP_REMOTE" "
 set -e
 systemctl is-active --quiet velo-web
+systemctl is-active --quiet velo-proxy
 cd $(shell_quote "$VELO_DEPLOY_DIR")
 VELO_DB=$(shell_quote "$VELO_DEPLOY_DIR/.velo/velo.sqlite") /root/.bun/bin/bun -e '
 import { Database } from \"bun:sqlite\";

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -42,6 +42,7 @@ VELO_LOCAL_MINIO_CONSOLE_PORT=$VELO_LOCAL_MINIO_CONSOLE_PORT
 VELO_LOCAL_WEB_PORT=$VELO_LOCAL_WEB_PORT
 BETTER_AUTH_URL=$BETTER_AUTH_URL
 BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET
+VELO_INTERNAL_TOKEN=$VELO_INTERNAL_TOKEN
 EOF
   chmod 600 "$LOCAL_ENV_FILE"
 }
@@ -85,6 +86,7 @@ ensure_ports() {
   fi
   export BETTER_AUTH_URL="${BETTER_AUTH_URL:-http://localhost:$VELO_LOCAL_WEB_PORT}"
   export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-$(openssl rand -base64 48)}"
+  export VELO_INTERNAL_TOKEN="${VELO_INTERNAL_TOKEN:-$(openssl rand -base64 48)}"
   save_env_file
 }
 
@@ -122,6 +124,7 @@ cleanup_local_branch_containers() {
 }
 
 DEV_SERVER_PID=""
+PROXY_PID=""
 CLEANUP_WATCHER_PID=""
 
 start_cleanup_watcher() {
@@ -158,6 +161,11 @@ cleanup_dev() {
   if [ -n "$DEV_SERVER_PID" ] && kill -0 "$DEV_SERVER_PID" 2>/dev/null; then
     kill "$DEV_SERVER_PID" 2>/dev/null || true
     wait "$DEV_SERVER_PID" 2>/dev/null || true
+  fi
+
+  if [ -n "$PROXY_PID" ] && kill -0 "$PROXY_PID" 2>/dev/null; then
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
   fi
 
   cleanup_local_branch_containers
@@ -479,6 +487,10 @@ dev() {
   up
   bun --bun vite dev --host 0.0.0.0 --port "$VELO_LOCAL_WEB_PORT" &
   DEV_SERVER_PID=$!
+  VELO_INTERNAL_API_URL="http://127.0.0.1:$VELO_LOCAL_WEB_PORT/internal" \
+  VELO_PROXY_IDLE_SECONDS="${VELO_PROXY_IDLE_SECONDS:-1800}" \
+  go run ./cmd/velo-proxy &
+  PROXY_PID=$!
   wait "$DEV_SERVER_PID"
 }
 
@@ -508,6 +520,7 @@ case "${1:-up}" in
     printf 'prod: postgresql://postgres:postgres@localhost:%s/postgres?sslmode=disable\n' "$VELO_LOCAL_PROD_PORT"
     printf 'dev:  postgresql://postgres:postgres@localhost:%s/postgres?sslmode=disable\n' "$VELO_LOCAL_DEV_PORT"
     printf 's3:   https://localhost:%s\n' "$VELO_LOCAL_MINIO_PORT"
+    printf 'proxy: go run ./cmd/velo-proxy --api http://127.0.0.1:%s/internal\n' "$VELO_LOCAL_WEB_PORT"
     ;;
   *)
     echo "usage: bun run local:up|local:dev|local:down|local:reset|local:status" >&2

--- a/scripts/local-dev.sh
+++ b/scripts/local-dev.sh
@@ -92,6 +92,35 @@ compose() {
   docker compose -f "$COMPOSE_FILE" "$@"
 }
 
+remove_containers_by_name() {
+  local name="$1"
+  local ids
+  ids="$(docker ps -aq --filter "name=$name" 2>/dev/null || true)"
+
+  if [ -n "$ids" ]; then
+    # shellcheck disable=SC2086
+    docker rm -f $ids >/dev/null 2>&1 || true
+  fi
+}
+
+remove_volumes_by_prefix() {
+  local prefix="$1"
+  local names
+  names="$(docker volume ls -q 2>/dev/null | grep "^$prefix" || true)"
+
+  if [ -n "$names" ]; then
+    # shellcheck disable=SC2086
+    docker volume rm $names >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup_local_branch_containers() {
+  remove_containers_by_name "$COMPOSE_PROJECT_NAME-branch-"
+  remove_containers_by_name "$COMPOSE_PROJECT_NAME-restore-"
+  remove_volumes_by_prefix "$COMPOSE_PROJECT_NAME-branch-"
+  remove_volumes_by_prefix "$COMPOSE_PROJECT_NAME-restore-"
+}
+
 DEV_SERVER_PID=""
 CLEANUP_WATCHER_PID=""
 
@@ -112,6 +141,10 @@ start_cleanup_watcher() {
         sleep 2
       done
 
+      docker ps -aq --filter "name=$compose_project_name-branch-" 2>/dev/null | xargs docker rm -f >/dev/null 2>&1 || true
+      docker ps -aq --filter "name=$compose_project_name-restore-" 2>/dev/null | xargs docker rm -f >/dev/null 2>&1 || true
+      docker volume ls -q 2>/dev/null | grep "^$compose_project_name-branch-" | xargs docker volume rm >/dev/null 2>&1 || true
+      docker volume ls -q 2>/dev/null | grep "^$compose_project_name-restore-" | xargs docker volume rm >/dev/null 2>&1 || true
       COMPOSE_PROJECT_NAME="$compose_project_name" docker compose -f "$compose_file" down -v --remove-orphans >/dev/null 2>&1 || true
     ' bash "$parent_pid" "$COMPOSE_FILE" "$COMPOSE_PROJECT_NAME" >/dev/null 2>&1 &
   CLEANUP_WATCHER_PID=$!
@@ -127,6 +160,7 @@ cleanup_dev() {
     wait "$DEV_SERVER_PID" 2>/dev/null || true
   fi
 
+  cleanup_local_branch_containers
   compose down -v --remove-orphans || true
 
   if [ -n "$CLEANUP_WATCHER_PID" ] && kill -0 "$CLEANUP_WATCHER_PID" 2>/dev/null; then
@@ -457,10 +491,12 @@ case "${1:-up}" in
     ;;
   down)
     ensure_ports
+    cleanup_local_branch_containers
     compose down
     ;;
   reset)
     ensure_ports
+    cleanup_local_branch_containers
     compose down -v
     rm -f "$LOCAL_DB" "$LOCAL_DB-shm" "$LOCAL_DB-wal"
     up

--- a/scripts/remote-dev.sh
+++ b/scripts/remote-dev.sh
@@ -30,12 +30,17 @@ export PATH=\"\$BUN_INSTALL/bin:\$PATH\"
 if ! command -v bun >/dev/null 2>&1; then
   curl -fsSL https://bun.sh/install | bash
 fi
+if ! command -v go >/dev/null 2>&1; then
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y golang-go
+fi
 
 bun install --frozen-lockfile
 VELO_STATE_DIR=\"${VELO_DB%/*}\"
 mkdir -p -m 700 \"\$VELO_STATE_DIR\"
 chmod 700 \"\$VELO_STATE_DIR\"
 VELO_DB='$VELO_DB' bun run db:migrate
+go build -o /usr/local/bin/velo-proxy ./cmd/velo-proxy
 
 if [ ! -f /etc/velo.env ]; then
   umask 077
@@ -43,6 +48,7 @@ if [ ! -f /etc/velo.env ]; then
 fi
 
 grep -q '^BETTER_AUTH_URL=' /etc/velo.env || printf 'BETTER_AUTH_URL=%s\n' '$VELO_PUBLIC_URL' >>/etc/velo.env
+grep -q '^VELO_INTERNAL_TOKEN=' /etc/velo.env || printf 'VELO_INTERNAL_TOKEN=%s\n' \"\$(openssl rand -base64 48)\" >>/etc/velo.env
 
 cat >/etc/systemd/system/velo-web-dev.service <<SERVICE
 [Unit]
@@ -66,14 +72,39 @@ RestartSec=2
 WantedBy=multi-user.target
 SERVICE
 
+cat >/etc/systemd/system/velo-proxy.service <<SERVICE
+[Unit]
+Description=Velo branch TCP proxy
+After=network-online.target docker.service velo-web-dev.service
+Wants=network-online.target
+Requires=velo-web-dev.service
+
+[Service]
+Type=simple
+WorkingDirectory=$VELO_REMOTE_DIR
+Environment=VELO_INTERNAL_API_URL=http://127.0.0.1:$VELO_PORT/internal
+Environment=VELO_PROXY_BIND=127.0.0.1
+Environment=VELO_PROXY_IDLE_SECONDS=1800
+EnvironmentFile=/etc/velo.env
+ExecStart=/usr/local/bin/velo-proxy
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
 systemctl daemon-reload
 systemctl stop velo-web || true
 systemctl enable velo-web-dev >/dev/null
+systemctl enable velo-proxy >/dev/null
 systemctl restart velo-web-dev
+systemctl restart velo-proxy
 
 for attempt in \$(seq 1 30); do
   if curl -fsS -I 'http://127.0.0.1:$VELO_PORT' >/dev/null 2>&1; then
     systemctl is-active --quiet velo-web-dev
+    systemctl is-active --quiet velo-proxy
     exit 0
   fi
   sleep 1

--- a/src/db/generated.ts
+++ b/src/db/generated.ts
@@ -10,18 +10,22 @@ export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   : ColumnType<T, T | undefined, T>;
 
 export interface Branches {
+  backendPort: number | null;
   connectionUrl: string | null;
   createdAt: Generated<string>;
   dataset: string;
   displayName: string;
+  expiresAt: string | null;
   id: Generated<number | null>;
+  lastActiveAt: string | null;
   parentBranchId: number | null;
   port: number | null;
   projectId: number;
+  proxyPort: number | null;
   slug: string;
   sourceReplayAt: string | null;
-  expiresAt: string | null;
   status: Generated<string>;
+  stoppedAt: string | null;
   updatedAt: Generated<string>;
 }
 
@@ -87,6 +91,7 @@ export interface Settings {
 }
 
 export interface SetupSteps {
+  failedJobId: number | null;
   id: Generated<number | null>;
   key: string;
   label: string;

--- a/src/db/migrations/009_branch_proxy.sql
+++ b/src/db/migrations/009_branch_proxy.sql
@@ -1,0 +1,11 @@
+alter table branches add column proxy_port integer;
+alter table branches add column backend_port integer;
+alter table branches add column last_active_at text;
+alter table branches add column stopped_at text;
+
+update branches
+set backend_port = port,
+    last_active_at = coalesce(updated_at, created_at)
+where backend_port is null;
+
+create unique index if not exists branches_proxy_port_idx on branches(proxy_port) where proxy_port is not null;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,11 +49,15 @@ export interface BranchesTable {
   displayName: string;
   dataset: string;
   port: number | null;
+  proxyPort: number | null;
+  backendPort: number | null;
   status: 'creating' | 'running' | 'stopped' | 'error';
   parentBranchId: number | null;
   sourceReplayAt: string | null;
   expiresAt: string | null;
   connectionUrl: string | null;
+  lastActiveAt: string | null;
+  stoppedAt: string | null;
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -19,7 +19,7 @@ import {
   type JobHandlers,
 } from './services/job-service';
 import { parseCreateBranchJobInput } from './services/job-handlers';
-import { createBranchFromBase, replaceBranchWithReadyBranch, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
+import { createBranchFromBase, listProxyBranches, replaceBranchWithReadyBranch, runExpiredBranchCleanup, updateBranchExpiry } from './services/branch-service';
 import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, invalidateDevReplicaBase, saveServer, setStepStatus } from './services/setup-state-service';
@@ -132,6 +132,52 @@ describe('control plane database', function controlPlaneDatabase() {
       });
       expect(job.run_after).toBeTruthy();
       expect(log?.message).toBe('old log');
+    } finally {
+      await closeDb();
+      process.env.VELO_DB = originalDb;
+      rmSync(existingDir, { recursive: true, force: true });
+    }
+  });
+
+  test('migrates branch proxy columns on existing databases', async function testExistingBranchProxyMigration() {
+    const originalDb = process.env.VELO_DB;
+    const existingDir = mkdtempSync(join(tmpdir(), 'velo-existing-proxy-'));
+    const existingDbPath = join(existingDir, 'velo.sqlite');
+
+    await closeDb();
+
+    try {
+      createPreProxyDatabase(existingDbPath);
+      process.env.VELO_DB = existingDbPath;
+      migrateDatabase();
+
+      const db = new Database(existingDbPath);
+      const branch = db
+        .query(`
+          select port, proxy_port, backend_port, last_active_at, stopped_at
+          from branches
+          where slug = ?
+        `)
+        .get('old-dev') as {
+          port: number;
+          proxy_port: number | null;
+          backend_port: number | null;
+          last_active_at: string | null;
+          stopped_at: string | null;
+        };
+      const proxyIndex = db
+        .query("select name from sqlite_master where type = 'index' and name = 'branches_proxy_port_idx'")
+        .get() as { name: string } | null;
+      db.close();
+
+      expect(branch).toEqual({
+        port: 41001,
+        proxy_port: null,
+        backend_port: 41001,
+        last_active_at: '2026-05-16T10:00:00.000Z',
+        stopped_at: null,
+      });
+      expect(proxyIndex?.name).toBe('branches_proxy_port_idx');
     } finally {
       await closeDb();
       process.env.VELO_DB = originalDb;
@@ -520,6 +566,98 @@ describe('control plane database', function controlPlaneDatabase() {
     }]);
   });
 
+  test('keeps proxy connection stable when promoting replacement', async function testPromoteReplacementKeepsProxy() {
+    const projectId = await createProject();
+    const originalId = await createBranchRecord({
+      projectId,
+      slug: 'dev',
+      displayName: 'dev',
+      dataset: 'prod.dev',
+      port: 41001,
+      proxyPort: 41001,
+      backendPort: 51001,
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+    const replacementId = await createBranchRecord({
+      projectId,
+      slug: 'dev-tmp',
+      displayName: 'dev',
+      dataset: 'prod.dev_tmp',
+      port: 41002,
+      proxyPort: 41002,
+      backendPort: 51002,
+      connectionUrl: 'postgresql://postgres:new@example.com:41002/postgres',
+    });
+
+    const result = await replaceBranchWithReadyBranch({
+      targetBranchId: originalId,
+      replacementBranchId: replacementId,
+      cleanupReplacedBranch: async function cleanup(branch) {
+        return [`cleaned ${branch.dataset}`];
+      },
+    });
+    const branch = await getDb()
+      .selectFrom('branches')
+      .select(['id', 'slug', 'dataset', 'port', 'proxyPort', 'backendPort', 'connectionUrl'])
+      .where('id', '=', originalId)
+      .executeTakeFirstOrThrow();
+
+    expect(result).toMatchObject({
+      id: originalId,
+      slug: 'dev',
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+    expect(branch).toEqual({
+      id: originalId,
+      slug: 'dev',
+      dataset: 'prod.dev_tmp',
+      port: 41001,
+      proxyPort: 41001,
+      backendPort: 51002,
+      connectionUrl: 'postgresql://postgres:old@example.com:41001/postgres',
+    });
+  });
+
+  test('lists only branches with proxy and backend ports', async function testListProxyBranches() {
+    const projectId = await createProject();
+    await createBranchRecord({
+      projectId,
+      slug: 'legacy',
+      displayName: 'legacy',
+      dataset: 'prod.legacy',
+      port: 41001,
+    });
+    await createBranchRecord({
+      projectId,
+      slug: 'missing-backend',
+      displayName: 'missing-backend',
+      dataset: 'prod.missing_backend',
+      port: 41002,
+      proxyPort: 41002,
+    });
+    await createBranchRecord({
+      projectId,
+      slug: 'proxied',
+      displayName: 'proxied',
+      dataset: 'prod.proxied',
+      port: 41003,
+      proxyPort: 41003,
+      backendPort: 51003,
+      lastActiveAt: '2026-05-16T10:00:00.000Z',
+    });
+
+    const branches = await listProxyBranches();
+
+    expect(branches).toEqual([{
+      id: expect.any(Number),
+      slug: 'proxied',
+      status: 'running',
+      proxyPort: 41003,
+      backendPort: 51003,
+      lastActiveAt: '2026-05-16T10:00:00.000Z',
+    }]);
+  });
+
   test('keeps original branch when replacement promotion fails', async function testReplacementPromotionFailureKeepsOriginal() {
     const projectId = await createProject();
     const originalId = await createBranchRecord({
@@ -639,7 +777,11 @@ async function createBranchRecord(input: {
   dataset: string;
   parentBranchId?: number | null;
   port?: number | null;
+  proxyPort?: number | null;
+  backendPort?: number | null;
   connectionUrl?: string | null;
+  lastActiveAt?: string | null;
+  status?: 'creating' | 'running' | 'stopped' | 'error';
 }): Promise<number> {
   await getDb()
     .insertInto('branches')
@@ -648,10 +790,13 @@ async function createBranchRecord(input: {
       slug: input.slug,
       displayName: input.displayName,
       dataset: input.dataset,
-      status: 'running',
+      status: input.status ?? 'running',
       parentBranchId: input.parentBranchId ?? null,
       port: input.port ?? null,
+      proxyPort: input.proxyPort ?? null,
+      backendPort: input.backendPort ?? null,
       connectionUrl: input.connectionUrl ?? null,
+      lastActiveAt: input.lastActiveAt ?? null,
     })
     .execute();
 
@@ -680,6 +825,60 @@ function createPreQueueDatabase(databasePath: string): void {
 
   const job = db.prepare('insert into jobs (type, status) values (?, ?)').run('old-job', 'running');
   db.prepare('insert into job_logs (job_id, level, message) values (?, ?, ?)').run(Number(job.lastInsertRowid), 'info', 'old log');
+  db.close();
+}
+
+function createPreProxyDatabase(databasePath: string): void {
+  const db = new Database(databasePath);
+  db.exec(`
+    create table schema_migrations (
+      id text primary key,
+      applied_at text not null default (datetime('now'))
+    );
+  `);
+
+  for (const id of [
+    '001_initial',
+    '002_jobs',
+    '003_branch_parent',
+    '004_branch_identity',
+    '005_branch_expiry',
+    '005_job_queue',
+    '006_remove_first_branch_setup_step',
+    '007_setup_step_stale_status',
+    '008_job_recovery_links',
+  ]) {
+    db.exec(readFileSync(join(process.cwd(), 'src/db/migrations', `${id}.sql`), 'utf8'));
+    db.prepare('insert into schema_migrations (id) values (?)').run(id);
+  }
+
+  const project = db
+    .prepare('insert into projects (name, postgres_version, database_name, app_user) values (?, ?, ?, ?)')
+    .run('prod', '17', 'postgres', 'postgres');
+  db
+    .prepare(`
+      insert into branches (
+        project_id,
+        slug,
+        display_name,
+        dataset,
+        port,
+        status,
+        created_at,
+        updated_at
+      )
+      values (?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      Number(project.lastInsertRowid),
+      'old-dev',
+      'old dev',
+      'prod.old_dev',
+      41001,
+      'running',
+      '2026-05-16T09:00:00.000Z',
+      '2026-05-16T10:00:00.000Z'
+    );
   db.close();
 }
 

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -379,7 +379,7 @@ export async function replaceBranchWithReadyBranch(input: ReplaceBranchWithReady
     id: target.id,
     slug: target.slug,
     displayName: target.displayName,
-    connectionUrl: replacement.connectionUrl || target.connectionUrl || '',
+    connectionUrl: promotedConnectionUrl || '',
     cleanupLogs,
   };
 }

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -12,10 +12,11 @@ import { runCommand } from './command-service';
 import { setStepStatus } from './setup-state-service';
 import { createBranchFromPgBackRest } from './pgbackrest-restore-service';
 import { cleanupOldReplicaBases, getReplicaBaseDataset, getReplicaFreshness } from './replica-service';
-import { createLocalDockerBranch, deleteLocalDockerBranch, deleteLocalDockerBranchResources, isLocalDockerMode } from './local-docker-service';
+import { createLocalDockerBranch, deleteLocalDockerBranch, deleteLocalDockerBranchResources, isLocalDockerMode, startLocalDockerBranchContainer, stopLocalDockerBranchContainer } from './local-docker-service';
 import { createJob, getActiveJobs } from './job-service';
 import { getBranchConnectionHost } from './branch-network-service';
 import { getReplicaBranchCreatePolicy } from '#utils/replica-freshness-policy';
+import { getAvailableTcpPort } from './tcp-port-service';
 
 const PROJECT_NAME = 'prod';
 
@@ -72,6 +73,15 @@ export interface ReplacedBranchResource {
 export interface UpdateBranchExpiryInput {
   id: number;
   expiresAt: string | null;
+}
+
+export interface ProxyBranchRecord {
+  id: number;
+  slug: string;
+  status: string;
+  proxyPort: number;
+  backendPort: number;
+  lastActiveAt: string | null;
 }
 
 export async function createBranchFromBase(input: CreateBranchInput): Promise<CreateBranchResult> {
@@ -212,7 +222,7 @@ async function createBranchClone(options: {
     containerId = await docker.createContainer({
       name: targetContainer,
       image,
-      port: options.preferredPort || 0,
+      port: 0,
       dataPath: mountpoint,
       walArchivePath,
       sslCertDir: certPaths.certDir,
@@ -226,12 +236,13 @@ async function createBranchClone(options: {
     await docker.startContainer(containerId);
     await docker.waitForHealthy(containerId);
     await setBranchPassword(docker, containerId, password);
-    const port = await docker.getContainerPort(containerId);
+    const backendPort = await docker.getContainerPort(containerId);
+    const proxyPort = await getAvailableTcpPort(options.preferredPort);
     const connectionUrl = formatPostgresConnectionUrl(
       'postgres',
       password,
       getBranchConnectionHost(devServer?.host, options.publicAccess),
-      port,
+      proxyPort,
       'postgres'
     );
 
@@ -242,12 +253,15 @@ async function createBranchClone(options: {
         slug: branchSlug,
         displayName: options.displayName,
         dataset: targetDataset,
-        port,
+        port: proxyPort,
+        proxyPort,
+        backendPort,
         status: 'running',
         parentBranchId: options.parentBranchId,
         connectionUrl: connectionUrl,
         sourceReplayAt: options.sourceReplayAt,
         expiresAt: options.expiresAt,
+        lastActiveAt: new Date().toISOString(),
       })
       .execute();
 
@@ -314,6 +328,10 @@ export async function replaceBranchWithReadyBranch(input: ReplaceBranchWithReady
     .where('id', '=', input.replacementBranchId)
     .executeTakeFirstOrThrow();
   let promoted = false;
+  const keepsTargetProxy = target.proxyPort !== null;
+  const promotedProxyPort = keepsTargetProxy ? target.proxyPort : replacement.proxyPort;
+  const promotedPort = keepsTargetProxy ? target.port : replacement.port;
+  const promotedConnectionUrl = keepsTargetProxy ? target.connectionUrl : replacement.connectionUrl;
 
   try {
     await assertBranchHasNoChildren(target.id);
@@ -323,10 +341,14 @@ export async function replaceBranchWithReadyBranch(input: ReplaceBranchWithReady
         .updateTable('branches')
         .set({
           dataset: replacement.dataset,
-          port: replacement.port,
+          port: promotedPort,
+          proxyPort: promotedProxyPort,
+          backendPort: replacement.backendPort ?? replacement.port,
           status: replacement.status,
           sourceReplayAt: replacement.sourceReplayAt,
-          connectionUrl: replacement.connectionUrl,
+          connectionUrl: promotedConnectionUrl,
+          lastActiveAt: new Date().toISOString(),
+          stoppedAt: null,
           updatedAt: new Date().toISOString(),
         })
         .where('id', '=', target.id)
@@ -380,6 +402,142 @@ export async function updateBranchExpiry(input: UpdateBranchExpiryInput): Promis
     })
     .where('id', '=', input.id)
     .execute();
+}
+
+export async function listProxyBranches(): Promise<ProxyBranchRecord[]> {
+  const rows = await getDb()
+    .selectFrom('branches')
+    .select(['id', 'slug', 'status', 'proxyPort', 'backendPort', 'lastActiveAt'])
+    .where('proxyPort', 'is not', null)
+    .where('backendPort', 'is not', null)
+    .orderBy('id')
+    .execute();
+
+  return rows.map(function mapProxyBranch(row) {
+    return {
+      id: row.id,
+      slug: row.slug,
+      status: row.status,
+      proxyPort: row.proxyPort!,
+      backendPort: row.backendPort!,
+      lastActiveAt: row.lastActiveAt,
+    };
+  });
+}
+
+export async function touchBranchActivity(branchId: number): Promise<void> {
+  await getDb()
+    .updateTable('branches')
+    .set({
+      lastActiveAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    .where('id', '=', branchId)
+    .execute();
+}
+
+export async function startBranchForProxy(branchId: number): Promise<{ id: number; backendPort: number }> {
+  const branch = await getDb()
+    .selectFrom('branches')
+    .select(['id', 'slug', 'dataset', 'status'])
+    .where('id', '=', branchId)
+    .executeTakeFirstOrThrow();
+  const backendPort = await ensureBranchContainerRunning(branch);
+
+  if (branch.status !== 'stopped') {
+    await getDb()
+      .updateTable('branches')
+      .set({
+        backendPort,
+        lastActiveAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      })
+      .where('id', '=', branch.id)
+      .execute();
+
+    return { id: branch.id, backendPort };
+  }
+
+  await getDb()
+    .updateTable('branches')
+    .set({
+      status: 'running',
+      backendPort,
+      stoppedAt: null,
+      lastActiveAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    .where('id', '=', branch.id)
+    .execute();
+
+  return { id: branch.id, backendPort };
+}
+
+async function ensureBranchContainerRunning(branch: {
+  slug: string;
+  dataset: string;
+}): Promise<number> {
+  if (isLocalDockerMode()) {
+    return startLocalDockerBranchContainer(branch.dataset);
+  }
+
+  const docker = new DockerManager();
+  const containerId = await getBranchContainerId(docker, branch);
+
+  if (!containerId) {
+    throw new Error(`Branch container not found: ${branch.slug}`);
+  }
+
+  await docker.startContainer(containerId).catch(function ignoreAlreadyStarted(error: any) {
+    if (error.statusCode !== 304) {
+      throw error;
+    }
+  });
+  await docker.waitForHealthy(containerId);
+  return docker.getContainerPort(containerId);
+}
+
+export async function stopBranchForProxy(branchId: number): Promise<{ id: number; stopped: boolean }> {
+  const branch = await getDb()
+    .selectFrom('branches')
+    .select(['id', 'slug', 'dataset', 'status'])
+    .where('id', '=', branchId)
+    .executeTakeFirstOrThrow();
+
+  if (branch.status === 'stopped') {
+    return { id: branch.id, stopped: false };
+  }
+
+  if (hasActiveBranchJob(branch.id, branch.slug, await getActiveJobs())) {
+    return { id: branch.id, stopped: false };
+  }
+
+  if (isLocalDockerMode()) {
+    await stopLocalDockerBranchContainer(branch.dataset);
+  } else {
+    const docker = new DockerManager();
+    const containerId = await getBranchContainerId(docker, branch);
+
+    if (containerId) {
+      await docker.stopContainer(containerId).catch(function ignoreAlreadyStopped(error: any) {
+        if (error.statusCode !== 304) {
+          throw error;
+        }
+      });
+    }
+  }
+
+  await getDb()
+    .updateTable('branches')
+    .set({
+      status: 'stopped',
+      stoppedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    .where('id', '=', branch.id)
+    .execute();
+
+  return { id: branch.id, stopped: true };
 }
 
 export async function runExpiredBranchCleanup(): Promise<void> {

--- a/src/server/services/local-docker-service.ts
+++ b/src/server/services/local-docker-service.ts
@@ -7,6 +7,7 @@ import type { SetupStepStatus } from './setup-state-service';
 
 const COMPOSE_FILE = process.env.VELO_LOCAL_COMPOSE_FILE || 'docker-compose.local.yml';
 const LOCAL_PGBACKREST_IMAGE = 'velo-local-postgres-pgbackrest:17';
+const LOCAL_BRANCH_IMAGE = 'postgres:17-alpine';
 const PROJECT_NAME = 'prod';
 
 export interface LocalDockerBranchInput {
@@ -127,7 +128,10 @@ export async function createLocalDockerReplicaBase() {
 }
 
 export async function createLocalDockerBranch(input: LocalDockerBranchInput): Promise<LocalDockerBranchResult> {
-  const database = getLocalDatabaseName(input.slug);
+  const containerName = getBranchContainerName(input.slug);
+  const volumeName = getBranchVolumeName(input.slug);
+  const dataset = formatContainerDataset(containerName);
+  const password = input.branchPassword || generatePassword();
   const db = getDb();
   const project = await ensureProject();
   const existing = await db
@@ -141,16 +145,33 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
     throw new Error(`Branch already exists: ${input.slug}`);
   }
 
-  await dropDevDatabase(database);
-  await createDevDatabase(database);
+  await removeContainer(containerName);
+  await removeVolume(volumeName);
+  await createVolume(volumeName);
 
-  if (input.sourceSlug === 'production') {
-    await copyProdToDevDatabase(database);
-  } else {
-    await copyDevDatabase(input.sourceDatabase, database);
+  try {
+    await startBranchContainer({
+      containerName,
+      volumeName,
+      password,
+      port: input.preferredPort,
+    });
+
+    if (input.sourceSlug === 'production') {
+      await copyProdToContainer(containerName);
+    } else if (input.sourceDatabase.startsWith('container:')) {
+      await copyContainerToContainer(getContainerNameFromDataset(input.sourceDatabase), containerName);
+    } else {
+      await copyDevDatabaseToContainer(input.sourceDatabase, containerName);
+    }
+  } catch (error) {
+    await removeContainer(containerName).catch(function ignoreContainerCleanupError() {});
+    await removeVolume(volumeName).catch(function ignoreVolumeCleanupError() {});
+    throw error;
   }
 
-  const connectionUrl = await formatDevConnectionUrl(database);
+  const port = await getContainerPort(containerName);
+  const connectionUrl = formatContainerConnectionUrl(password, port);
 
   await db
     .insertInto('branches')
@@ -158,8 +179,8 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
       projectId: project.id,
       slug: input.slug,
       displayName: input.displayName,
-      dataset: database,
-      port: await getServicePort('dev-postgres'),
+      dataset,
+      port,
       status: 'running',
       parentBranchId: input.parentBranchId,
       connectionUrl: connectionUrl,
@@ -192,7 +213,7 @@ export async function deleteLocalDockerBranch(id: number) {
     .executeTakeFirstOrThrow();
 
   if (branch.dataset.startsWith('container:')) {
-    await deleteRestoreContainer(branch.dataset);
+    await deleteContainerDataset(branch.dataset);
   } else {
     await dropDevDatabase(branch.dataset);
   }
@@ -211,7 +232,7 @@ export async function deleteLocalDockerBranch(id: number) {
 
 export async function deleteLocalDockerBranchResources(dataset: string): Promise<void> {
   if (dataset.startsWith('container:')) {
-    await deleteRestoreContainer(dataset);
+    await deleteContainerDataset(dataset);
     return;
   }
 
@@ -358,10 +379,6 @@ async function setLocalStepStatus(
     .execute();
 }
 
-function getLocalDatabaseName(slug: string): string {
-  return `velo_${slug.replace(/[^a-z0-9_]/g, '_')}`.slice(0, 63);
-}
-
 async function ensureProject() {
   const db = getDb();
   const existing = await db
@@ -391,25 +408,28 @@ async function ensureProject() {
     .executeTakeFirstOrThrow();
 }
 
-async function createDevDatabase(database: string): Promise<void> {
-  await runLocalCommand(`docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T dev-postgres createdb -U postgres ${shellQuote(database)}`);
-}
-
 async function dropDevDatabase(database: string): Promise<void> {
   await runLocalCommand(`docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T dev-postgres dropdb -U postgres --if-exists --force ${shellQuote(database)}`);
 }
 
-async function copyProdToDevDatabase(targetDatabase: string): Promise<void> {
+async function copyProdToContainer(targetContainer: string): Promise<void> {
   await runLocalCommand([
-    `docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T prod-postgres pg_dump -U postgres -d postgres`,
-    `docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T dev-postgres psql -v ON_ERROR_STOP=1 -U postgres -d ${shellQuote(targetDatabase)}`,
+    `docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T --user postgres prod-postgres pg_dump -U postgres -d postgres`,
+    `docker exec -i --user postgres ${shellQuote(targetContainer)} psql -v ON_ERROR_STOP=1 -U postgres -d postgres`,
   ].join(' | '), 10 * 60 * 1000);
 }
 
-async function copyDevDatabase(sourceDatabase: string, targetDatabase: string): Promise<void> {
+async function copyDevDatabaseToContainer(sourceDatabase: string, targetContainer: string): Promise<void> {
   await runLocalCommand([
-    `docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T dev-postgres pg_dump -U postgres -d ${shellQuote(sourceDatabase)}`,
-    `docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T dev-postgres psql -v ON_ERROR_STOP=1 -U postgres -d ${shellQuote(targetDatabase)}`,
+    `docker compose -f ${shellQuote(COMPOSE_FILE)} exec -T --user postgres dev-postgres pg_dump -U postgres -d ${shellQuote(sourceDatabase)}`,
+    `docker exec -i --user postgres ${shellQuote(targetContainer)} psql -v ON_ERROR_STOP=1 -U postgres -d postgres`,
+  ].join(' | '), 10 * 60 * 1000);
+}
+
+async function copyContainerToContainer(sourceContainer: string, targetContainer: string): Promise<void> {
+  await runLocalCommand([
+    `docker exec --user postgres ${shellQuote(sourceContainer)} pg_dump -U postgres -d postgres`,
+    `docker exec -i --user postgres ${shellQuote(targetContainer)} psql -v ON_ERROR_STOP=1 -U postgres -d postgres`,
   ].join(' | '), 10 * 60 * 1000);
 }
 
@@ -433,8 +453,8 @@ async function formatProdConnectionUrl(): Promise<string> {
   return `postgresql://postgres:postgres@localhost:${await getServicePort('prod-postgres')}/postgres?sslmode=disable`;
 }
 
-async function formatDevConnectionUrl(database: string): Promise<string> {
-  return `postgresql://postgres:postgres@localhost:${await getServicePort('dev-postgres')}/${encodeURIComponent(database)}?sslmode=disable`;
+function formatContainerConnectionUrl(password: string, port: number): string {
+  return `postgresql://postgres:${encodeURIComponent(password)}@localhost:${port}/postgres?sslmode=disable`;
 }
 
 async function restorePgBackRestVolume(volumeName: string, restoreTime: Date): Promise<void> {
@@ -486,6 +506,32 @@ async function startRestoreContainer(options: {
   await setContainerPassword(options.containerName, options.password);
 }
 
+async function startBranchContainer(options: {
+  containerName: string;
+  volumeName: string;
+  password: string;
+  port?: number | null;
+}): Promise<void> {
+  const hostPort = options.port ? String(options.port) : '';
+
+  await runLocalCommand([
+    'docker run -d',
+    `--name ${shellQuote(options.containerName)}`,
+    `--network ${shellQuote(getComposeNetworkName())}`,
+    `-p 127.0.0.1:${hostPort}:5432`,
+    `-v ${shellQuote(options.volumeName)}:/var/lib/postgresql/data`,
+    `-e POSTGRES_USER=postgres`,
+    `-e POSTGRES_PASSWORD=${shellQuote(options.password)}`,
+    `-e POSTGRES_DB=postgres`,
+    shellQuote(LOCAL_BRANCH_IMAGE),
+    'postgres',
+    '-c listen_addresses=*',
+  ].join(' '), 60_000);
+
+  await waitForNewPostgresContainer(options.containerName);
+  await setContainerPassword(options.containerName, options.password);
+}
+
 async function setContainerPassword(containerName: string, password: string): Promise<void> {
   await runLocalCommand(
     `docker exec --user postgres ${shellQuote(containerName)} psql -d postgres -v ON_ERROR_STOP=1 -c ${shellQuote(`alter role postgres with password ${sqlStringLiteral(password)}`)}`,
@@ -497,35 +543,70 @@ async function waitForContainer(containerName: string): Promise<void> {
   const startedAt = Date.now();
 
   while (Date.now() - startedAt < 60_000) {
-    const result = await runCommand([
-      'sh',
-      '-lc',
-      `docker exec ${shellQuote(containerName)} pg_isready -U postgres -d postgres`,
-    ]);
-
-    if (result.exitCode === 0) {
+    if (await isContainerReady(containerName)) {
       return;
     }
 
-    const state = await runCommand([
-      'sh',
-      '-lc',
-      `docker inspect -f '{{.State.Status}}' ${shellQuote(containerName)} 2>/dev/null || true`,
-    ]);
-
-    if (state.stdout === 'exited' || state.stdout === 'dead') {
-      const logs = await runCommand([
-        'sh',
-        '-lc',
-        `docker logs --tail 40 ${shellQuote(containerName)} 2>&1`,
-      ]);
-      throw new Error(logs.stdout || `${containerName} exited before it was ready`);
-    }
+    await assertContainerStillStarting(containerName);
 
     await Bun.sleep(250);
   }
 
   throw new Error(`Container ${containerName} did not become ready`);
+}
+
+async function waitForNewPostgresContainer(containerName: string): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 60_000) {
+    if ((await hasPostgresInitCompleted(containerName)) && await isContainerReady(containerName)) {
+      return;
+    }
+
+    await assertContainerStillStarting(containerName);
+    await Bun.sleep(250);
+  }
+
+  throw new Error(`Container ${containerName} did not finish initialization`);
+}
+
+async function isContainerReady(containerName: string): Promise<boolean> {
+  const result = await runCommand([
+    'sh',
+    '-lc',
+    `docker exec ${shellQuote(containerName)} pg_isready -U postgres -d postgres`,
+  ]);
+
+  return result.exitCode === 0;
+}
+
+async function hasPostgresInitCompleted(containerName: string): Promise<boolean> {
+  const logs = await runCommand([
+    'sh',
+    '-lc',
+    `docker logs --tail 80 ${shellQuote(containerName)} 2>&1`,
+  ]);
+
+  return logs.stdout.includes('PostgreSQL init process complete; ready for start up.');
+}
+
+async function assertContainerStillStarting(containerName: string): Promise<void> {
+  const state = await runCommand([
+    'sh',
+    '-lc',
+    `docker inspect -f '{{.State.Status}}' ${shellQuote(containerName)} 2>/dev/null || true`,
+  ]);
+
+  if (state.stdout !== 'exited' && state.stdout !== 'dead') {
+    return;
+  }
+
+  const logs = await runCommand([
+    'sh',
+    '-lc',
+    `docker logs --tail 40 ${shellQuote(containerName)} 2>&1`,
+  ]);
+  throw new Error(logs.stdout || `${containerName} exited before it was ready`);
 }
 
 async function createVolume(volumeName: string): Promise<void> {
@@ -540,8 +621,8 @@ async function removeContainer(containerName: string): Promise<void> {
   await runLocalCommand(`docker rm -f ${shellQuote(containerName)} >/dev/null 2>&1 || true`);
 }
 
-async function deleteRestoreContainer(dataset: string): Promise<void> {
-  const containerName = dataset.replace(/^container:/, '');
+async function deleteContainerDataset(dataset: string): Promise<void> {
+  const containerName = getContainerNameFromDataset(dataset);
   await removeContainer(containerName);
   await removeVolume(containerName);
 }
@@ -566,6 +647,22 @@ function getRestoreContainerName(slug: string): string {
 
 function getRestoreVolumeName(slug: string): string {
   return `${getComposeProjectName()}-restore-${slug}`;
+}
+
+function getBranchContainerName(slug: string): string {
+  return `${getComposeProjectName()}-branch-${slug}`;
+}
+
+function getBranchVolumeName(slug: string): string {
+  return getBranchContainerName(slug);
+}
+
+function formatContainerDataset(containerName: string): string {
+  return `container:${containerName}`;
+}
+
+function getContainerNameFromDataset(dataset: string): string {
+  return dataset.replace(/^container:/, '');
 }
 
 function getComposeNetworkName(): string {

--- a/src/server/services/local-docker-service.ts
+++ b/src/server/services/local-docker-service.ts
@@ -4,6 +4,7 @@ import { generatePassword } from '../../utils/helpers';
 import { runCommand } from './command-service';
 import { saveBackupSettings, setSetting } from './settings-service';
 import type { SetupStepStatus } from './setup-state-service';
+import { getAvailableTcpPort } from './tcp-port-service';
 
 const COMPOSE_FILE = process.env.VELO_LOCAL_COMPOSE_FILE || 'docker-compose.local.yml';
 const LOCAL_PGBACKREST_IMAGE = 'velo-local-postgres-pgbackrest:17';
@@ -134,6 +135,8 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
   const password = input.branchPassword || generatePassword();
   const db = getDb();
   const project = await ensureProject();
+  let backendPort = 0;
+  let proxyPort = 0;
   const existing = await db
     .selectFrom('branches')
     .select('id')
@@ -154,7 +157,6 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
       containerName,
       volumeName,
       password,
-      port: input.preferredPort,
     });
 
     if (input.sourceSlug === 'production') {
@@ -164,14 +166,16 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
     } else {
       await copyDevDatabaseToContainer(input.sourceDatabase, containerName);
     }
+
+    backendPort = await getContainerPort(containerName);
+    proxyPort = await getAvailableTcpPort(input.preferredPort);
   } catch (error) {
     await removeContainer(containerName).catch(function ignoreContainerCleanupError() {});
     await removeVolume(volumeName).catch(function ignoreVolumeCleanupError() {});
     throw error;
   }
 
-  const port = await getContainerPort(containerName);
-  const connectionUrl = formatContainerConnectionUrl(password, port);
+  const connectionUrl = formatLocalConnectionUrl(password, proxyPort);
 
   await db
     .insertInto('branches')
@@ -180,12 +184,15 @@ export async function createLocalDockerBranch(input: LocalDockerBranchInput): Pr
       slug: input.slug,
       displayName: input.displayName,
       dataset,
-      port,
+      port: proxyPort,
+      proxyPort,
+      backendPort,
       status: 'running',
       parentBranchId: input.parentBranchId,
       connectionUrl: connectionUrl,
       sourceReplayAt: input.sourceReplayAt,
       expiresAt: input.expiresAt,
+      lastActiveAt: new Date().toISOString(),
     })
     .execute();
 
@@ -259,22 +266,32 @@ export async function createLocalDockerPitrBranch(input: LocalDockerRestoreInput
   const volumeName = getRestoreVolumeName(branchSlug);
   const dataset = `container:${containerName}`;
   const password = input.branchPassword || generatePassword();
+  let backendPort = 0;
+  let proxyPort = 0;
 
   await removeContainer(containerName);
   await removeVolume(volumeName);
-  await createVolume(volumeName);
-  await restorePgBackRestVolume(volumeName, restoreTime);
-  await startRestoreContainer({
-    containerName,
-    volumeName,
-    password,
-    port: input.preferredPort,
-    readOnly: input.readOnly === true,
-    publicAccess: input.publicAccess === true,
-  });
 
-  const port = await getContainerPort(containerName);
-  const connectionUrl = `postgresql://postgres:${password}@localhost:${port}/postgres?sslmode=disable`;
+  try {
+    await createVolume(volumeName);
+    await restorePgBackRestVolume(volumeName, restoreTime);
+    await startRestoreContainer({
+      containerName,
+      volumeName,
+      password,
+      readOnly: input.readOnly === true,
+      publicAccess: input.publicAccess === true,
+    });
+
+    backendPort = await getContainerPort(containerName);
+    proxyPort = await getAvailableTcpPort(input.preferredPort);
+  } catch (error) {
+    await removeContainer(containerName).catch(function ignoreContainerCleanupError() {});
+    await removeVolume(volumeName).catch(function ignoreVolumeCleanupError() {});
+    throw error;
+  }
+
+  const connectionUrl = formatLocalConnectionUrl(password, proxyPort);
 
   await db
     .insertInto('branches')
@@ -283,11 +300,14 @@ export async function createLocalDockerPitrBranch(input: LocalDockerRestoreInput
       slug: branchSlug,
       displayName: branchSlug,
       dataset,
-      port,
+      port: proxyPort,
+      proxyPort,
+      backendPort,
       status: 'running',
       parentBranchId: null,
       connectionUrl: connectionUrl,
       sourceReplayAt: restoreTime.toISOString(),
+      lastActiveAt: new Date().toISOString(),
     })
     .execute();
 
@@ -330,6 +350,18 @@ export async function getLocalPgBackRestInfo(): Promise<string> {
   }
 
   return result.stdout;
+}
+
+export async function startLocalDockerBranchContainer(dataset: string): Promise<number> {
+  const containerName = getContainerNameFromDataset(dataset);
+  await runLocalCommand(`docker start ${shellQuote(containerName)} >/dev/null`);
+  await waitForContainer(containerName);
+  return getContainerPort(containerName);
+}
+
+export async function stopLocalDockerBranchContainer(dataset: string): Promise<void> {
+  const containerName = getContainerNameFromDataset(dataset);
+  await runLocalCommand(`docker stop ${shellQuote(containerName)} >/dev/null 2>&1 || true`, 60_000);
 }
 
 async function saveLocalServer(input: {
@@ -453,7 +485,7 @@ async function formatProdConnectionUrl(): Promise<string> {
   return `postgresql://postgres:postgres@localhost:${await getServicePort('prod-postgres')}/postgres?sslmode=disable`;
 }
 
-function formatContainerConnectionUrl(password: string, port: number): string {
+function formatLocalConnectionUrl(password: string, port: number): string {
   return `postgresql://postgres:${encodeURIComponent(password)}@localhost:${port}/postgres?sslmode=disable`;
 }
 

--- a/src/server/services/pgbackrest-restore-service.ts
+++ b/src/server/services/pgbackrest-restore-service.ts
@@ -18,6 +18,7 @@ import { getBackupSettings, setSetting } from './settings-service';
 import { invalidateDevReplicaBase } from './setup-state-service';
 import { createLocalDockerPitrBranch, isLocalDockerMode, restoreLocalDockerProduction } from './local-docker-service';
 import { getBranchConnectionHost } from './branch-network-service';
+import { getAvailableTcpPort } from './tcp-port-service';
 
 const PROJECT_NAME = 'prod';
 
@@ -113,7 +114,7 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
     containerId = await docker.createContainer({
       name: containerName,
       image,
-      port: input.preferredPort || 0,
+      port: 0,
       dataPath: mountpoint,
       walArchivePath: wal.getArchivePath(dataset),
       sslCertDir: certPaths.certDir,
@@ -134,12 +135,13 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
       await enableDefaultReadOnly(docker, containerId);
     }
 
-    const port = await docker.getContainerPort(containerId);
+    const backendPort = await docker.getContainerPort(containerId);
+    const proxyPort = await getAvailableTcpPort(input.preferredPort);
     const connectionUrl = formatPostgresConnectionUrl(
       'postgres',
       branchPassword,
       getBranchConnectionHost(devServer?.host, input.publicAccess),
-      port,
+      proxyPort,
       'postgres'
     );
 
@@ -150,11 +152,14 @@ export async function createBranchFromPgBackRest(input: RestoreBranchInput): Pro
         slug: branchName,
         displayName: branchName,
         dataset,
-        port,
+        port: proxyPort,
+        proxyPort,
+        backendPort,
         status: 'running',
         parentBranchId: null,
         sourceReplayAt: restoreTime.toISOString(),
         connectionUrl: connectionUrl,
+        lastActiveAt: new Date().toISOString(),
       })
       .execute();
 

--- a/src/server/services/tcp-port-service.ts
+++ b/src/server/services/tcp-port-service.ts
@@ -1,0 +1,38 @@
+import { createServer } from 'node:net';
+
+export async function getAvailableTcpPort(preferredPort?: number | null): Promise<number> {
+  if (preferredPort) {
+    await assertTcpPortAvailable(preferredPort);
+    return preferredPort;
+  }
+
+  return listenForPort(0);
+}
+
+async function assertTcpPortAvailable(port: number): Promise<void> {
+  await listenForPort(port);
+}
+
+async function listenForPort(port: number): Promise<number> {
+  const server = createServer();
+
+  return new Promise<number>(function resolvePort(resolve, reject) {
+    server.once('error', function handleListenError(error) {
+      reject(error);
+    });
+
+    server.listen(port, '127.0.0.1', function handleListen() {
+      const address = server.address();
+      const resolvedPort = typeof address === 'object' && address ? address.port : port;
+
+      server.close(function closeServer(error) {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(resolvedPort);
+      });
+    });
+  });
+}

--- a/src/server/web-runtime.ts
+++ b/src/server/web-runtime.ts
@@ -37,6 +37,10 @@ Bun.serve({
       return healthResponse;
     }
 
+    if (isInternalRequest(request)) {
+      return serverEntry.default.fetch(request);
+    }
+
     const authResponse = requireBasicAuth(request);
 
     if (authResponse) {
@@ -159,6 +163,10 @@ function requireBasicAuth(request: Request): Response | null {
   }
 
   return null;
+}
+
+function isInternalRequest(request: Request): boolean {
+  return new URL(request.url).pathname.startsWith('/internal/');
 }
 
 function unauthorizedResponse(): Response {

--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -1265,7 +1265,11 @@ function getStatusVariant(status: string): BadgeProps['variant'] {
     return 'info';
   }
 
-  if (status === 'error' || status === 'stopped') {
+  if (status === 'stopped') {
+    return 'warning';
+  }
+
+  if (status === 'error') {
     return 'destructive';
   }
 
@@ -1285,7 +1289,11 @@ function getStatusIcon(status: string) {
     return Loader2;
   }
 
-  if (status === 'error' || status === 'stopped') {
+  if (status === 'stopped') {
+    return Clock3;
+  }
+
+  if (status === 'error') {
     return AlertTriangle;
   }
 

--- a/src/web/routeTree.gen.ts
+++ b/src/web/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as InternalSplatRouteImport } from './routes/internal/$'
 import { Route as BranchBranchIdTablesRouteImport } from './routes/branch/$branchId/tables'
 import { Route as BranchBranchIdSqlRouteImport } from './routes/branch/$branchId/sql'
 import { Route as BranchBranchIdOverviewRouteImport } from './routes/branch/$branchId/overview'
@@ -26,6 +27,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InternalSplatRoute = InternalSplatRouteImport.update({
+  id: '/internal/$',
+  path: '/internal/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BranchBranchIdTablesRoute = BranchBranchIdTablesRouteImport.update({
@@ -63,6 +69,7 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
+  '/internal/$': typeof InternalSplatRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
@@ -73,6 +80,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
+  '/internal/$': typeof InternalSplatRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
@@ -84,6 +92,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/settings': typeof SettingsRoute
+  '/internal/$': typeof InternalSplatRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/v1/$': typeof ApiV1SplatRoute
   '/branch/$branchId/backup-restore': typeof BranchBranchIdBackupRestoreRoute
@@ -96,6 +105,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/settings'
+    | '/internal/$'
     | '/api/auth/$'
     | '/api/v1/$'
     | '/branch/$branchId/backup-restore'
@@ -106,6 +116,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/settings'
+    | '/internal/$'
     | '/api/auth/$'
     | '/api/v1/$'
     | '/branch/$branchId/backup-restore'
@@ -116,6 +127,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/settings'
+    | '/internal/$'
     | '/api/auth/$'
     | '/api/v1/$'
     | '/branch/$branchId/backup-restore'
@@ -127,6 +139,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SettingsRoute: typeof SettingsRoute
+  InternalSplatRoute: typeof InternalSplatRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiV1SplatRoute: typeof ApiV1SplatRoute
   BranchBranchIdBackupRestoreRoute: typeof BranchBranchIdBackupRestoreRoute
@@ -149,6 +162,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/internal/$': {
+      id: '/internal/$'
+      path: '/internal/$'
+      fullPath: '/internal/$'
+      preLoaderRoute: typeof InternalSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/branch/$branchId/tables': {
@@ -199,6 +219,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SettingsRoute: SettingsRoute,
+  InternalSplatRoute: InternalSplatRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiV1SplatRoute: ApiV1SplatRoute,
   BranchBranchIdBackupRestoreRoute: BranchBranchIdBackupRestoreRoute,

--- a/src/web/routes/internal/$.ts
+++ b/src/web/routes/internal/$.ts
@@ -1,0 +1,75 @@
+import { createFileRoute } from '@tanstack/react-router';
+import {
+  listProxyBranches,
+  startBranchForProxy,
+  stopBranchForProxy,
+  touchBranchActivity,
+} from '#server/services/branch-service';
+
+export const Route = createFileRoute('/internal/$')({
+  server: {
+    handlers: {
+      GET: handleInternalRequest,
+      POST: handleInternalRequest,
+    },
+  },
+});
+
+async function handleInternalRequest(context: { request: Request }): Promise<Response> {
+  const auth = authorizeInternalRequest(context.request);
+
+  if (auth) {
+    return auth;
+  }
+
+  const url = new URL(context.request.url);
+  const path = url.pathname.replace(/^\/internal\/?/, '');
+
+  try {
+    if (context.request.method === 'GET' && path === 'proxy/branches') {
+      return Response.json({ branches: await listProxyBranches() });
+    }
+
+    const match = /^branches\/([0-9]+)\/(start|stop|touch)$/.exec(path);
+
+    if (!match || context.request.method !== 'POST') {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    const branchId = Number(match[1]);
+    const action = match[2];
+
+    if (action === 'start') {
+      return Response.json(await startBranchForProxy(branchId));
+    }
+
+    if (action === 'stop') {
+      return Response.json(await stopBranchForProxy(branchId));
+    }
+
+    await touchBranchActivity(branchId);
+    return Response.json({ id: branchId, touched: true });
+  } catch (error) {
+    return Response.json({
+      error: error instanceof Error ? error.message : String(error),
+    }, { status: 500 });
+  }
+}
+
+function authorizeInternalRequest(request: Request): Response | null {
+  const token = process.env.VELO_INTERNAL_TOKEN;
+
+  if (!token) {
+    return new Response('Internal token not configured', { status: 503 });
+  }
+
+  if (request.headers.get('authorization') === `Bearer ${token}`) {
+    return null;
+  }
+
+  if (request.headers.get('x-velo-internal-token') === token) {
+    return null;
+  }
+
+  return new Response('Unauthorized', { status: 401 });
+}


### PR DESCRIPTION
## Summary
- run Local Docker dev branches as separate Postgres containers and volumes
- add a Go TCP proxy that owns branch connection ports, wakes stopped branches, and stops idle ones
- lower default proxy idle stop from 30 minutes to 5 minutes
- wire the proxy into local dev and deploy/remote-dev systemd units
- store proxy/backend ports and branch activity in SQLite
- add regression tests for stale backends, active idle protection, proxy migration/listing, and replacement URL stability
- merge latest `main` auth changes and keep `/internal/*` proxy routes token-protected

## API routes, procedures, contracts
- Added internal proxy routes protected by `VELO_INTERNAL_TOKEN`:
  - `GET /internal/proxy/branches`
  - `POST /internal/branches/:id/start`
  - `POST /internal/branches/:id/stop`
  - `POST /internal/branches/:id/touch`
- Added branch DB columns: `proxy_port`, `backend_port`, `last_active_at`, `stopped_at`.
- Updated branch connection contract: branch `connectionUrl` points at the proxy port; Docker/Postgres listens on `backend_port`.
- Added Go proxy entrypoint: `cmd/velo-proxy`.

## Validation
- `go test ./cmd/velo-proxy ./internal/proxy`
- `bun run typecheck`
- `bun run test`
- `bun run web:build`
- `bash -n scripts/*.sh`
- `git diff --check`
- Local proxy smoke: reset local Docker, start Vite + Go proxy, create branch, query through proxy, stop branch, wake on query, idle-stop branch, delete branch
- Local wake timing with `VELO_PROXY_IDLE_SECONDS=2`: 268 ms, 256 ms, 257 ms