### PR TITLE
chore(release): revert accidental version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@elitan/velo",
   "displayName": "Velo",
   "containerPrefix": "velo",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "Web-first PostgreSQL branching with ZFS snapshots",
   "author": "Johan Eliasson <johan@eliasson.me> (https://github.com/elitan)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- revert accidental package version bump from canceled release run
- removed stray v1.2.0 tag before this PR

## API routes, procedures, contracts
- none

## Checks
- not run; package version revert only