### PR TITLE
fix(ui): tighten production restore flows

### DIFF
--- a/src/web/routes/branch/$branchId/-table-row-dialogs.tsx
+++ b/src/web/routes/branch/$branchId/-table-row-dialogs.tsx
@@ -1,0 +1,339 @@
+import type { FormEvent } from 'react';
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '#web/components/ui/alert-dialog';
+import { Button } from '#web/components/ui/button';
+import { Checkbox } from '#web/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#web/components/ui/dialog';
+import { Input } from '#web/components/ui/input';
+import { Label } from '#web/components/ui/label';
+import { isConfirmedProductionWrite, PRODUCTION_WRITE_CONFIRMATION } from '#utils/prod-write-guard';
+
+export type RowEditorMode = 'insert' | 'edit';
+
+export interface TableActionTarget {
+  branchId: string;
+  database: string;
+  schema: string;
+  table: string;
+}
+
+export interface RowDraftField {
+  column: string;
+  type: string;
+  value: string;
+  isNull: boolean;
+  enabled: boolean;
+}
+
+export interface RowEditorState {
+  mode: RowEditorMode;
+  target: TableActionTarget;
+  rowId: string | null;
+  fields: RowDraftField[];
+}
+
+export interface DeleteRowState {
+  target: TableActionTarget;
+  rowId: string;
+  label: string;
+}
+
+interface RowEditorDialogProps {
+  editor: RowEditorState | null;
+  selectedLabel: string;
+  isProduction: boolean;
+  saving: boolean;
+  onClose: () => void;
+  onChangeField: (column: string, patch: Partial<RowDraftField>) => void;
+  onSave: (productionWriteConfirmation: string) => void;
+}
+
+export function RowEditorDialog(props: RowEditorDialogProps) {
+  const [productionWriteConfirmation, setProductionWriteConfirmation] = useState('');
+  const editorKey = getEditorKey(props.editor);
+  const productionWriteLocked = props.isProduction && !isConfirmedProductionWrite(productionWriteConfirmation);
+
+  useEffect(function resetProductionWriteConfirmation() {
+    setProductionWriteConfirmation('');
+  }, [editorKey]);
+
+  function handleSave(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!props.editor) {
+      return;
+    }
+
+    if (productionWriteLocked) {
+      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
+      return;
+    }
+
+    props.onSave(productionWriteConfirmation);
+  }
+
+  return (
+    <Dialog open={props.editor !== null} onOpenChange={function handleEditorOpenChange(open) {
+      if (!open) {
+        props.onClose();
+      }
+    }}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{props.editor?.mode === 'insert' ? 'Add row' : 'Edit row'}</DialogTitle>
+          <DialogDescription>
+            {props.editor ? `${props.editor.target.schema}.${props.editor.target.table}` : props.selectedLabel}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="grid gap-4" onSubmit={handleSave}>
+          {props.editor ? (
+            <RowFieldsEditor
+              fields={props.editor.fields}
+              mode={props.editor.mode}
+              disabled={props.saving}
+              onChangeField={props.onChangeField}
+            />
+          ) : null}
+
+          {props.isProduction ? (
+            <ProductionWriteConfirmationField
+              value={productionWriteConfirmation}
+              disabled={props.saving}
+              onChange={setProductionWriteConfirmation}
+            />
+          ) : null}
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" disabled={props.saving} onClick={props.onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={props.saving || !props.editor || productionWriteLocked}>
+              {props.saving ? <Loader2 className="animate-spin" /> : null}
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface DeleteRowDialogProps {
+  rowToDelete: DeleteRowState | null;
+  isProduction: boolean;
+  deleting: boolean;
+  onClose: () => void;
+  onDelete: (productionWriteConfirmation: string) => void;
+}
+
+export function DeleteRowDialog(props: DeleteRowDialogProps) {
+  const [productionWriteConfirmation, setProductionWriteConfirmation] = useState('');
+  const deleteKey = getDeleteKey(props.rowToDelete);
+  const productionWriteLocked = props.isProduction && !isConfirmedProductionWrite(productionWriteConfirmation);
+
+  useEffect(function resetProductionWriteConfirmation() {
+    setProductionWriteConfirmation('');
+  }, [deleteKey]);
+
+  function handleDelete() {
+    if (!props.rowToDelete) {
+      return;
+    }
+
+    if (productionWriteLocked) {
+      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to delete production rows.`);
+      return;
+    }
+
+    props.onDelete(productionWriteConfirmation);
+  }
+
+  return (
+    <AlertDialog open={props.rowToDelete !== null} onOpenChange={function handleDeleteOpenChange(open) {
+      if (!open) {
+        props.onClose();
+      }
+    }}>
+      <AlertDialogContent
+        onKeyDown={function handleDeleteDialogKeyDown(event) {
+          if (event.key !== 'Enter' || props.deleting) {
+            return;
+          }
+
+          event.preventDefault();
+          handleDelete();
+        }}
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete row?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {props.rowToDelete ? `Delete ${props.rowToDelete.label} from ${props.rowToDelete.target.schema}.${props.rowToDelete.target.table}.` : null}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {props.isProduction ? (
+          <ProductionWriteConfirmationField
+            value={productionWriteConfirmation}
+            disabled={props.deleting}
+            onChange={setProductionWriteConfirmation}
+          />
+        ) : null}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={props.deleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            autoFocus
+            className="bg-destructive text-white hover:bg-destructive/90"
+            disabled={props.deleting || productionWriteLocked}
+            onClick={function deleteConfirmed(event) {
+              event.preventDefault();
+              handleDelete();
+            }}
+          >
+            {props.deleting ? <Loader2 className="animate-spin" /> : null}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+interface ProductionWriteConfirmationFieldProps {
+  value: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}
+
+function ProductionWriteConfirmationField(props: ProductionWriteConfirmationFieldProps) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="production-write-confirmation">
+        Type <ConfirmationCode value={PRODUCTION_WRITE_CONFIRMATION} />
+      </Label>
+      <Input
+        id="production-write-confirmation"
+        value={props.value}
+        disabled={props.disabled}
+        onChange={function updateProductionWriteConfirmation(event) {
+          props.onChange(event.target.value);
+        }}
+        className="font-mono"
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
+function ConfirmationCode(props: { value: string }) {
+  return <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">{props.value}</code>;
+}
+
+interface RowFieldsEditorProps {
+  fields: RowDraftField[];
+  mode: RowEditorMode;
+  disabled: boolean;
+  onChangeField: (column: string, patch: Partial<RowDraftField>) => void;
+}
+
+function RowFieldsEditor(props: RowFieldsEditorProps) {
+  return (
+    <div className="grid gap-2">
+      {props.fields.map(function renderField(field) {
+        const valueDisabled = props.disabled || field.isNull || !field.enabled;
+
+        return (
+          <div
+            key={field.column}
+            className="grid gap-2 border-t border-border pt-2 first:border-t-0 first:pt-0 md:grid-cols-[minmax(140px,1fr)_minmax(180px,2fr)_auto_auto]"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              {props.mode === 'insert' ? (
+                <Checkbox
+                  checked={field.enabled}
+                  disabled={props.disabled}
+                  onCheckedChange={function toggleEnabled(checked) {
+                    props.onChangeField(field.column, { enabled: checked === true });
+                  }}
+                  aria-label={`Include ${field.column}`}
+                />
+              ) : null}
+              <div className="min-w-0">
+                <div className="truncate font-mono text-xs font-medium">{field.column}</div>
+                <div className="truncate text-[11px] text-muted-foreground">{field.type}</div>
+              </div>
+            </div>
+
+            <Input
+              value={field.value}
+              disabled={valueDisabled}
+              className="h-8 font-mono text-xs"
+              onChange={function updateValue(event) {
+                props.onChangeField(field.column, { value: event.target.value });
+              }}
+            />
+
+            <Label className="inline-flex h-8 items-center gap-2 rounded-md border border-border px-2 text-xs text-muted-foreground">
+              <Checkbox
+                checked={field.isNull}
+                disabled={props.disabled || !field.enabled}
+                onCheckedChange={function toggleNull(checked) {
+                  props.onChangeField(field.column, { isNull: checked === true });
+                }}
+              />
+              null
+            </Label>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function getEditorKey(editor: RowEditorState | null): string {
+  if (!editor) {
+    return 'closed';
+  }
+
+  return [
+    editor.mode,
+    editor.target.branchId,
+    editor.target.database,
+    editor.target.schema,
+    editor.target.table,
+    editor.rowId || 'insert',
+  ].join(':');
+}
+
+function getDeleteKey(rowToDelete: DeleteRowState | null): string {
+  if (!rowToDelete) {
+    return 'closed';
+  }
+
+  return [
+    rowToDelete.target.branchId,
+    rowToDelete.target.database,
+    rowToDelete.target.schema,
+    rowToDelete.target.table,
+    rowToDelete.rowId,
+  ].join(':');
+}

--- a/src/web/routes/branch/$branchId/backup-restore.tsx
+++ b/src/web/routes/branch/$branchId/backup-restore.tsx
@@ -2,12 +2,9 @@ import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import {
-  AlertTriangle,
-  Calendar,
   GitBranch,
   Loader2,
   RotateCcw,
-  Zap,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
@@ -30,6 +27,13 @@ import {
   CardHeader,
   CardTitle,
 } from '#web/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#web/components/ui/dialog';
 import { Input } from '#web/components/ui/input';
 import { Label } from '#web/components/ui/label';
 import { orpc, type ControlPlaneState } from '#web/lib/api-client';
@@ -40,7 +44,6 @@ import {
 import { getMutationErrorMessage } from '#web/lib/errors';
 
 const LOCAL_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'local time';
-const TIME_FORMAT_LABEL = `Times are local to ${LOCAL_TIME_ZONE}.`;
 const PRODUCTION_RESTORE_CONFIRMATION = 'restore production';
 
 export const Route = createFileRoute('/branch/$branchId/backup-restore')({
@@ -221,9 +224,6 @@ function BackupRestorePage() {
                 <GitBranch className="size-4" />
                 <span>{selectedBranchLabel}</span>
               </div>
-              <p className="mt-6 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Choose a time to restore production.
-              </p>
             </header>
 
             {restoreJob ? (
@@ -236,40 +236,23 @@ function BackupRestorePage() {
             ) : null}
 
             <Card>
-              <CardHeader>
-                <div className="flex gap-4">
-                  <div className="mt-1 grid size-10 shrink-0 place-items-center rounded-md bg-primary text-primary-foreground">
-                    <Calendar className="size-5" />
-                  </div>
-                  <div className="min-w-0">
-                    <CardTitle>Restore to</CardTitle>
-                    <CardDescription className="mt-2 max-w-xl">
-                      Pick the date and time to go back to.
-                    </CardDescription>
-                  </div>
-                </div>
-              </CardHeader>
-
               <CardContent className="grid gap-5">
-                <div className="grid gap-2 border-t border-border pt-4">
+                <div className="grid gap-2">
                   <Label htmlFor="restore-time">Date and time</Label>
                   <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                    <div className="relative">
-                      <Calendar className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                      <Input
-                        id="restore-time"
-                        className="h-10 pl-9 font-mono"
-                        type="datetime-local"
-                        step={1}
-                        min={restoreWindow.min || undefined}
-                        max={restoreWindow.max || undefined}
-                        value={restoreTime}
-                        disabled={!pitrAvailable}
-                        onChange={function changeRestoreTime(event) {
-                          updateRestoreTime(event.target.value);
-                        }}
-                      />
-                    </div>
+                    <Input
+                      id="restore-time"
+                      className="h-10 font-mono"
+                      type="datetime-local"
+                      step={1}
+                      min={restoreWindow.min || undefined}
+                      max={restoreWindow.max || undefined}
+                      value={restoreTime}
+                      disabled={!pitrAvailable}
+                      onChange={function changeRestoreTime(event) {
+                        updateRestoreTime(event.target.value);
+                      }}
+                    />
                     <Button
                       type="button"
                       variant="outline"
@@ -288,13 +271,9 @@ function BackupRestorePage() {
                   />
                 </div>
 
-                <div className="flex flex-col gap-3 border-t border-border pt-5 sm:flex-row sm:items-center sm:justify-between">
-                  <p className="max-w-xl text-xs leading-5 text-muted-foreground">
-                    Production restore requires confirmation.
-                  </p>
+                <div className="flex justify-end border-t border-border pt-5">
                   <Button
                     type="button"
-                    variant="destructive"
                     disabled={!restoreTimeValid || restoreLocked}
                     onClick={function restoreClick() {
                       handleOpenRestorePrompt();
@@ -312,20 +291,19 @@ function BackupRestorePage() {
         </section>
       </div>
 
-      {restorePromptOpen ? (
-        <RestorePromptModal
-          restoreTime={restoreTime}
-          confirmation={productionRestoreConfirmation}
-          restoreBusy={restoreBusy}
-          onClose={function closeRestorePrompt() {
-            setRestorePromptOpen(false);
-          }}
-          onConfirmationChange={setProductionRestoreConfirmation}
-          onRestore={function confirmRestore() {
-            void handleRestore();
-          }}
-        />
-      ) : null}
+      <RestorePromptModal
+        open={restorePromptOpen}
+        restoreTime={restoreTime}
+        confirmation={productionRestoreConfirmation}
+        restoreBusy={restoreBusy}
+        onOpenChange={function changeRestorePromptOpen(open) {
+          setRestorePromptOpen(open);
+        }}
+        onConfirmationChange={setProductionRestoreConfirmation}
+        onRestore={function confirmRestore() {
+          void handleRestore();
+        }}
+      />
     </main>
   );
 }
@@ -491,14 +469,20 @@ function RestoreAvailability(props: {
   return (
     <div className="grid gap-1 text-xs text-muted-foreground">
       <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={props.restoreTimeValid ? 'success' : 'warning'}>
-          {props.restoreTimeValid ? 'Exact restore available' : 'Outside available range'}
-        </Badge>
+        {!props.restoreTimeValid ? <Badge variant="warning">Exact restore not available</Badge> : null}
         <span>
-          Available from {formatDisplayDateTime(props.restoreWindow.min)} to {formatDisplayDateTime(props.restoreWindow.max)}.
+          Valid from {formatDisplayDateTime(props.restoreWindow.min)} to {formatDisplayDateTime(props.restoreWindow.max)}.
         </span>
       </div>
-      <div>{TIME_FORMAT_LABEL}</div>
+      <LocalTimeZoneLabel />
+    </div>
+  );
+}
+
+function LocalTimeZoneLabel() {
+  return (
+    <div>
+      Times are local to <span className="font-medium text-foreground">{LOCAL_TIME_ZONE}</span>.
     </div>
   );
 }
@@ -555,10 +539,11 @@ function SummaryItem(props: {
 }
 
 function RestorePromptModal(props: {
+  open: boolean;
   restoreTime: string;
   confirmation: string;
   restoreBusy: boolean;
-  onClose: () => void;
+  onOpenChange: (open: boolean) => void;
   onConfirmationChange: (value: string) => void;
   onRestore: () => void;
 }) {
@@ -566,29 +551,20 @@ function RestorePromptModal(props: {
     || props.confirmation !== PRODUCTION_RESTORE_CONFIRMATION;
 
   return (
-    <div className="fixed inset-0 z-50 grid place-items-center bg-background/80 p-4 backdrop-blur-sm">
-      <div className="w-full max-w-lg rounded-md border border-border bg-card p-5 text-card-foreground shadow-xl">
-        <div className="flex gap-3">
-          <div className="grid size-10 shrink-0 place-items-center rounded-md bg-amber-500/10 text-amber-300">
-            <AlertTriangle className="size-5" />
-          </div>
-          <div className="min-w-0">
-            <h2 className="text-lg font-semibold tracking-normal">Restore branch</h2>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              You are about to restore production from production at {formatDisplayDateTime(props.restoreTime)}.
-              This replaces the current branch data with the selected point in time.
-            </p>
-          </div>
-        </div>
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Confirm restore production</DialogTitle>
+        </DialogHeader>
 
-        <div className="mt-5 grid gap-3 rounded-md border border-border bg-muted/20 p-4 text-sm">
-          <SummaryItem label="Target" value="production" />
-          <SummaryItem label="Source" value="production" />
+        <div className="grid gap-3 rounded-md border border-border bg-muted/20 p-4 text-sm">
           <SummaryItem label="Selected time" value={`${formatDisplayDateTime(props.restoreTime)} (${LOCAL_TIME_ZONE})`} />
         </div>
 
-        <div className="mt-5 grid gap-2">
-          <Label htmlFor="production-restore-confirmation">Type {PRODUCTION_RESTORE_CONFIRMATION}</Label>
+        <div className="grid gap-2">
+          <Label htmlFor="production-restore-confirmation">
+            Type <ConfirmationCode value={PRODUCTION_RESTORE_CONFIRMATION} />
+          </Label>
           <Input
             id="production-restore-confirmation"
             aria-label="Production restore confirmation"
@@ -600,8 +576,10 @@ function RestorePromptModal(props: {
           />
         </div>
 
-        <div className="mt-5 flex justify-end gap-2">
-          <Button type="button" variant="outline" onClick={props.onClose}>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={function closeRestorePrompt() {
+            props.onOpenChange(false);
+          }}>
             Cancel
           </Button>
           <Button
@@ -611,13 +589,17 @@ function RestorePromptModal(props: {
             disabled={restoreDisabled}
             onClick={props.onRestore}
           >
-            {props.restoreBusy ? <Loader2 className="animate-spin" /> : <Zap />}
-            Restore now
+            {props.restoreBusy ? <Loader2 className="animate-spin" /> : null}
+            Restore production
           </Button>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
+}
+
+function ConfirmationCode(props: { value: string }) {
+  return <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">{props.value}</code>;
 }
 
 type RestoreJob = ControlPlaneState['jobs'][number];

--- a/src/web/routes/branch/$branchId/tables.tsx
+++ b/src/web/routes/branch/$branchId/tables.tsx
@@ -1,12 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import type { FormEvent } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import {
   ChevronLeft,
   ChevronRight,
   Database,
-  Loader2,
   Pencil,
   Plus,
   RefreshCw,
@@ -17,28 +15,8 @@ import {
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { AppSidebar } from '#web/components/control-plane';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '#web/components/ui/alert-dialog';
 import { Button } from '#web/components/ui/button';
-import { Checkbox } from '#web/components/ui/checkbox';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '#web/components/ui/dialog';
 import { Input } from '#web/components/ui/input';
-import { Label } from '#web/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -50,7 +28,15 @@ import {
 import { orpc } from '#web/lib/api-client';
 import { getMutationErrorMessage } from '#web/lib/errors';
 import { cn } from '#lib/utils';
-import { isConfirmedProductionWrite, isProductionBranchId, PRODUCTION_WRITE_CONFIRMATION } from '#utils/prod-write-guard';
+import { isProductionBranchId } from '#utils/prod-write-guard';
+import {
+  DeleteRowDialog,
+  RowEditorDialog,
+  type DeleteRowState,
+  type RowDraftField,
+  type RowEditorState,
+  type TableActionTarget,
+} from './-table-row-dialogs';
 
 export const Route = createFileRoute('/branch/$branchId/tables')({
   component: BranchTablesPage,
@@ -65,7 +51,6 @@ function BranchTablesPage() {
   const [search, setSearch] = useState('');
   const [editor, setEditor] = useState<RowEditorState | null>(null);
   const [rowToDelete, setRowToDelete] = useState<DeleteRowState | null>(null);
-  const [productionWriteConfirmation, setProductionWriteConfirmation] = useState('');
   const metadata = useQuery({
     ...orpc.tables.browse.queryOptions({
       input: {
@@ -109,7 +94,6 @@ function BranchTablesPage() {
     setSearch('');
     setEditor(null);
     setRowToDelete(null);
-    setProductionWriteConfirmation('');
   }, [params.branchId]);
 
   useEffect(function setInitialTable() {
@@ -179,11 +163,6 @@ function BranchTablesPage() {
   }
 
   function openAddRow() {
-    if (!productionWritesUnlocked) {
-      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
-      return;
-    }
-
     const target = getCurrentRowsTarget();
 
     if (!rows.data || !target) {
@@ -199,11 +178,6 @@ function BranchTablesPage() {
   }
 
   function openEditRow(row: Record<string, unknown>) {
-    if (!productionWritesUnlocked) {
-      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
-      return;
-    }
-
     const target = getCurrentRowsTarget();
 
     if (!rows.data || !target) {
@@ -219,11 +193,6 @@ function BranchTablesPage() {
   }
 
   function openDeleteRow(row: Record<string, unknown>) {
-    if (!productionWritesUnlocked) {
-      toast.error(`Type "${PRODUCTION_WRITE_CONFIRMATION}" to edit production rows.`);
-      return;
-    }
-
     const target = getCurrentRowsTarget();
 
     if (!rows.data || !target) {
@@ -253,7 +222,7 @@ function BranchTablesPage() {
     setRowToDelete(null);
   }
 
-  async function confirmDeleteRow() {
+  async function confirmDeleteRow(productionWriteConfirmation: string) {
     if (!rowToDelete) {
       return;
     }
@@ -301,9 +270,7 @@ function BranchTablesPage() {
     });
   }
 
-  async function saveEditor(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
+  async function saveEditor(productionWriteConfirmation: string) {
     if (!editor) {
       return;
     }
@@ -353,8 +320,8 @@ function BranchTablesPage() {
   const deleting = deleteRow.isPending;
   const rowsReady = Boolean(rows.data && rowDataMatches(rows.data, params.branchId, selectedDatabase, selectedSchema, selectedTable));
   const isProduction = isProductionBranchId(params.branchId);
-  const productionWritesUnlocked = !isProduction || isConfirmedProductionWrite(productionWriteConfirmation);
-  const tableActionsDisabled = !rowsReady || !productionWritesUnlocked;
+  const tableActionsDisabled = !rowsReady;
+  const contentGridRows = isProduction ? 'grid-rows-[auto_auto_1fr]' : 'grid-rows-[auto_1fr]';
 
   return (
     <>
@@ -455,20 +422,11 @@ function BranchTablesPage() {
               </div>
             </aside>
 
-            <div className="grid min-h-0 grid-rows-[auto_1fr]">
+            <div className={cn('grid min-h-0', contentGridRows)}>
               {isProduction ? (
-                <div className="flex flex-wrap items-center gap-2 border-b border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                <div className="flex flex-wrap items-center gap-2 border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-200">
                   <ShieldAlert className="size-4" />
-                  <span className="font-medium">{productionWritesUnlocked ? 'production writes unlocked' : 'production rows read-only'}</span>
-                  <Input
-                    value={productionWriteConfirmation}
-                    onChange={function updateProductionWriteConfirmation(event) {
-                      setProductionWriteConfirmation(event.target.value);
-                    }}
-                    className="h-8 w-48 bg-background font-mono text-xs text-foreground"
-                    placeholder={PRODUCTION_WRITE_CONFIRMATION}
-                    aria-label="Production write confirmation"
-                  />
+                  <span className="font-medium">production database</span>
                 </div>
               ) : null}
               <div className="flex flex-wrap items-center justify-end gap-2 border-b border-border px-3 py-2">
@@ -546,81 +504,23 @@ function BranchTablesPage() {
         </div>
       </main>
 
-      <Dialog open={editor !== null} onOpenChange={function handleEditorOpenChange(open) {
-        if (!open) {
-          closeEditor();
-        }
-      }}>
-        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
-          <DialogHeader>
-            <DialogTitle>{editor?.mode === 'insert' ? 'Add row' : 'Edit row'}</DialogTitle>
-            <DialogDescription>
-              {editor ? `${editor.target.schema}.${editor.target.table}` : `${selectedSchema}.${selectedTable}`}
-            </DialogDescription>
-          </DialogHeader>
+      <RowEditorDialog
+        editor={editor}
+        selectedLabel={`${selectedSchema}.${selectedTable}`}
+        isProduction={isProduction}
+        saving={saving}
+        onClose={closeEditor}
+        onChangeField={updateDraftField}
+        onSave={saveEditor}
+      />
 
-          <form className="grid gap-4" onSubmit={saveEditor}>
-            {editor ? (
-              <RowFieldsEditor
-                fields={editor.fields}
-                mode={editor.mode}
-                disabled={saving}
-                onChangeField={updateDraftField}
-              />
-            ) : null}
-
-            <DialogFooter>
-              <Button type="button" variant="ghost" disabled={saving} onClick={closeEditor}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={saving || !editor}>
-                {saving ? <Loader2 className="animate-spin" /> : null}
-                Save
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
-
-      <AlertDialog open={rowToDelete !== null} onOpenChange={function handleDeleteOpenChange(open) {
-        if (!open) {
-          closeDeleteDialog();
-        }
-      }}>
-        <AlertDialogContent
-          onKeyDown={function handleDeleteDialogKeyDown(event) {
-            if (event.key !== 'Enter' || deleting) {
-              return;
-            }
-
-            event.preventDefault();
-            void confirmDeleteRow();
-          }}
-        >
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete row?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {rowToDelete ? `Delete ${rowToDelete.label} from ${rowToDelete.target.schema}.${rowToDelete.target.table}.` : null}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              autoFocus
-              className="bg-destructive text-white hover:bg-destructive/90"
-              disabled={deleting}
-              onClick={function deleteConfirmed(event) {
-                event.preventDefault();
-                void confirmDeleteRow();
-              }}
-            >
-              {deleting ? <Loader2 className="animate-spin" /> : null}
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteRowDialog
+        rowToDelete={rowToDelete}
+        isProduction={isProduction}
+        deleting={deleting}
+        onClose={closeDeleteDialog}
+        onDelete={confirmDeleteRow}
+      />
     </>
   );
 }
@@ -743,36 +643,6 @@ function TableGrid(props: TableGridProps) {
   );
 }
 
-type RowEditorMode = 'insert' | 'edit';
-
-interface TableActionTarget {
-  branchId: string;
-  database: string;
-  schema: string;
-  table: string;
-}
-
-interface RowDraftField {
-  column: string;
-  type: string;
-  value: string;
-  isNull: boolean;
-  enabled: boolean;
-}
-
-interface RowEditorState {
-  mode: RowEditorMode;
-  target: TableActionTarget;
-  rowId: string | null;
-  fields: RowDraftField[];
-}
-
-interface DeleteRowState {
-  target: TableActionTarget;
-  rowId: string;
-  label: string;
-}
-
 function createInsertDraft(columns: Array<{ name: string; type: string; nullable: boolean; defaultValue: string | null }>): RowDraftField[] {
   return columns.map(function createField(column) {
     return {
@@ -833,67 +703,6 @@ function buildEditorValues(editor: RowEditorState): Record<string, string | null
       .map(function mapField(field) {
         return [field.column, field.isNull ? null : field.value];
       })
-  );
-}
-
-interface RowFieldsEditorProps {
-  fields: RowDraftField[];
-  mode: RowEditorMode;
-  disabled: boolean;
-  onChangeField: (column: string, patch: Partial<RowDraftField>) => void;
-}
-
-function RowFieldsEditor(props: RowFieldsEditorProps) {
-  return (
-    <div className="grid gap-2">
-      {props.fields.map(function renderField(field) {
-        const valueDisabled = props.disabled || field.isNull || !field.enabled;
-
-        return (
-          <div
-            key={field.column}
-            className="grid gap-2 border-t border-border pt-2 first:border-t-0 first:pt-0 md:grid-cols-[minmax(140px,1fr)_minmax(180px,2fr)_auto_auto]"
-          >
-            <div className="flex min-w-0 items-center gap-2">
-              {props.mode === 'insert' ? (
-                <Checkbox
-                  checked={field.enabled}
-                  disabled={props.disabled}
-                  onCheckedChange={function toggleEnabled(checked) {
-                    props.onChangeField(field.column, { enabled: checked === true });
-                  }}
-                  aria-label={`Include ${field.column}`}
-                />
-              ) : null}
-              <div className="min-w-0">
-                <div className="truncate font-mono text-xs font-medium">{field.column}</div>
-                <div className="truncate text-[11px] text-muted-foreground">{field.type}</div>
-              </div>
-            </div>
-
-            <Input
-              value={field.value}
-              disabled={valueDisabled}
-              className="h-8 font-mono text-xs"
-              onChange={function updateValue(event) {
-                props.onChangeField(field.column, { value: event.target.value });
-              }}
-            />
-
-            <Label className="inline-flex h-8 items-center gap-2 rounded-md border border-border px-2 text-xs text-muted-foreground">
-              <Checkbox
-                checked={field.isNull}
-                disabled={props.disabled || !field.enabled}
-                onCheckedChange={function toggleNull(checked) {
-                  props.onChangeField(field.column, { isNull: checked === true });
-                }}
-              />
-              null
-            </Label>
-          </div>
-        );
-      })}
-    </div>
   );
 }
 


### PR DESCRIPTION
## What changed

- Simplified production restore UI copy and confirmation modal.
- Kept valid restore range visible and highlighted the local timezone.
- Moved production table row write confirmation into dialog-owned state.
- Extracted table row edit/delete dialogs out of the route file.

## API routes, procedures, contracts

- No API routes, procedures, or contracts were added, updated, or deleted.

## Validation

- `bun run typecheck`
- `bun run web:build`
- Browser smoke: production table confirmation no longer carries from add row into delete row.
