### PR TITLE
feat(api): add rest routes for public api

### DIFF
--- a/scripts/e2e/http-branch-api.ts
+++ b/scripts/e2e/http-branch-api.ts
@@ -10,16 +10,20 @@ export interface HttpBranchApiTestOptions {
 }
 
 export async function testHttpBranchApi(options: HttpBranchApiTestOptions): Promise<void> {
-  const { token } = await createApiToken(`e2e ${options.runId}`);
+  const { apiToken, token } = await createApiToken(`e2e ${options.runId}`);
+  const keys = await apiFetch<Array<{ id: number }>>(options, '/api-keys', token);
   const branchName = `e2e_http_${options.runId}`;
-  const created = await apiFetch<{ branch: { slug: string }; connectionUri: string }>(options, '/branches', token, {
+  const created = await apiFetch<{ branch: { slug: string }; connectionString: string }>(options, '/branches', token, {
     method: 'POST',
     body: JSON.stringify({ name: branchName }),
   });
   options.trackBranch(created.branch.slug);
 
+  assert(keys.some(function hasCreatedKey(key) {
+    return key.id === apiToken.id;
+  }), 'HTTP API keys list should include created key');
   assert(created.branch.slug === branchName, 'HTTP create should return branch slug');
-  assert(created.connectionUri.startsWith('postgresql://'), 'HTTP create should return connection URI');
+  assert(created.connectionString.startsWith('postgresql://'), 'HTTP create should return connection string');
   await options.assertBranchConnects(created.branch.slug);
 
   const listed = await apiFetch<{ branches: Array<{ slug: string }> }>(options, '/branches', token);
@@ -27,8 +31,8 @@ export async function testHttpBranchApi(options: HttpBranchApiTestOptions): Prom
     return branch.slug === created.branch.slug;
   }), 'HTTP list should include created branch');
 
-  const retrieved = await apiFetch<{ branch: { slug: string; connectionUri: string } }>(options, `/branches/${created.branch.slug}`, token);
-  assert(retrieved.branch.connectionUri === created.connectionUri, 'HTTP retrieve should return connection URI');
+  const retrieved = await apiFetch<{ branch: { slug: string; connectionString: string } }>(options, `/branches/${created.branch.slug}`, token);
+  assert(retrieved.branch.connectionString === created.connectionString, 'HTTP retrieve should return connection string');
 
   await apiFetch(options, `/branches/${created.branch.slug}`, token, { method: 'DELETE' });
   options.untrackBranch(created.branch.slug);

--- a/src/api/api-keys.ts
+++ b/src/api/api-keys.ts
@@ -11,14 +11,14 @@ const tokenIdInput = z.object({
   id: z.coerce.number().int().positive(),
 });
 
-export const apiTokensRouter = {
+export const apiKeysRouter = {
   list: publicProcedure
-    .route({ method: 'GET', path: '/api-tokens', summary: 'List API keys' })
+    .route({ method: 'GET', path: '/api-keys', summary: 'List API keys' })
     .handler(async function listTokens() {
       return listApiTokens();
     }),
   create: publicProcedure
-    .route({ method: 'POST', path: '/api-tokens', successStatus: 201, summary: 'Create API key' })
+    .route({ method: 'POST', path: '/api-keys', successStatus: 201, summary: 'Create API key' })
     .input(createTokenInput)
     .handler(async function createToken({ input }) {
       try {
@@ -28,7 +28,7 @@ export const apiTokensRouter = {
       }
     }),
   revoke: publicProcedure
-    .route({ method: 'DELETE', path: '/api-tokens/{id}', summary: 'Revoke API key' })
+    .route({ method: 'DELETE', path: '/api-keys/{id}', summary: 'Revoke API key' })
     .input(tokenIdInput)
     .handler(async function revokeToken({ input }) {
       try {

--- a/src/api/backup.ts
+++ b/src/api/backup.ts
@@ -16,8 +16,11 @@ const backupInput = z.object({
 
 export const backupRouter = {
   settings: {
-    update: publicProcedure.input(backupInput).handler(async function updateBackupSettings({ input }) {
-      return saveBackupSettings(input);
-    }),
+    update: publicProcedure
+      .route({ method: 'PUT', path: '/backup/settings', summary: 'Update backup settings' })
+      .input(backupInput)
+      .handler(async function updateBackupSettings({ input }) {
+        return saveBackupSettings(input);
+      }),
   },
 };

--- a/src/api/branch-contract.ts
+++ b/src/api/branch-contract.ts
@@ -13,7 +13,7 @@ export const branchSchema = z.object({
   }).nullable(),
   createdAt: z.string().nullable(),
   expiresAt: z.string().nullable(),
-  connectionUri: z.string().nullable(),
+  connectionString: z.string().nullable(),
 });
 
 export const branchCreateInput = z.object({
@@ -45,7 +45,7 @@ export const branchesContract = {
     .input(branchCreateInput)
     .output(z.object({
       branch: branchSchema,
-      connectionUri: z.string(),
+      connectionString: z.string(),
       replicaWarning: z.string().nullable(),
     })),
   delete: oc
@@ -64,7 +64,7 @@ export const branchesContract = {
     .input(branchSlugInput)
     .output(z.object({
       branch: branchSchema,
-      connectionUri: z.string(),
+      connectionString: z.string(),
     })),
   expiry: {
     update: oc

--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -16,7 +16,7 @@ import {
 } from '#server/services/branch-api-service';
 
 const branchIdInput = z.object({
-  id: z.number().int().positive(),
+  id: z.coerce.number().int().positive(),
 });
 
 const previewBranchInput = z.object({
@@ -82,11 +82,13 @@ export const branchesRouter = {
   },
   preview: {
     create: publicProcedure
+      .route({ method: 'POST', path: '/branches/{sourceBranch}/previews', successStatus: 201, summary: 'Create preview branch' })
       .input(previewBranchInput)
       .handler(async function createBranchPreview({ input }) {
         return createPreviewBranch(input);
       }),
     delete: publicProcedure
+      .route({ method: 'DELETE', path: '/branch-previews/{id}', summary: 'Delete preview branch' })
       .input(branchIdInput)
       .handler(async function deleteBranchPreview({ input }) {
         try {
@@ -98,6 +100,7 @@ export const branchesRouter = {
   },
   sql: {
     run: publicProcedure
+      .route({ method: 'POST', path: '/branches/{branchId}/sql', summary: 'Run branch SQL' })
       .input(runSqlInput)
       .handler(async function runSql({ input }) {
         try {
@@ -108,6 +111,7 @@ export const branchesRouter = {
       }),
   },
   restore: publicProcedure
+    .route({ method: 'POST', path: '/branches/{targetBranch}/restore', summary: 'Restore branch' })
     .input(restoreBranchInput)
     .handler(async function restoreBranch({ input }) {
       assertProductionRestoreConfirmed(input.targetBranch, input.productionRestoreConfirmation);

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -2,7 +2,9 @@ import { publicProcedure } from './context';
 import { getControlPlaneState } from '#server/services/setup-state-service';
 
 export const dashboardRouter = {
-  retrieve: publicProcedure.handler(async function retrieveDashboard() {
-    return getControlPlaneState();
-  }),
+  retrieve: publicProcedure
+    .route({ method: 'GET', path: '/dashboard', summary: 'Get dashboard state' })
+    .handler(async function retrieveDashboard() {
+      return getControlPlaneState();
+    }),
 };

--- a/src/api/jobs.ts
+++ b/src/api/jobs.ts
@@ -3,13 +3,14 @@ import { publicProcedure } from './context';
 import { cancelJobById, getJob, listJobs, retryJobById } from '#server/services/job-service';
 
 const jobStatusInput = z.enum(['queued', 'running', 'done', 'error', 'cancelled']);
-const jobIdInput = z.object({ id: z.number().int().positive() });
+const jobIdInput = z.object({ id: z.coerce.number().int().positive() });
 
 export const jobsRouter = {
   list: publicProcedure
+    .route({ method: 'GET', path: '/jobs', summary: 'List jobs' })
     .input(z.object({
-      limit: z.number().int().positive().max(100).optional(),
-      offset: z.number().int().min(0).optional(),
+      limit: z.coerce.number().int().positive().max(100).optional(),
+      offset: z.coerce.number().int().min(0).optional(),
       status: jobStatusInput.optional(),
       type: z.string().min(1).optional(),
     }).optional())
@@ -21,16 +22,19 @@ export const jobsRouter = {
       });
     }),
   retrieve: publicProcedure
+    .route({ method: 'GET', path: '/jobs/{id}', summary: 'Get job' })
     .input(jobIdInput)
     .handler(async function retrieveJob({ input }) {
       return getJob(input.id);
     }),
   retry: publicProcedure
+    .route({ method: 'POST', path: '/jobs/{id}/retry', summary: 'Retry job' })
     .input(jobIdInput)
     .handler(async function retryJob({ input }) {
       return retryJobById(input.id);
     }),
   cancel: publicProcedure
+    .route({ method: 'POST', path: '/jobs/{id}/cancel', summary: 'Cancel job' })
     .input(jobIdInput)
     .handler(async function cancelJob({ input }) {
       return cancelJobById(input.id);

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,5 +1,5 @@
 import { createRouterClient } from '@orpc/server';
-import { apiTokensRouter } from './api-tokens';
+import { apiKeysRouter } from './api-keys';
 import { backupRouter } from './backup';
 import { branchesRouter } from './branches';
 import { createOrpcContext } from './context';
@@ -10,7 +10,7 @@ import { tablesRouter } from './tables';
 import { updatesRouter } from './updates';
 
 export const appRouter = {
-  apiTokens: apiTokensRouter,
+  apiKeys: apiKeysRouter,
   dashboard: dashboardRouter,
   jobs: jobsRouter,
   servers: serversRouter,

--- a/src/api/servers.ts
+++ b/src/api/servers.ts
@@ -11,10 +11,14 @@ const serverInput = z.object({
 });
 
 export const serversRouter = {
-  update: publicProcedure.input(serverInput).handler(async function updateServer({ input }) {
-    return saveServer(input);
-  }),
+  update: publicProcedure
+    .route({ method: 'PUT', path: '/servers/{role}', summary: 'Update server' })
+    .input(serverInput)
+    .handler(async function updateServer({ input }) {
+      return saveServer(input);
+    }),
   check: publicProcedure
+    .route({ method: 'POST', path: '/servers/{role}/check', summary: 'Check server' })
     .input(z.object({ role: z.enum(['prod', 'dev']) }))
     .handler(async function checkServerHealth({ input }) {
       return checkServer(input.role);

--- a/src/api/tables.ts
+++ b/src/api/tables.ts
@@ -21,7 +21,7 @@ const tableRowsInput = z.object({
   database: z.string().min(1),
   schema: z.string().min(1),
   table: z.string().min(1),
-  offset: z.number().int().min(0).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
 });
 
 const tableRowValues = z.record(z.string(), z.string().nullable());
@@ -46,16 +46,19 @@ const tableDeleteInput = tableRowsInput.extend({
 
 export const tablesRouter = {
   browse: publicProcedure
+    .route({ method: 'GET', path: '/branches/{branchId}/tables', summary: 'Browse branch tables' })
     .input(tableBrowserInput)
     .handler(async function browseTables({ input }) {
       return getTableBrowserMetadata(input);
     }),
   rows: publicProcedure
+    .route({ method: 'GET', path: '/branches/{branchId}/tables/{database}/{schema}/{table}/rows', summary: 'List table rows' })
     .input(tableRowsInput)
     .handler(async function browseRows({ input }) {
       return getTableRows(input);
     }),
   insert: publicProcedure
+    .route({ method: 'POST', path: '/branches/{branchId}/tables/{database}/{schema}/{table}/rows', successStatus: 201, summary: 'Insert table row' })
     .input(tableInsertInput)
     .handler(async function insertRow({ input }) {
       try {
@@ -65,6 +68,7 @@ export const tablesRouter = {
       }
     }),
   update: publicProcedure
+    .route({ method: 'PATCH', path: '/branches/{branchId}/tables/{database}/{schema}/{table}/rows/{rowId}', summary: 'Update table row' })
     .input(tableUpdateInput)
     .handler(async function updateRow({ input }) {
       try {
@@ -74,6 +78,7 @@ export const tablesRouter = {
       }
     }),
   delete: publicProcedure
+    .route({ method: 'DELETE', path: '/branches/{branchId}/tables/{database}/{schema}/{table}/rows/{rowId}', summary: 'Delete table row' })
     .input(tableDeleteInput)
     .handler(async function deleteRow({ input }) {
       try {

--- a/src/api/updates.ts
+++ b/src/api/updates.ts
@@ -19,40 +19,55 @@ const autoUpdateInput = z.object({
 });
 
 export const updatesRouter = {
-  get: publicProcedure.handler(async function getUpdates() {
-    return formatUpdateInfo(await getUpdateStatus());
-  }),
-  check: publicProcedure.handler(async function checkUpdates() {
-    return formatUpdateInfo(await checkForUpdate(true));
-  }),
-  apply: publicProcedure.handler(async function applyAvailableUpdate() {
-    const result = await applyUpdate();
+  get: publicProcedure
+    .route({ method: 'GET', path: '/updates', summary: 'Get update status' })
+    .handler(async function getUpdates() {
+      return formatUpdateInfo(await getUpdateStatus());
+    }),
+  check: publicProcedure
+    .route({ method: 'POST', path: '/updates/check', summary: 'Check for updates' })
+    .handler(async function checkUpdates() {
+      return formatUpdateInfo(await checkForUpdate(true));
+    }),
+  apply: publicProcedure
+    .route({ method: 'POST', path: '/updates/apply', summary: 'Apply update' })
+    .handler(async function applyAvailableUpdate() {
+      const result = await applyUpdate();
 
-    if (!result.success) {
-      throw new Error(result.error || 'Could not apply update.');
-    }
+      if (!result.success) {
+        throw new Error(result.error || 'Could not apply update.');
+      }
 
-    return { success: true };
-  }),
-  result: publicProcedure.handler(async function getUpdateResult() {
-    return (await getPersistedUpdateResult()) || {
-      completed: false,
-      success: false,
-      newVersion: null,
-      log: null,
-    };
-  }),
-  clearResult: publicProcedure.handler(async function clearUpdateResult() {
-    await clearPersistedUpdateResult();
-    return { success: true };
-  }),
+      return { success: true };
+    }),
+  result: publicProcedure
+    .route({ method: 'GET', path: '/updates/result', summary: 'Get update result' })
+    .handler(async function getUpdateResult() {
+      return (await getPersistedUpdateResult()) || {
+        completed: false,
+        success: false,
+        newVersion: null,
+        log: null,
+      };
+    }),
+  clearResult: publicProcedure
+    .route({ method: 'DELETE', path: '/updates/result', summary: 'Clear update result' })
+    .handler(async function clearUpdateResult() {
+      await clearPersistedUpdateResult();
+      return { success: true };
+    }),
   auto: {
-    get: publicProcedure.handler(async function getAutoUpdates() {
-      return getAutoUpdateSettings();
-    }),
-    update: publicProcedure.input(autoUpdateInput).handler(async function updateAutoUpdates({ input }) {
-      return saveAutoUpdateSettings(input);
-    }),
+    get: publicProcedure
+      .route({ method: 'GET', path: '/updates/auto', summary: 'Get auto-update settings' })
+      .handler(async function getAutoUpdates() {
+        return getAutoUpdateSettings();
+      }),
+    update: publicProcedure
+      .route({ method: 'PATCH', path: '/updates/auto', summary: 'Update auto-update settings' })
+      .input(autoUpdateInput)
+      .handler(async function updateAutoUpdates({ input }) {
+        return saveAutoUpdateSettings(input);
+      }),
   },
 };
 

--- a/src/server/control-plane.test.ts
+++ b/src/server/control-plane.test.ts
@@ -545,12 +545,12 @@ describe('control plane database', function controlPlaneDatabase() {
     expect(list.branches.map(function mapBranch(branch) {
       return branch.slug;
     })).toEqual(['production', 'dev']);
-    expect(list.branches[0]?.connectionUri).toBe('postgresql://postgres:prod@example.com:5432/postgres');
+    expect(list.branches[0]?.connectionString).toBe('postgresql://postgres:prod@example.com:5432/postgres');
     expect(retrieved.branch).toMatchObject({
       slug: 'dev',
       name: 'dev',
       type: 'development',
-      connectionUri: 'postgresql://postgres:dev@example.com:41001/postgres',
+      connectionString: 'postgresql://postgres:dev@example.com:41001/postgres',
     });
   });
 
@@ -568,9 +568,10 @@ describe('control plane database', function controlPlaneDatabase() {
     expect(await verifyApiToken(created.token)).toBe(false);
   });
 
-  test('serves OpenAPI branch routes with bearer auth', async function testOpenApiBranchBearerAuth() {
+  test('serves REST routes with bearer auth', async function testOpenApiBearerAuth() {
     await setPassword('password123');
     const created = await createApiToken('ci');
+    const job = await createAuditJob('api-test', { ok: true }, 'api test');
     const projectId = await createProject();
     await setSetting('prod.connectionUrl', 'postgresql://postgres:prod@example.com:5432/postgres');
     await createBranchRecord({
@@ -599,19 +600,90 @@ describe('control plane database', function controlPlaneDatabase() {
         },
       }),
     }, { startDevJobWorker: false });
+    const apiKeysResponse = await handleApiRequest({
+      request: new Request('http://example.com/api/v1/api-keys', {
+        headers: {
+          authorization: `Bearer ${created.token}`,
+        },
+      }),
+    }, { startDevJobWorker: false });
+    const dashboardResponse = await handleApiRequest({
+      request: new Request('http://example.com/api/v1/dashboard', {
+        headers: {
+          authorization: `Bearer ${created.token}`,
+        },
+      }),
+    }, { startDevJobWorker: false });
+    const jobsResponse = await handleApiRequest({
+      request: new Request('http://example.com/api/v1/jobs?limit=1&type=api-test', {
+        headers: {
+          authorization: `Bearer ${created.token}`,
+        },
+      }),
+    }, { startDevJobWorker: false });
+    const jobResponse = await handleApiRequest({
+      request: new Request(`http://example.com/api/v1/jobs/${job.id}`, {
+        headers: {
+          authorization: `Bearer ${created.token}`,
+        },
+      }),
+    }, { startDevJobWorker: false });
     const body = await authorized.json() as {
-      branches: Array<{ slug: string; connectionUri: string | null }>;
+      branches: Array<{ slug: string; connectionString: string | null }>;
     };
     const spec = await specResponse.json() as { paths: Record<string, unknown> };
+    const apiKeys = await apiKeysResponse.json() as Array<{ id: number }>;
+    const dashboard = await dashboardResponse.json() as { branches: unknown[] };
+    const jobs = await jobsResponse.json() as Array<{ id: number }>;
+    const retrievedJob = await jobResponse.json() as { id: number };
 
     expect(unauthorized.status).toBe(401);
     expect(authorized.status).toBe(200);
     expect(specResponse.status).toBe(200);
+    expect(apiKeysResponse.status).toBe(200);
+    expect(dashboardResponse.status).toBe(200);
+    expect(jobsResponse.status).toBe(200);
+    expect(jobResponse.status).toBe(200);
     expect(body.branches.map(function mapBranch(branch) {
       return branch.slug;
     })).toEqual(['production', 'dev']);
-    expect(body.branches[1]?.connectionUri).toBe('postgresql://postgres:dev@example.com:41001/postgres');
-    expect(spec.paths['/branches']).toBeTruthy();
+    expect(body.branches[1]?.connectionString).toBe('postgresql://postgres:dev@example.com:41001/postgres');
+    expect(apiKeys.map(function mapKey(key) {
+      return key.id;
+    })).toContain(created.apiToken.id);
+    expect(dashboard.branches).toHaveLength(1);
+    expect(jobs[0]?.id).toBe(job.id);
+    expect(retrievedJob.id).toBe(job.id);
+    expect([
+      '/api-keys',
+      '/api-keys/{id}',
+      '/backup/settings',
+      '/branch-previews/{id}',
+      '/branches',
+      '/branches/{branchId}/sql',
+      '/branches/{branchId}/tables',
+      '/branches/{branchId}/tables/{database}/{schema}/{table}/rows',
+      '/branches/{branchId}/tables/{database}/{schema}/{table}/rows/{rowId}',
+      '/branches/{slug}',
+      '/branches/{slug}/expiry',
+      '/branches/{slug}/reset',
+      '/branches/{sourceBranch}/previews',
+      '/branches/{targetBranch}/restore',
+      '/dashboard',
+      '/jobs',
+      '/jobs/{id}',
+      '/jobs/{id}/cancel',
+      '/jobs/{id}/retry',
+      '/servers/{role}',
+      '/servers/{role}/check',
+      '/updates',
+      '/updates/apply',
+      '/updates/auto',
+      '/updates/check',
+      '/updates/result',
+    ].every(function hasPath(path) {
+      return Boolean(spec.paths[path]);
+    })).toBe(true);
   });
 
   test('promotes ready replacement without changing branch identity', async function testPromoteReadyReplacement() {

--- a/src/server/services/branch-api-service.ts
+++ b/src/server/services/branch-api-service.ts
@@ -26,7 +26,7 @@ export interface BranchApiRecord {
   } | null;
   createdAt: string | null;
   expiresAt: string | null;
-  connectionUri: string | null;
+  connectionString: string | null;
 }
 
 export async function listBranchesApi(): Promise<{ branches: BranchApiRecord[] }> {
@@ -57,7 +57,7 @@ export async function getBranchApi(slug: string): Promise<{ branch: BranchApiRec
 
 export async function createBranchApi(input: CreateBranchApiInput): Promise<{
   branch: BranchApiRecord;
-  connectionUri: string;
+  connectionString: string;
   replicaWarning: string | null;
 }> {
   const branchSlug = normalizeBranchSlug(input.name);
@@ -76,13 +76,13 @@ export async function createBranchApi(input: CreateBranchApiInput): Promise<{
 
   const branch = mapDevelopmentBranchRow(await getBranchRecord(branchSlug));
 
-  if (!branch.connectionUri) {
-    throw new Error('Branch connection URI is missing');
+  if (!branch.connectionString) {
+    throw new Error('Branch connection string is missing');
   }
 
   return {
     branch,
-    connectionUri: branch.connectionUri,
+    connectionString: branch.connectionString,
     replicaWarning: replicaPolicy.status === 'warn' ? formatReplicaWarning(replicaPolicy) : null,
   };
 }
@@ -111,7 +111,7 @@ export async function deleteBranchApi(slug: string): Promise<{
 
 export async function resetBranchApi(slug: string): Promise<{
   branch: BranchApiRecord;
-  connectionUri: string;
+  connectionString: string;
 }> {
   const normalized = normalizeDevelopmentBranchLookup(slug);
   const branch = await getBranchRecord(normalized);
@@ -119,13 +119,13 @@ export async function resetBranchApi(slug: string): Promise<{
 
   const updated = mapDevelopmentBranchRow(await getBranchRecord(normalized));
 
-  if (!updated.connectionUri) {
-    throw new Error('Branch connection URI is missing');
+  if (!updated.connectionString) {
+    throw new Error('Branch connection string is missing');
   }
 
   return {
     branch: updated,
-    connectionUri: updated.connectionUri,
+    connectionString: updated.connectionString,
   };
 }
 
@@ -147,18 +147,18 @@ export async function updateBranchExpiryApi(input: {
 }
 
 async function getProductionBranchApiRecord(): Promise<BranchApiRecord> {
-  const connectionUri = await getSetting('prod.connectionUrl');
+  const connectionString = await getSetting('prod.connectionUrl');
 
   return {
     id: 'production',
     slug: 'production',
     name: 'production',
     type: 'production',
-    status: connectionUri ? 'ready' : 'pending',
+    status: connectionString ? 'ready' : 'pending',
     parent: null,
     createdAt: null,
     expiresAt: null,
-    connectionUri,
+    connectionString,
   };
 }
 
@@ -211,7 +211,7 @@ function mapDevelopmentBranchRow(row: BranchRecord): BranchApiRecord {
     },
     createdAt: row.createdAt,
     expiresAt: row.expiresAt,
-    connectionUri: row.connectionUrl,
+    connectionString: row.connectionUrl,
   };
 }
 

--- a/src/web/components/settings/api-keys-panel.tsx
+++ b/src/web/components/settings/api-keys-panel.tsx
@@ -22,15 +22,15 @@ import { orpc } from '#web/lib/api-client';
 
 export function ApiKeysPanel() {
   const queryClient = useQueryClient();
-  const apiTokens = useQuery(orpc.apiTokens.list.queryOptions());
-  const createToken = useMutation(orpc.apiTokens.create.mutationOptions({ onSuccess: refreshApiTokens }));
-  const revokeToken = useMutation(orpc.apiTokens.revoke.mutationOptions({ onSuccess: refreshApiTokens }));
+  const apiKeys = useQuery(orpc.apiKeys.list.queryOptions());
+  const createToken = useMutation(orpc.apiKeys.create.mutationOptions({ onSuccess: refreshApiTokens }));
+  const revokeToken = useMutation(orpc.apiKeys.revoke.mutationOptions({ onSuccess: refreshApiTokens }));
   const [name, setName] = useState('');
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const [revokeId, setRevokeId] = useState<number | null>(null);
 
   async function refreshApiTokens() {
-    await queryClient.invalidateQueries({ queryKey: orpc.apiTokens.list.key() });
+    await queryClient.invalidateQueries({ queryKey: orpc.apiKeys.list.key() });
   }
 
   async function handleCreate(event: FormEvent<HTMLFormElement>) {
@@ -71,7 +71,7 @@ export function ApiKeysPanel() {
     }
   }
 
-  const tokens = apiTokens.data || [];
+  const tokens = apiKeys.data || [];
 
   return (
     <Card>
@@ -111,7 +111,7 @@ export function ApiKeysPanel() {
         ) : null}
 
         <div className="grid gap-2">
-          {apiTokens.isLoading ? (
+          {apiKeys.isLoading ? (
             <div className="flex items-center gap-2 rounded-md border border-border p-3 text-sm text-muted-foreground">
               <Loader2 className="size-4 animate-spin" />
               Loading API keys


### PR DESCRIPTION
## Summary
- add REST-shaped OpenAPI routes for dashboard, jobs, servers, backup, branch extras, tables, and updates
- rename public API key routes from `/api-tokens` to `/api-keys`
- rename branch response `connectionUri` to `connectionString`
- add integration coverage for the expanded REST surface
- update HTTP e2e coverage for `/api-keys`

## API routes, procedures, contracts
Added/updated:
- `GET /api/v1/dashboard`
- `GET /api/v1/jobs`
- `GET /api/v1/jobs/{id}`
- `POST /api/v1/jobs/{id}/retry`
- `POST /api/v1/jobs/{id}/cancel`
- `PUT /api/v1/servers/{role}`
- `POST /api/v1/servers/{role}/check`
- `PUT /api/v1/backup/settings`
- `POST /api/v1/branches/{sourceBranch}/previews`
- `DELETE /api/v1/branch-previews/{id}`
- `POST /api/v1/branches/{branchId}/sql`
- `POST /api/v1/branches/{targetBranch}/restore`
- `GET /api/v1/branches/{branchId}/tables`
- `GET /api/v1/branches/{branchId}/tables/{database}/{schema}/{table}/rows`
- `POST /api/v1/branches/{branchId}/tables/{database}/{schema}/{table}/rows`
- `PATCH /api/v1/branches/{branchId}/tables/{database}/{schema}/{table}/rows/{rowId}`
- `DELETE /api/v1/branches/{branchId}/tables/{database}/{schema}/{table}/rows/{rowId}`
- `GET /api/v1/updates`
- `POST /api/v1/updates/check`
- `POST /api/v1/updates/apply`
- `GET /api/v1/updates/result`
- `DELETE /api/v1/updates/result`
- `GET /api/v1/updates/auto`
- `PATCH /api/v1/updates/auto`
- `GET /api/v1/api-keys`
- `POST /api/v1/api-keys`
- `DELETE /api/v1/api-keys/{id}`

Changed:
- public branch API responses now use `connectionString` instead of `connectionUri`

Deleted:
- `/api/v1/api-tokens` public routes

## Checks
- `bun run typecheck`
- `bun run test`
- `bun run web:build`
- `bash -n scripts/*.sh`
