### PR TITLE
chore(release): revert failed release bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@elitan/velo",
   "displayName": "Velo",
   "containerPrefix": "velo",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Web-first PostgreSQL branching with ZFS snapshots",
   "author": "Johan Eliasson <johan@eliasson.me> (https://github.com/elitan)",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- revert accidental 1.1.0 package version bump from failed release run
- leaves latest published release as v1.0.0

## API routes, procedures, contracts
- none

## Checks
- not run; package version revert only