### PR TITLE
feat(branches): add stop branch action

### DIFF
--- a/src/api/branch-contract.ts
+++ b/src/api/branch-contract.ts
@@ -86,6 +86,14 @@ export const branchesContract = oc.tag(OPEN_API_TAGS.branches).router({
         connectionString: z.string(),
       }),
     ),
+  stop: oc
+    .route({
+      method: 'POST',
+      path: '/branches/{slug}/stop',
+      summary: 'Stop branch',
+    })
+    .input(branchSlugInput)
+    .output(z.object({ branch: branchSchema })),
   expiry: {
     update: oc
       .route({

--- a/src/api/branches.ts
+++ b/src/api/branches.ts
@@ -6,7 +6,15 @@ import { userFacingError } from './errors';
 import { OPEN_API_TAGS } from './openapi-tags';
 import { createJob } from '#server/services/job-service';
 import { runBranchSql } from '#server/services/sql-editor-service';
-import { createBranchApi, deleteBranchApi, getBranchApi, listBranchesApi, resetBranchApi, updateBranchExpiryApi } from '#server/services/branch-api-service';
+import {
+  createBranchApi,
+  deleteBranchApi,
+  getBranchApi,
+  listBranchesApi,
+  resetBranchApi,
+  stopBranchApi,
+  updateBranchExpiryApi,
+} from '#server/services/branch-api-service';
 
 const restoreBranchInput = z.object({
   targetBranch: z.string().min(1),
@@ -89,6 +97,13 @@ export const branchesRouter = {
       return await resetBranchApi(input.slug);
     } catch (error) {
       throw userFacingError(error, 'Could not reset branch');
+    }
+  }),
+  stop: branchContractRouter.stop.handler(async function stopBranch({ input }) {
+    try {
+      return await stopBranchApi(input.slug);
+    } catch (error) {
+      throw userFacingError(error, 'Could not stop branch');
     }
   }),
   expiry: {

--- a/src/server/api-routes.test.ts
+++ b/src/server/api-routes.test.ts
@@ -30,6 +30,7 @@ const EXPECTED_REST_PATHS = [
   '/branches/{slug}',
   '/branches/{slug}/expiry',
   '/branches/{slug}/reset',
+  '/branches/{slug}/stop',
   '/branches/{targetBranch}/restore',
   '/dashboard',
   '/jobs',

--- a/src/server/services/branch-api-service.ts
+++ b/src/server/services/branch-api-service.ts
@@ -4,6 +4,7 @@ import {
   deleteBranch,
   normalizeBranchSlug,
   resetBranchFromParent,
+  stopBranchForProxy,
   updateBranchExpiry,
 } from './branch-service';
 import { getReplicaFreshness } from './replica-service';
@@ -126,6 +127,17 @@ export async function resetBranchApi(slug: string): Promise<{
   return {
     branch: updated,
     connectionString: updated.connectionString,
+  };
+}
+
+export async function stopBranchApi(slug: string): Promise<{ branch: BranchApiRecord }> {
+  const normalized = normalizeDevelopmentBranchLookup(slug);
+  const branch = await getBranchRecord(normalized);
+
+  await stopBranchForProxy(branch.id);
+
+  return {
+    branch: mapDevelopmentBranchRow(await getBranchRecord(normalized)),
   };
 }
 

--- a/src/web/routes/branch/$branchId/overview.tsx
+++ b/src/web/routes/branch/$branchId/overview.tsx
@@ -8,6 +8,7 @@ import {
   GitBranch,
   Loader2,
   Pencil,
+  Power,
   RotateCcw,
   ShieldCheck,
   Trash2,
@@ -66,6 +67,8 @@ export const Route = createFileRoute('/branch/$branchId/overview')({
   component: BranchOverviewPage,
 });
 
+type BusyKey = 'create-child' | 'delete' | 'reset' | 'stop' | null;
+
 function BranchOverviewPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -73,6 +76,7 @@ function BranchOverviewPage() {
   const createBranch = useMutation(orpc.branches.create.mutationOptions({ onSuccess: refreshDashboard }));
   const deleteBranch = useMutation(orpc.branches.delete.mutationOptions({ onSuccess: refreshDashboard }));
   const resetBranch = useMutation(orpc.branches.reset.mutationOptions({ onSuccess: refreshDashboard }));
+  const stopBranch = useMutation(orpc.branches.stop.mutationOptions({ onSuccess: refreshDashboard }));
   const updateExpiry = useMutation(orpc.branches.expiry.update.mutationOptions({ onSuccess: refreshDashboard }));
   const params = Route.useParams();
   const busy = getBusyKey();
@@ -93,8 +97,10 @@ function BranchOverviewPage() {
   const state = dashboard.data;
 
   const branch = getBranchView(state, params.branchId);
+  const branchIsStopped = branch.status === 'stopped';
+  const canStopBranch = branch.rowId !== null && !branchIsStopped;
 
-  function getBusyKey(): string | null {
+  function getBusyKey(): BusyKey {
     if (createBranch.isPending) {
       return 'create-child';
     }
@@ -105,6 +111,10 @@ function BranchOverviewPage() {
 
     if (deleteBranch.isPending) {
       return 'delete';
+    }
+
+    if (stopBranch.isPending) {
+      return 'stop';
     }
 
     return null;
@@ -171,6 +181,19 @@ function BranchOverviewPage() {
     }
 
     await navigate({ to: '/branch/$branchId/overview', params: { branchId: branch.parentSlug || 'production' } });
+  }
+
+  async function handleStop() {
+    if (!branch.rowId) {
+      return;
+    }
+
+    try {
+      const result = await stopBranch.mutateAsync({ slug: branch.slug });
+      toast.success(result.branch.status === 'stopped' ? `Stopped ${branch.name}.` : `${branch.name} is still running.`);
+    } catch (error: any) {
+      toast.error(getMutationErrorMessage(error, 'Could not stop branch.'));
+    }
   }
 
   function handleConfirmAction() {
@@ -264,6 +287,15 @@ function BranchOverviewPage() {
                     >
                       <RotateCcw />
                       Reset from parent
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={!canStopBranch || busy === 'stop'}
+                      onSelect={function selectStop() {
+                        void handleStop();
+                      }}
+                    >
+                      {busy === 'stop' ? <Loader2 className="animate-spin" /> : <Power />}
+                      {branchIsStopped ? 'Already stopped' : 'Stop branch'}
                     </DropdownMenuItem>
                     <DropdownMenuItem disabled>
                       <Pencil />


### PR DESCRIPTION
## Summary
- add a dev branch Stop branch action in the overview More menu
- wire it to the existing branch stop/proxy path
- show Already stopped when the branch status is stopped

## API routes / contracts
- Added POST /branches/{slug}/stop to the branches contract.
- No routes or contracts deleted.

## Checks
- bun run typecheck
- bun run web:build
- bun run test