### PR TITLE
fix(branches): pause replica replay for base snapshots

### DIFF
--- a/scripts/e2e/hetzner-suite.ts
+++ b/scripts/e2e/hetzner-suite.ts
@@ -1,6 +1,7 @@
 import { SQL } from 'bun';
 import { getDb } from '#db/client';
 import type { Branch } from '#db/schema';
+import { DockerManager } from '#managers/docker';
 import { createApiClient } from '#api/router';
 import { getSetting } from '#server/services/settings-service';
 import { runCommand, runSshCommand } from '#server/services/command-service';
@@ -87,6 +88,7 @@ async function testReplicaBase(): Promise<void> {
 async function testBranchLifecycle(): Promise<void> {
   const branch = await createBranch(`e2e_life_${RUN_ID}`);
 
+  await assertReplicaReplayRunning();
   await assertBranchConnects(branch.slug);
   await assertDockerContainerHealthy(getContainerName(PROJECT_NAME, branch.slug));
   await assertBranchPostgresPrivate(branch);
@@ -802,6 +804,17 @@ async function assertBranchPostgresRejectsBadPassword(branch: Branch): Promise<v
   ], 30000);
 
   assert(result.exitCode !== 0, `${branch.slug} PostgreSQL should reject bad password`);
+}
+
+async function assertReplicaReplayRunning(): Promise<void> {
+  const docker = new DockerManager();
+  const containerName = getContainerName(PROJECT_NAME, 'base');
+  const containerId = await docker.getContainerByName(containerName);
+
+  assert(containerId, `replica base container should exist: ${containerName}`);
+
+  const state = await docker.execSQL(containerId, 'select pg_get_wal_replay_pause_state()');
+  assert(state === 'not paused', `replica replay should resume after branch snapshot, got ${state}`);
 }
 
 async function assertZfsDatasetExists(dataset: string): Promise<void> {

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -24,7 +24,7 @@ import { parsePgBackRestInfo } from './services/backup-availability-service';
 import { getBackupSettings, saveBackupSettings, setSetting } from './services/settings-service';
 import { getControlPlaneState, invalidateDevReplicaBase, saveServer, setStepStatus } from './services/setup-state-service';
 import { defaultCidrForHost, getProdAllowedCidr, normalizeAllowedCidr } from './services/prod-network-service';
-import { buildReplicaBaseHealth, buildReplicaFreshness } from './services/replica-service';
+import { buildReplicaBaseHealth, buildReplicaFreshness, withPausedReplicaReplay } from './services/replica-service';
 import { getReplicaBranchCreatePolicy } from '#utils/replica-freshness-policy';
 
 let testDir: string;
@@ -281,6 +281,44 @@ describe('control plane database', function controlPlaneDatabase() {
       'WAL replay is paused',
       'replica timeline does not follow production',
       'replication slot retained WAL is too large',
+    ]);
+  });
+
+  test('pauses and resumes replica replay around snapshot work', async function testPausedReplicaReplay() {
+    const calls: string[] = [];
+    const docker = createReplicaReplayDocker(calls, ['pause requested', 'paused']);
+
+    const result = await withPausedReplicaReplay(async function snapshotReplica() {
+      calls.push('snapshot');
+      return 'done';
+    }, { docker, pollMs: 0 });
+
+    expect(result).toBe('done');
+    expect(calls).toEqual([
+      'container:velo-prod.base',
+      'sql:select pg_wal_replay_pause()',
+      'sql:select pg_get_wal_replay_pause_state()',
+      'sql:select pg_get_wal_replay_pause_state()',
+      'snapshot',
+      'sql:select pg_wal_replay_resume()',
+    ]);
+  });
+
+  test('resumes replica replay when snapshot work fails', async function testPausedReplicaReplayFailure() {
+    const calls: string[] = [];
+    const docker = createReplicaReplayDocker(calls, ['paused']);
+
+    await expect(withPausedReplicaReplay(async function failSnapshot() {
+      calls.push('snapshot');
+      throw new Error('snapshot failed');
+    }, { docker, pollMs: 0 })).rejects.toThrow('snapshot failed');
+
+    expect(calls).toEqual([
+      'container:velo-prod.base',
+      'sql:select pg_wal_replay_pause()',
+      'sql:select pg_get_wal_replay_pause_state()',
+      'snapshot',
+      'sql:select pg_wal_replay_resume()',
     ]);
   });
 
@@ -1154,4 +1192,26 @@ async function waitForJob(jobId: number) {
   }
 
   throw new Error(`job ${jobId} did not finish`);
+}
+
+function createReplicaReplayDocker(calls: string[], states: string[]) {
+  let stateIndex = 0;
+
+  return {
+    async getContainerByName(name: string): Promise<string | null> {
+      calls.push(`container:${name}`);
+      return 'replica-container';
+    },
+    async execSQL(_containerId: string, query: string): Promise<string> {
+      calls.push(`sql:${query}`);
+
+      if (query === 'select pg_get_wal_replay_pause_state()') {
+        const state = states[stateIndex] || states[states.length - 1] || 'paused';
+        stateIndex += 1;
+        return state;
+      }
+
+      return '';
+    },
+  };
 }

--- a/src/server/services/branch-service.ts
+++ b/src/server/services/branch-service.ts
@@ -11,7 +11,7 @@ import { getDb } from '../../db/client';
 import { runCommand } from './command-service';
 import { setStepStatus } from './setup-state-service';
 import { createBranchFromPgBackRest } from './pgbackrest-restore-service';
-import { cleanupOldReplicaBases, getReplicaBaseDataset, getReplicaFreshness } from './replica-service';
+import { cleanupOldReplicaBases, getReplicaBaseDataset, getReplicaFreshness, withPausedReplicaReplay } from './replica-service';
 import { createLocalDockerBranch, deleteLocalDockerBranch, deleteLocalDockerBranchResources, isLocalDockerMode, startLocalDockerBranchContainer, stopLocalDockerBranchContainer } from './local-docker-service';
 import { createJob, getActiveJobs } from './job-service';
 import { getBranchConnectionHost } from './branch-network-service';
@@ -197,7 +197,12 @@ async function createBranchClone(options: {
   let containerId: string | null = null;
 
   try {
-    await zfs.createSnapshot(options.sourceDataset, snapshotName);
+    await createSourceSnapshot({
+      zfs,
+      sourceBranch: options.sourceBranch,
+      sourceDataset: options.sourceDataset,
+      snapshotName,
+    });
     await zfs.cloneSnapshot(fullSnapshotName, targetDataset);
     await zfs.mountDataset(targetDataset);
 
@@ -290,6 +295,22 @@ async function createBranchClone(options: {
     });
     throw error;
   }
+}
+
+async function createSourceSnapshot(options: {
+  zfs: ZFSManager;
+  sourceBranch: string;
+  sourceDataset: string;
+  snapshotName: string;
+}): Promise<void> {
+  if (options.sourceBranch !== 'production') {
+    await options.zfs.createSnapshot(options.sourceDataset, options.snapshotName);
+    return;
+  }
+
+  await withPausedReplicaReplay(async function snapshotPausedReplica() {
+    await options.zfs.createSnapshot(options.sourceDataset, options.snapshotName);
+  });
 }
 
 export async function resetBranchFromParent(input: DeleteBranchInput): Promise<ReplaceBranchResult> {

--- a/src/server/services/replica-service.ts
+++ b/src/server/services/replica-service.ts
@@ -19,6 +19,8 @@ const BASE_DATASET_PREFIX = `${PROJECT_NAME}.${BASE_BRANCH_NAME}-`;
 const REPLICATION_USER = 'velo_replica';
 const REPLICATION_SLOT = 'velo_replica_base';
 const REPLICA_REPLAY_ADVANCE_TIMEOUT_MS = 60_000;
+const REPLICA_REPLAY_PAUSE_TIMEOUT_MS = 30_000;
+const REPLICA_REPLAY_PAUSE_POLL_MS = 100;
 const MAX_SLOT_RETAINED_WAL_BYTES = 1024 * 1024 * 1024;
 
 export interface ReplicaResult {
@@ -51,6 +53,12 @@ export interface ReplicaBaseHealth {
   ok: boolean;
   errors: string[];
   lagMs: number | null;
+}
+
+export interface ReplicaReplayPauseOptions {
+  docker?: Pick<DockerManager, 'getContainerByName' | 'execSQL'>;
+  pollMs?: number;
+  timeoutMs?: number;
 }
 
 export async function createReplicaBase(): Promise<ReplicaResult> {
@@ -309,6 +317,28 @@ export function buildReplicaBaseHealth(input: ReplicaBaseHealthInput): ReplicaBa
   };
 }
 
+export async function withPausedReplicaReplay<T>(
+  callback: () => Promise<T>,
+  options: ReplicaReplayPauseOptions = {}
+): Promise<T> {
+  const docker = options.docker || new DockerManager();
+  const containerName = getContainerName(PROJECT_NAME, BASE_BRANCH_NAME);
+  const containerId = await docker.getContainerByName(containerName);
+
+  if (!containerId) {
+    throw new Error(`Replica base container not found: ${containerName}`);
+  }
+
+  await docker.execSQL(containerId, 'select pg_wal_replay_pause()');
+
+  try {
+    await waitForReplayPaused(docker, containerId, options);
+    return await callback();
+  } finally {
+    await docker.execSQL(containerId, 'select pg_wal_replay_resume()');
+  }
+}
+
 async function configureProdReplication(options: {
   host: string;
   user: string;
@@ -457,6 +487,28 @@ async function getDevBaseHealthState(docker: DockerManager, containerId: string)
     replayPaused: replayPaused === 't',
     replayTimelineId: parseNullableInteger(replayTimelineId),
   };
+}
+
+async function waitForReplayPaused(
+  docker: Pick<DockerManager, 'execSQL'>,
+  containerId: string,
+  options: Pick<ReplicaReplayPauseOptions, 'pollMs' | 'timeoutMs'>
+): Promise<void> {
+  const pollMs = options.pollMs ?? REPLICA_REPLAY_PAUSE_POLL_MS;
+  const timeoutMs = options.timeoutMs ?? REPLICA_REPLAY_PAUSE_TIMEOUT_MS;
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const state = await docker.execSQL(containerId, 'select pg_get_wal_replay_pause_state()');
+
+    if (state.trim() === 'paused') {
+      return;
+    }
+
+    await Bun.sleep(pollMs);
+  }
+
+  throw new Error('Timed out waiting for replica WAL replay to pause');
 }
 
 interface ProductionHealthState {


### PR DESCRIPTION
## Summary
- pause dev replica WAL replay before production-base ZFS snapshots
- wait until replay is actually paused before cloning
- always resume replay after snapshot work, including failures
- assert Hetzner e2e branch creation leaves replica replay running

## API routes, procedures, contracts
- none

Closes #99

## Checks
- bun run typecheck
- bun run test
- bun run web:build