### PR TITLE
feat(settings): add backup health status

### DIFF
--- a/src/web/components/control-plane.tsx
+++ b/src/web/components/control-plane.tsx
@@ -49,7 +49,6 @@ import {
   CardHeader,
   CardTitle,
 } from '#web/components/ui/card';
-import { Checkbox } from '#web/components/ui/checkbox';
 import {
   Dialog,
   DialogClose,
@@ -72,6 +71,7 @@ import {
   SelectValue,
 } from '#web/components/ui/select';
 import { logout } from '#web/lib/auth-client';
+import { formatRelativeTime as formatLastCheck } from '#web/lib/time';
 
 export type ServerRole = 'prod' | 'dev';
 
@@ -170,16 +170,10 @@ export function AppSidebar(props: AppSidebarProps) {
   );
 }
 
-function AppBrand() {
+function AppBrand(props: { className?: string }) {
   return (
-    <div className="flex items-center gap-3">
-      <div className="grid size-9 place-items-center rounded-md bg-primary text-primary-foreground">
-        <Database className="size-4" />
-      </div>
-      <div>
-        <div className="text-sm font-semibold leading-none">Velo</div>
-        <div className="mt-1 text-xs text-muted-foreground">Control plane</div>
-      </div>
+    <div className={cn('text-sm font-semibold leading-none', props.className)}>
+      Velo
     </div>
   );
 }
@@ -235,7 +229,7 @@ function SidebarContent(props: SidebarContentProps) {
   return (
     <div className={cn('flex flex-col', props.className)}>
       <div className="hidden lg:block">
-        <AppBrand />
+        <AppBrand className="px-3" />
       </div>
 
       <SidebarSection label="Project" className="mt-8">
@@ -337,7 +331,7 @@ function NavItem(props: NavItemProps) {
       to={props.href}
       onClick={props.onNavigate}
       className={cn(
-        'flex h-9 items-center gap-2 rounded-md px-3 text-muted-foreground',
+        'flex h-9 items-center gap-2 rounded-md px-3 text-sm text-muted-foreground',
         'transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         props.active && 'bg-sidebar-accent text-sidebar-accent-foreground'
       )}
@@ -770,18 +764,20 @@ export function ServerPanel(props: ServerPanelProps) {
   );
 }
 
+interface BackupSettingsSummary {
+  enabled: boolean;
+  endpoint: string;
+  bucket: string;
+  region: string;
+  accessKeyId: string;
+  secretConfigured: boolean;
+  path: string;
+  pitrDays: number;
+  fullBackupRetentionDays: number;
+}
+
 export interface BackupPanelProps {
-  backup: {
-    enabled: boolean;
-    endpoint: string;
-    bucket: string;
-    region: string;
-    accessKeyId: string;
-    secretConfigured: boolean;
-    path: string;
-    pitrDays: number;
-    fullBackupRetentionDays: number;
-  };
+  backup: BackupSettingsSummary;
   busy: boolean;
   onSave: (formData: FormData) => Promise<void>;
 }
@@ -805,10 +801,6 @@ export function BackupPanel(props: BackupPanelProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={submitForm} className="grid gap-4">
-          <Label className="flex items-center gap-2">
-            <Checkbox name="enabled" defaultChecked={props.backup.enabled} />
-            Use S3 compatible storage
-          </Label>
           <Field label="Endpoint">
             <Input name="endpoint" defaultValue={props.backup.endpoint} placeholder="https://account.r2.cloudflarestorage.com" />
           </Field>
@@ -1144,37 +1136,6 @@ function formatJobInput(input: unknown): string {
   }
 
   return JSON.stringify(input, null, 2);
-}
-
-function formatLastCheck(value: string | null | undefined): string {
-  if (!value) {
-    return 'never';
-  }
-
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  const diffMs = Date.now() - date.getTime();
-  const minutes = Math.max(0, Math.round(diffMs / 60000));
-
-  if (minutes < 1) {
-    return 'just now';
-  }
-
-  if (minutes < 60) {
-    return `${minutes}m ago`;
-  }
-
-  const hours = Math.round(minutes / 60);
-
-  if (hours < 24) {
-    return `${hours}h ago`;
-  }
-
-  return `${Math.round(hours / 24)}d ago`;
 }
 
 interface FieldProps {

--- a/src/web/components/settings/backup-health-panel.tsx
+++ b/src/web/components/settings/backup-health-panel.tsx
@@ -1,0 +1,200 @@
+import { Activity, AlertTriangle, Eye, Loader2, RefreshCw } from 'lucide-react';
+import { cn } from '#lib/utils';
+import { Badge } from '#web/components/ui/badge';
+import { Button } from '#web/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '#web/components/ui/card';
+import type { ControlPlaneState } from '#web/lib/api-client';
+import { formatRelativeTime } from '#web/lib/time';
+
+type BackupAvailability = ControlPlaneState['backupAvailability'];
+type BackupPoint = BackupAvailability['backups'][number];
+type BackupJob = ControlPlaneState['jobs'][number];
+
+export interface BackupHealthPanelProps {
+  availability: BackupAvailability;
+  checkedAt: string | null;
+  checking?: boolean;
+  jobs: BackupJob[];
+  onRefresh: () => void;
+  onOpenJob: (jobId: number) => void;
+}
+
+export function BackupHealthPanel(props: BackupHealthPanelProps) {
+  const healthy = props.availability.status === 'ok';
+  const latestBackup = props.availability.backups[0] || null;
+  const backupJob = findBackupJob(props.jobs);
+  const showBackupJob = backupJob && (backupJob.status === 'queued' || backupJob.status === 'running' || backupJob.status === 'error');
+
+  return (
+    <Card>
+      <CardHeader className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-start">
+        <div className="flex min-w-0 gap-3">
+          <div className={cn('mt-1.5 size-2.5 shrink-0 rounded-full', healthy ? 'bg-emerald-500' : 'bg-destructive')} />
+          <div className="min-w-0">
+            <CardTitle>{healthy ? 'Backups are working' : 'Backups need attention'}</CardTitle>
+            <CardDescription>{formatBackupHealthSummary(props.availability, latestBackup)}</CardDescription>
+          </div>
+        </div>
+        <Button type="button" variant="outline" size="sm" disabled={props.checking} onClick={props.onRefresh}>
+          {props.checking ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+          Check
+        </Button>
+      </CardHeader>
+      <CardContent className="grid gap-3">
+        {props.availability.message ? (
+          <div className="flex gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <p>{props.availability.message}</p>
+          </div>
+        ) : null}
+
+        {showBackupJob ? (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-muted/20 p-3">
+            <div>
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium">Settings update</p>
+                <BackupJobStatus status={backupJob.status} />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {backupJob.error || `updated ${formatRelativeTime(backupJob.updatedAt)}`}
+              </p>
+            </div>
+            <Button type="button" variant="outline" size="sm" onClick={function openBackupJob() {
+              props.onOpenJob(backupJob.id);
+            }}>
+              <Eye />
+              View
+            </Button>
+          </div>
+        ) : null}
+
+        <div className="border-y border-border">
+          <BackupHealthRow
+            label="Last backup"
+            value={latestBackup ? formatRelativeTime(latestBackup.completedAt) : 'none found'}
+            detail={latestBackup ? latestBackup.label : 'no successful backup yet'}
+          />
+          <BackupHealthRow
+            label="Restore window"
+            value={props.availability.pitr.from && props.availability.pitr.to ? 'available' : 'not available'}
+            detail={formatPitrWindow(props.availability)}
+          />
+          <BackupHealthRow
+            label="Continuous recovery"
+            value={formatArchiveValue(props.availability)}
+            detail={formatArchiveDetail(props.availability)}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">
+            Last checked {formatRelativeTime(props.checkedAt)}
+          </p>
+          {props.availability.backups.length > 0 ? (
+            <p className="truncate text-xs text-muted-foreground">
+              {props.availability.backups.length} backup{props.availability.backups.length === 1 ? '' : 's'} found
+            </p>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BackupHealthRow(props: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="grid gap-1 border-t border-border py-3 first:border-t-0 sm:grid-cols-[140px_minmax(0,1fr)] sm:items-center">
+      <p className="text-xs font-medium text-muted-foreground">{props.label}</p>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium">{props.value}</p>
+        <p className="mt-0.5 truncate text-xs text-muted-foreground">{props.detail}</p>
+      </div>
+    </div>
+  );
+}
+
+function BackupJobStatus(props: { status: string }) {
+  return (
+    <Badge variant={getJobStatusVariant(props.status)} className="capitalize">
+      <Activity className={cn('size-3', props.status === 'running' && 'animate-pulse')} />
+      {props.status}
+    </Badge>
+  );
+}
+
+function getJobStatusVariant(status: string) {
+  if (status === 'done' || status === 'running') {
+    return 'success';
+  }
+
+  if (status === 'error') {
+    return 'destructive';
+  }
+
+  return 'warning';
+}
+
+function formatBackupHealthSummary(availability: BackupAvailability, latestBackup: BackupPoint | null): string {
+  if (availability.status !== 'ok') {
+    return availability.message || 'Backup status could not be verified.';
+  }
+
+  if (!latestBackup) {
+    return 'Backup storage is reachable, but no backup has completed yet.';
+  }
+
+  if (availability.pitr.from && availability.pitr.to) {
+    return `Last backup completed ${formatRelativeTime(latestBackup.completedAt)}. Restore points are available.`;
+  }
+
+  return `Last backup completed ${formatRelativeTime(latestBackup.completedAt)}. Waiting for restore points.`;
+}
+
+function findBackupJob(jobs: BackupJob[]): BackupJob | null {
+  const backupJobs = jobs.filter(function isBackupJob(job) {
+    return job.type === 'backup-reconfigure';
+  });
+
+  return backupJobs.find(function isActiveBackupJob(job) {
+    return job.status === 'queued' || job.status === 'running';
+  }) || backupJobs[0] || null;
+}
+
+function formatPitrWindow(availability: BackupAvailability): string {
+  if (!availability.pitr.from || !availability.pitr.to) {
+    return availability.message || 'waiting for backup history';
+  }
+
+  return `${formatBackupDate(availability.pitr.from)} to ${formatBackupDate(availability.pitr.to)}`;
+}
+
+function formatArchiveValue(availability: BackupAvailability): string {
+  if (availability.archive?.lastArchivedAt) {
+    return availability.archive.failedCount && availability.archive.failedCount > 0 ? 'active with failures' : 'active';
+  }
+
+  return availability.status === 'ok' ? 'ok' : 'unknown';
+}
+
+function formatArchiveDetail(availability: BackupAvailability): string {
+  if (availability.archive?.lastArchivedAt) {
+    const failedCount = availability.archive.failedCount || 0;
+    return `last archived ${formatRelativeTime(availability.archive.lastArchivedAt)} · ${failedCount} failed`;
+  }
+
+  return availability.status === 'ok' ? 'backup history is readable' : 'archive status unavailable';
+}
+
+function formatBackupDate(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}

--- a/src/web/lib/time.ts
+++ b/src/web/lib/time.ts
@@ -1,0 +1,30 @@
+export function formatRelativeTime(value: string | null | undefined): string {
+  if (!value) {
+    return 'never';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const diffMs = Date.now() - date.getTime();
+  const minutes = Math.max(0, Math.round(diffMs / 60000));
+
+  if (minutes < 1) {
+    return 'just now';
+  }
+
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.round(minutes / 60);
+
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  return `${Math.round(hours / 24)}d ago`;
+}

--- a/src/web/routes/settings.tsx
+++ b/src/web/routes/settings.tsx
@@ -45,6 +45,7 @@ import {
   type ServerRole,
 } from '#web/components/control-plane';
 import { ApiKeysPanel } from '#web/components/settings/api-keys-panel';
+import { BackupHealthPanel } from '#web/components/settings/backup-health-panel';
 
 const JOB_PAGE_SIZE = 20;
 type JobStatusFilter = 'all' | 'queued' | 'running' | 'done' | 'error' | 'cancelled';
@@ -62,7 +63,7 @@ function SettingsPage() {
   const [selectedJobId, setSelectedJobId] = useState<number | null>(null);
   const saveServer = useMutation(orpc.servers.update.mutationOptions({ onSuccess: refreshDashboard }));
   const checkServer = useMutation(orpc.servers.check.mutationOptions({ onSuccess: refreshDashboard }));
-  const saveBackupSettings = useMutation(orpc.backup.settings.update.mutationOptions({ onSuccess: refreshDashboard }));
+  const saveBackupSettings = useMutation(orpc.backup.settings.update.mutationOptions());
   const jobList = useQuery({
     queryKey: ['settings-jobs', jobStatus, jobPage],
     queryFn: function listSettingsJobs() {
@@ -202,7 +203,7 @@ function SettingsPage() {
   async function handleSaveBackup(formData: FormData) {
     try {
       const result = await saveBackupSettings.mutateAsync({
-        enabled: formData.get('enabled') === 'on',
+        enabled: true,
         endpoint: String(formData.get('endpoint') || ''),
         bucket: String(formData.get('bucket') || ''),
         region: String(formData.get('region') || 'auto'),
@@ -212,7 +213,8 @@ function SettingsPage() {
         pitrDays: Number(formData.get('pitrDays') || 7),
         fullBackupRetentionDays: Number(formData.get('fullBackupRetentionDays') || 90),
       });
-      toast.success(result.jobId ? 'Backup settings saved. Applying to production.' : 'Backup settings saved.');
+      await dashboard.refetch();
+      toast.success(result.jobId ? 'Backup settings saved. Applying to production.' : 'Backup settings saved. Health refreshed.');
     } catch (error: any) {
       toast.error(getMutationErrorMessage(error, 'Could not save backup settings.'));
     }
@@ -257,17 +259,13 @@ function SettingsPage() {
 
         <section className="min-w-0">
           <div className="mx-auto grid w-full max-w-[980px] gap-6 px-4 py-6 sm:px-6 lg:px-8">
-            <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <header>
               <div>
                 <h1 className="text-3xl font-semibold tracking-normal md:text-4xl">Settings</h1>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
                   Manage server access, backup storage, and background activity.
                 </p>
               </div>
-              <Button variant="outline" onClick={function refreshPage() { void dashboard.refetch(); }}>
-                <RefreshCw />
-                Refresh
-              </Button>
             </header>
 
             <Tabs value={settingsTab} onValueChange={setSettingsTab} orientation="vertical" className="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)]">
@@ -320,7 +318,19 @@ function SettingsPage() {
               </TabsContent>
 
               <TabsContent value="backups" className="min-w-0">
-                <BackupPanel backup={state.backup} busy={busy === 'save-backup'} onSave={handleSaveBackup} />
+                <div className="grid gap-6">
+                  <BackupHealthPanel
+                    availability={state.backupAvailability}
+                    checkedAt={dashboard.dataUpdatedAt ? new Date(dashboard.dataUpdatedAt).toISOString() : null}
+                    checking={dashboard.isFetching}
+                    jobs={state.jobs}
+                    onRefresh={function refreshBackupHealth() {
+                      void dashboard.refetch();
+                    }}
+                    onOpenJob={openJob}
+                  />
+                  <BackupPanel backup={state.backup} busy={busy === 'save-backup'} onSave={handleSaveBackup} />
+                </div>
               </TabsContent>
 
               <TabsContent value="updates" className="min-w-0">


### PR DESCRIPTION
## Summary
- add a backup health card to Settings > Backups
- simplify the sidebar brand and backup settings UI
- extract backup health UI into a focused settings component
- add a shared relative time formatter

## API routes / procedures / contracts
- no API routes added, updated, or deleted
- no procedures added, updated, or deleted
- no backend contracts changed

## Checks
- bun run typecheck
- bun run test
- bun run web:build
- browser smoke on Settings > Backups