### PR TITLE
fix(branches): allow current replica with old replay timestamp

### DIFF
--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -239,6 +239,7 @@ describe('control plane database', function controlPlaneDatabase() {
     expect(getReplicaBranchCreatePolicy({ lagMs: 9000 })).toEqual({ status: 'allow', lagMs: 9000 });
     expect(getReplicaBranchCreatePolicy({ lagMs: 10_000 })).toEqual({ status: 'warn', lagMs: 10_000 });
     expect(getReplicaBranchCreatePolicy({ lagMs: 60_001 })).toEqual({ status: 'block', lagMs: 60_001 });
+    expect(getReplicaBranchCreatePolicy({ lagMs: 60_001, byteLag: 0 })).toEqual({ status: 'allow', lagMs: 60_001 });
   });
 
   test('accepts healthy dev replica base signals', function testHealthyReplicaBaseSignals() {

--- a/src/utils/replica-freshness-policy.ts
+++ b/src/utils/replica-freshness-policy.ts
@@ -5,6 +5,7 @@ export type ReplicaBranchCreateStatus = 'allow' | 'warn' | 'block';
 
 export interface ReplicaBranchFreshness {
   lagMs: number | null;
+  byteLag?: number | null;
 }
 
 export interface ReplicaBranchCreatePolicy {
@@ -16,6 +17,11 @@ export function getReplicaBranchCreatePolicy(
   freshness: ReplicaBranchFreshness | null | undefined
 ): ReplicaBranchCreatePolicy {
   const lagMs = freshness?.lagMs ?? null;
+  const byteLag = freshness?.byteLag ?? null;
+
+  if (byteLag === 0) {
+    return { status: 'allow', lagMs };
+  }
 
   if (lagMs === null || lagMs < REPLICA_BRANCH_WARN_MS) {
     return { status: 'allow', lagMs };


### PR DESCRIPTION
## Summary
- treat zero replica byte lag as current for branch creation
- keep timestamp lag warnings when byte lag is unknown or non-zero
- add policy coverage for idle production replicas

## API routes, procedures, contracts
- none

## Checks
- bun run typecheck
- bun run test