### PR TITLE
fix(release): run checks before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
             range="HEAD"
           fi
 
-          git log --pretty=format:'%s' --no-merges "$range" > commits.txt
+          git log --pretty=format:'%s' --no-merges "$range" \
+            | grep -Ev '^chore\(release\): (bump version to|revert .*version bump|revert .*release bump)' \
+            > commits.txt || true
           if [ ! -s commits.txt ]; then
             echo "No commits since last release."
             exit 1
@@ -104,30 +106,32 @@ jobs:
           esac
           echo "value=$major.$minor.$patch" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release target
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.value }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "Tag v$version already exists."
+            exit 1
+          fi
+          if gh release view "v$version" >/dev/null 2>&1; then
+            echo "Release v$version already exists."
+            exit 1
+          fi
+
       - name: Bump package version
         run: |
           set -euo pipefail
           jq '.version = "${{ steps.version.outputs.value }}"' package.json > package.tmp
           mv package.tmp package.json
 
-      - name: Commit version bump
-        run: |
-          set -euo pipefail
-          git add package.json
-          git commit -m "chore(release): bump version to ${{ steps.version.outputs.value }}"
-          git push
-
-      - name: Tag release
-        run: |
-          set -euo pipefail
-          git tag "v${{ steps.version.outputs.value }}"
-          git push origin "v${{ steps.version.outputs.value }}"
-
       - name: Generate release notes
         run: |
           set -euo pipefail
           version="${{ steps.version.outputs.value }}"
-          VELO_LAST_TAG="${{ steps.policy.outputs.last_tag }}" scripts/generate-release-notes.sh "$version" release_notes.md HEAD^
+          VELO_LAST_TAG="${{ steps.policy.outputs.last_tag }}" scripts/generate-release-notes.sh "$version" release_notes.md HEAD
           cat release_notes.md
 
       - name: Setup Bun
@@ -139,6 +143,8 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Check
+        env:
+          VELO_UPGRADE_TARGET_VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           bun run typecheck
@@ -176,6 +182,19 @@ jobs:
           path: |
             velo-v${{ steps.version.outputs.value }}.tar.gz
             release_notes.md
+
+      - name: Commit version bump
+        run: |
+          set -euo pipefail
+          git add package.json
+          git commit -m "chore(release): bump version to ${{ steps.version.outputs.value }}"
+          git push
+
+      - name: Tag release
+        run: |
+          set -euo pipefail
+          git tag "v${{ steps.version.outputs.value }}"
+          git push origin "v${{ steps.version.outputs.value }}"
 
       - name: Create GitHub release
         env:

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -17,7 +17,18 @@ tmp="$(mktemp)"
 notes="$(mktemp)"
 trap 'rm -f "$tmp" "$notes"' EXIT
 
-git log --pretty=format:'%h%x1f%s' --no-merges "$RANGE" > "$tmp"
+is_release_mechanics() {
+  local subject="$1"
+  printf '%s\n' "$subject" | grep -Eq '^chore\(release\): (bump version to|revert .*version bump|revert .*release bump)'
+}
+
+git log --pretty=format:'%h%x1f%s' --no-merges "$RANGE" | while IFS=$'\x1f' read -r hash subject || [ -n "$hash$subject" ]; do
+  [ -n "$subject" ] || continue
+  if is_release_mechanics "$subject"; then
+    continue
+  fi
+  printf '%s\x1f%s\n' "$hash" "$subject"
+done > "$tmp"
 
 append_section() {
   local title="$1"


### PR DESCRIPTION
## Summary
- move release version commit and tag publish after checks, tarball build, and smoke tests
- validate target release/tag before preparing the release
- filter accidental release bump/revert commits from bump policy and release notes
- make release upgrade smoke use the selected release version

## API routes, procedures, contracts
- none

## Checks
- bun run typecheck
- bun run test
- bun run web:build
- bash -n scripts/*.sh
- scripts/generate-release-notes.sh 1.1.0 /tmp/velo-release-notes.md HEAD
- scripts/test-release-artifact.sh
- scripts/test-update-flow.sh
- VELO_UPGRADE_TARGET_VERSION=1.1.0 scripts/test-release-upgrade-flow.sh (exited cleanly; skipped old v1.0.0 source because it lacks current release scripts)