### PR TITLE
test(release): add packaged update smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,7 @@ jobs:
           bash -n scripts/*.sh
           scripts/test-release-artifact.sh
           scripts/test-update-flow.sh
+          scripts/test-packaged-update-flow.sh
           scripts/test-release-upgrade-flow.sh
 
       - name: Create release tarball

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
     - name: Test update flow
       run: scripts/test-update-flow.sh
 
+    - name: Test packaged update flow
+      run: scripts/test-packaged-update-flow.sh
+
     - name: Test release upgrade flow
       env:
         GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ bun run web:build
 bash -n scripts/*.sh
 scripts/test-release-artifact.sh
 scripts/test-update-flow.sh
+scripts/test-packaged-update-flow.sh
 scripts/test-release-upgrade-flow.sh
 ```
 

--- a/scripts/lib/release-smoke.sh
+++ b/scripts/lib/release-smoke.sh
@@ -1,0 +1,202 @@
+release_smoke_file_mode() {
+  if [ "$(uname)" = "Darwin" ]; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+release_smoke_package_version() {
+  local package_path="${1:-package.json}"
+
+  SMOKE_PACKAGE_PATH="$package_path" bun -e "
+    import { readFileSync } from 'node:fs';
+    const pkg = JSON.parse(readFileSync(process.env.SMOKE_PACKAGE_PATH, 'utf8'));
+    console.log(pkg.version);
+  "
+}
+
+release_smoke_set_package_version() {
+  local app_dir="$1"
+  local version="$2"
+
+  (
+    cd "$app_dir"
+    SMOKE_VERSION="$version" bun -e "
+      import { readFileSync, writeFileSync } from 'node:fs';
+      const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+      pkg.version = process.env.SMOKE_VERSION;
+      writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+    "
+  )
+}
+
+release_smoke_build_web() {
+  bun run web:build
+}
+
+release_smoke_create_tarball() {
+  local version="$1"
+  local output="$2"
+
+  scripts/create-release-tarball.sh "$version" "$output" >/dev/null
+}
+
+release_smoke_extract_tarball() {
+  local tarball="$1"
+  local app_dir="$2"
+
+  mkdir -p "$app_dir"
+  tar -xzf "$tarball" -C "$app_dir"
+}
+
+release_smoke_install_production_deps() {
+  local app_dir="$1"
+
+  (
+    cd "$app_dir"
+    bun install --production --frozen-lockfile
+  )
+}
+
+release_smoke_migrate() {
+  local app_dir="$1"
+  local db_path="$2"
+
+  (
+    cd "$app_dir"
+    VELO_DB="$db_path" bun run db:migrate
+  )
+}
+
+release_smoke_set_password() {
+  local app_dir="$1"
+  local db_path="$2"
+  local password="$3"
+
+  (
+    cd "$app_dir"
+    APP_PASSWORD="$password" VELO_DB="$db_path" bun run auth:set-password
+  )
+}
+
+release_smoke_seed_table() {
+  local db_path="$1"
+  local table="$2"
+
+  SMOKE_DB_PATH="$db_path" SMOKE_TABLE="$table" bun -e "
+    import { Database } from 'bun:sqlite';
+    const table = process.env.SMOKE_TABLE;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(table)) {
+      throw new Error('invalid smoke table name');
+    }
+    const db = new Database(process.env.SMOKE_DB_PATH);
+    db.exec('create table if not exists ' + table + ' (id integer primary key, value text not null)');
+    db.prepare('insert into ' + table + ' (value) values (?)').run('survived');
+    db.close();
+  "
+}
+
+release_smoke_assert_table_value() {
+  local db_path="$1"
+  local table="$2"
+  local expected="${3:-survived}"
+
+  test "$(SMOKE_DB_PATH="$db_path" SMOKE_TABLE="$table" bun -e "
+    import { Database } from 'bun:sqlite';
+    const table = process.env.SMOKE_TABLE;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(table)) {
+      throw new Error('invalid smoke table name');
+    }
+    const db = new Database(process.env.SMOKE_DB_PATH);
+    const row = db.query('select value from ' + table + ' where id = 1').get();
+    console.log(row?.value || '');
+    db.close();
+  ")" = "$expected"
+}
+
+release_smoke_run_update() {
+  local app_dir="$1"
+  local db_path="$2"
+  local version="$3"
+  local tarball="$4"
+
+  VELO_DIR="$app_dir" \
+  VELO_DB="$db_path" \
+  VELO_SKIP_ROOT_CHECK=1 \
+  VELO_SYSTEMCTL= \
+  VELO_LATEST_VERSION="$version" \
+  VELO_TARBALL_URL="file://$tarball" \
+  bash "$app_dir/scripts/update.sh"
+}
+
+release_smoke_assert_update_result() {
+  local app_dir="$1"
+  local version="$2"
+
+  test "$(cat "$app_dir/.velo/.update-result")" = "success:$version"
+}
+
+release_smoke_assert_state_private() {
+  local app_dir="$1"
+
+  test "$(release_smoke_file_mode "$app_dir/.velo")" = "700"
+  test "$(release_smoke_file_mode "$app_dir/.velo/velo.sqlite")" = "600"
+}
+
+release_smoke_assert_update_files_private() {
+  local app_dir="$1"
+
+  release_smoke_assert_state_private "$app_dir"
+  test "$(release_smoke_file_mode "$app_dir/.velo/.update-log")" = "600"
+  test "$(release_smoke_file_mode "$app_dir/.velo/.update-result")" = "600"
+}
+
+release_smoke_http_status() {
+  curl -sS -o /dev/null -w '%{http_code}' "$@"
+}
+
+release_smoke_assert_status() {
+  local expected="$1"
+  local log_path="$2"
+  shift 2
+  local actual
+
+  actual="$(release_smoke_http_status "$@")"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "expected HTTP $expected, got $actual: $*"
+    cat "$log_path"
+    exit 1
+  fi
+}
+
+release_smoke_start_app() {
+  local app_dir="$1"
+  local db_path="$2"
+  local port="$3"
+  local log_path="$4"
+
+  (
+    cd "$app_dir"
+    HOST=127.0.0.1 \
+    PORT="$port" \
+    NODE_ENV=production \
+    VELO_DB="$db_path" \
+    bun src/server/web-runtime.ts >"$log_path" 2>&1
+  ) &
+  SERVER_PID="$!"
+
+  for attempt in $(seq 1 30); do
+    if curl -fsS "http://127.0.0.1:$port/healthz" >/dev/null 2>&1; then
+      return
+    fi
+
+    if [ "$attempt" = "30" ]; then
+      cat "$log_path"
+      exit 1
+    fi
+
+    sleep 1
+  done
+}

--- a/scripts/test-packaged-update-flow.sh
+++ b/scripts/test-packaged-update-flow.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+BASE_VERSION="${VELO_TEST_BASE_VERSION:-2.0.0}"
+TARGET_VERSION="${VELO_TEST_TARGET_VERSION:-2.0.1}"
+PORT="${VELO_TEST_PORT:-$((4300 + RANDOM % 500))}"
+SERVER_PID=""
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/release-smoke.sh"
+
+release_smoke_build_web
+
+base_tarball="$WORK_DIR/velo-v$BASE_VERSION.tar.gz"
+target_tarball="$WORK_DIR/velo-v$TARGET_VERSION.tar.gz"
+release_smoke_create_tarball "$BASE_VERSION" "$base_tarball"
+release_smoke_create_tarball "$TARGET_VERSION" "$target_tarball"
+
+release_smoke_extract_tarball "$base_tarball" "$WORK_DIR/app"
+test "$(release_smoke_package_version "$WORK_DIR/app/package.json")" = "$BASE_VERSION"
+
+release_smoke_install_production_deps "$WORK_DIR/app"
+release_smoke_migrate "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite"
+release_smoke_seed_table "$WORK_DIR/app/.velo/velo.sqlite" release_packaged_update_smoke
+
+release_smoke_run_update "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite" "$TARGET_VERSION" "$target_tarball"
+
+release_smoke_assert_update_result "$WORK_DIR/app" "$TARGET_VERSION"
+release_smoke_assert_update_files_private "$WORK_DIR/app"
+test "$(release_smoke_package_version "$WORK_DIR/app/package.json")" = "$TARGET_VERSION"
+release_smoke_assert_table_value "$WORK_DIR/app/.velo/velo.sqlite" release_packaged_update_smoke
+
+release_smoke_start_app "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite" "$PORT" "$WORK_DIR/server.log"
+release_smoke_assert_status 200 "$WORK_DIR/server.log" "http://127.0.0.1:$PORT/healthz"
+
+echo "packaged update smoke passed"

--- a/scripts/test-release-artifact.sh
+++ b/scripts/test-release-artifact.sh
@@ -16,21 +16,13 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/release-smoke.sh"
 
-file_mode() {
-  if [ "$(uname)" = "Darwin" ]; then
-    stat -f '%Lp' "$1"
-  else
-    stat -c '%a' "$1"
-  fi
-}
-
-bun run web:build
+release_smoke_build_web
 TARBALL="$WORK_DIR/velo.tar.gz"
-scripts/create-release-tarball.sh "$(bun -e "import pkg from './package.json'; console.log(pkg.version)")" "$TARBALL" >/dev/null
+release_smoke_create_tarball "$(release_smoke_package_version "$ROOT_DIR/package.json")" "$TARBALL"
 
-mkdir -p "$WORK_DIR/app"
-tar -xzf "$TARBALL" -C "$WORK_DIR/app"
+release_smoke_extract_tarball "$TARBALL" "$WORK_DIR/app"
 
 cd "$WORK_DIR/app"
 test -f package.json
@@ -40,55 +32,20 @@ test -f dist/server/server.js
 test -d dist/client
 test -f dist/server/assets/migrations/001_initial.sql
 
-bun install --production --frozen-lockfile
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run db:migrate
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run db:migrate
-APP_PASSWORD=test-password VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run auth:set-password
-test "$(file_mode "$WORK_DIR/app/.velo")" = "700"
-test "$(file_mode "$WORK_DIR/app/.velo/velo.sqlite")" = "600"
+release_smoke_install_production_deps "$WORK_DIR/app"
+release_smoke_migrate "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite"
+release_smoke_migrate "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite"
+release_smoke_set_password "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite" test-password
+release_smoke_assert_state_private "$WORK_DIR/app"
 
-HOST=127.0.0.1 \
-PORT="$PORT" \
-NODE_ENV=production \
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" \
-bun src/server/web-runtime.ts >"$WORK_DIR/server.log" 2>&1 &
-SERVER_PID="$!"
+release_smoke_start_app "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite" "$PORT" "$WORK_DIR/server.log"
 
-for attempt in $(seq 1 30); do
-  if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
-    break
-  fi
-
-  if [ "$attempt" = "30" ]; then
-    cat "$WORK_DIR/server.log"
-    exit 1
-  fi
-
-  sleep 1
-done
-
-http_status() {
-  curl -sS -o /dev/null -w '%{http_code}' "$@"
-}
-
-assert_status() {
-  expected="$1"
-  shift
-  actual="$(http_status "$@")"
-
-  if [ "$actual" != "$expected" ]; then
-    echo "expected HTTP $expected, got $actual: $*"
-    cat "$WORK_DIR/server.log"
-    exit 1
-  fi
-}
-
-assert_status 200 "http://127.0.0.1:$PORT/healthz"
-assert_status 302 -I "http://127.0.0.1:$PORT"
-assert_status 200 -I "http://127.0.0.1:$PORT/login"
-assert_status 401 -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
-assert_status 401 -H 'content-type: application/json' -d '{"password":"bad-password"}' "http://127.0.0.1:$PORT/api/auth/login"
+release_smoke_assert_status 200 "$WORK_DIR/server.log" "http://127.0.0.1:$PORT/healthz"
+release_smoke_assert_status 302 "$WORK_DIR/server.log" -I "http://127.0.0.1:$PORT"
+release_smoke_assert_status 200 "$WORK_DIR/server.log" -I "http://127.0.0.1:$PORT/login"
+release_smoke_assert_status 401 "$WORK_DIR/server.log" -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
+release_smoke_assert_status 401 "$WORK_DIR/server.log" -H 'content-type: application/json' -d '{"password":"bad-password"}' "http://127.0.0.1:$PORT/api/auth/login"
 curl -fsS -c "$WORK_DIR/cookie" -H 'content-type: application/json' -d '{"password":"test-password"}' "http://127.0.0.1:$PORT/api/auth/login" >/dev/null
-assert_status 200 -b "$WORK_DIR/cookie" -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
+release_smoke_assert_status 200 "$WORK_DIR/server.log" -b "$WORK_DIR/cookie" -H 'content-type: application/json' -d '{}' "http://127.0.0.1:$PORT/api/v1/dashboard/retrieve"
 
 echo "release artifact smoke passed"

--- a/scripts/test-release-upgrade-flow.sh
+++ b/scripts/test-release-upgrade-flow.sh
@@ -11,14 +11,7 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$ROOT_DIR"
-
-file_mode() {
-  if [ "$(uname)" = "Darwin" ]; then
-    stat -f '%Lp' "$1"
-  else
-    stat -c '%a' "$1"
-  fi
-}
+source "$ROOT_DIR/scripts/lib/release-smoke.sh"
 
 latest_tag="${VELO_RELEASE_TAG:-}"
 if [ -z "$latest_tag" ]; then
@@ -36,6 +29,10 @@ major="${major:-0}"
 minor="${minor:-0}"
 patch="${patch:-0}"
 target_version="${VELO_UPGRADE_TARGET_VERSION:-$major.$minor.$((patch + 1))}"
+allow_legacy_fallback=false
+if [ "$major" -lt 2 ]; then
+  allow_legacy_fallback=true
+fi
 
 echo "Testing release upgrade: $latest_tag -> v$target_version"
 
@@ -47,6 +44,11 @@ gh release download "$latest_tag" \
   --dir "$WORK_DIR/release" || true
 
 if [ ! -f "$release_tarball" ]; then
+  if [ "$allow_legacy_fallback" != true ]; then
+    echo "Release $latest_tag is missing velo-$latest_tag.tar.gz."
+    exit 1
+  fi
+
   echo "Missing release asset, building $latest_tag from source"
   git clone --depth 1 --branch "$latest_tag" "https://github.com/$REPO.git" "$WORK_DIR/latest-src"
   (
@@ -67,43 +69,21 @@ if [ ! -f "$release_tarball" ]; then
   }
 fi
 
-bun run web:build
+release_smoke_build_web
 current_tarball="$WORK_DIR/current/velo-v$target_version.tar.gz"
-scripts/create-release-tarball.sh "$target_version" "$current_tarball" >/dev/null
+release_smoke_create_tarball "$target_version" "$current_tarball"
 
-tar -xzf "$release_tarball" -C "$WORK_DIR/app"
-cd "$WORK_DIR/app"
-bun install --production --frozen-lockfile
+release_smoke_extract_tarball "$release_tarball" "$WORK_DIR/app"
+release_smoke_install_production_deps "$WORK_DIR/app"
 
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run db:migrate
-bun -e "
-  import { Database } from 'bun:sqlite';
-  const db = new Database('$WORK_DIR/app/.velo/velo.sqlite');
-  db.exec('create table if not exists release_upgrade_smoke (id integer primary key, value text not null)');
-  db.prepare('insert into release_upgrade_smoke (value) values (?)').run('survived');
-  db.close();
-"
+release_smoke_migrate "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite"
+release_smoke_seed_table "$WORK_DIR/app/.velo/velo.sqlite" release_upgrade_smoke
 
-VELO_DIR="$WORK_DIR/app" \
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" \
-VELO_SKIP_ROOT_CHECK=1 \
-VELO_SYSTEMCTL= \
-VELO_LATEST_VERSION="$target_version" \
-VELO_TARBALL_URL="file://$current_tarball" \
-bash "$WORK_DIR/app/scripts/update.sh"
+release_smoke_run_update "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite" "$target_version" "$current_tarball"
 
-test "$(cat "$WORK_DIR/app/.velo/.update-result")" = "success:$target_version"
-test "$(file_mode "$WORK_DIR/app/.velo")" = "700"
-test "$(file_mode "$WORK_DIR/app/.velo/velo.sqlite")" = "600"
-test "$(file_mode "$WORK_DIR/app/.velo/.update-log")" = "600"
-test "$(file_mode "$WORK_DIR/app/.velo/.update-result")" = "600"
-test "$(bun -e "import pkg from '$WORK_DIR/app/package.json'; console.log(pkg.version)")" = "$target_version"
-test "$(bun -e "
-  import { Database } from 'bun:sqlite';
-  const db = new Database('$WORK_DIR/app/.velo/velo.sqlite');
-  const row = db.query('select value from release_upgrade_smoke where id = 1').get();
-  console.log(row?.value || '');
-  db.close();
-")" = "survived"
+release_smoke_assert_update_result "$WORK_DIR/app" "$target_version"
+release_smoke_assert_update_files_private "$WORK_DIR/app"
+test "$(release_smoke_package_version "$WORK_DIR/app/package.json")" = "$target_version"
+release_smoke_assert_table_value "$WORK_DIR/app/.velo/velo.sqlite" release_upgrade_smoke
 
 echo "release upgrade smoke passed"

--- a/scripts/test-update-flow.sh
+++ b/scripts/test-update-flow.sh
@@ -10,70 +10,28 @@ cleanup() {
 trap cleanup EXIT
 
 cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/release-smoke.sh"
 
-file_mode() {
-  if [ "$(uname)" = "Darwin" ]; then
-    stat -f '%Lp' "$1"
-  else
-    stat -c '%a' "$1"
-  fi
-}
-
-bun run web:build
-VERSION="$(bun -e "import pkg from './package.json'; console.log(pkg.version)")"
+release_smoke_build_web
+VERSION="$(release_smoke_package_version "$ROOT_DIR/package.json")"
 TARBALL="$WORK_DIR/velo-v$VERSION.tar.gz"
-scripts/create-release-tarball.sh "$VERSION" "$TARBALL" >/dev/null
+release_smoke_create_tarball "$VERSION" "$TARBALL"
 
-mkdir -p "$WORK_DIR/app/.velo"
-tar -xzf "$TARBALL" -C "$WORK_DIR/app"
+release_smoke_extract_tarball "$TARBALL" "$WORK_DIR/app"
 
-cd "$WORK_DIR/app"
-bun install --production --frozen-lockfile
+release_smoke_install_production_deps "$WORK_DIR/app"
+release_smoke_set_package_version "$WORK_DIR/app" "0.0.0"
 
-bun -e "
-  import { readFileSync, writeFileSync } from 'node:fs';
-  const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-  pkg.version = '0.0.0';
-  writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-"
+release_smoke_migrate "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite"
+release_smoke_seed_table "$WORK_DIR/app/.velo/velo.sqlite" update_smoke
 
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" bun run db:migrate
-bun -e "
-  import { Database } from 'bun:sqlite';
-  const db = new Database('$WORK_DIR/app/.velo/velo.sqlite');
-  db.exec('create table if not exists update_smoke (id integer primary key, value text not null)');
-  db.prepare('insert into update_smoke (value) values (?)').run('survived');
-  db.close();
-"
+release_smoke_assert_table_value "$WORK_DIR/app/.velo/velo.sqlite" update_smoke
 
-test "$(bun -e "
-  import { Database } from 'bun:sqlite';
-  const db = new Database('$WORK_DIR/app/.velo/velo.sqlite');
-  const row = db.query('select value from update_smoke where id = 1').get();
-  console.log(row?.value || '');
-  db.close();
-")" = "survived"
+release_smoke_run_update "$WORK_DIR/app" "$WORK_DIR/app/.velo/velo.sqlite" "$VERSION" "$TARBALL"
 
-VELO_DIR="$WORK_DIR/app" \
-VELO_DB="$WORK_DIR/app/.velo/velo.sqlite" \
-VELO_SKIP_ROOT_CHECK=1 \
-VELO_SYSTEMCTL= \
-VELO_LATEST_VERSION="$VERSION" \
-VELO_TARBALL_URL="file://$TARBALL" \
-bash "$WORK_DIR/app/scripts/update.sh"
-
-test "$(cat "$WORK_DIR/app/.velo/.update-result")" = "success:$VERSION"
-test "$(file_mode "$WORK_DIR/app/.velo")" = "700"
-test "$(file_mode "$WORK_DIR/app/.velo/velo.sqlite")" = "600"
-test "$(file_mode "$WORK_DIR/app/.velo/.update-log")" = "600"
-test "$(file_mode "$WORK_DIR/app/.velo/.update-result")" = "600"
-test "$(bun -e "import pkg from '$WORK_DIR/app/package.json'; console.log(pkg.version)")" = "$VERSION"
-test "$(bun -e "
-  import { Database } from 'bun:sqlite';
-  const db = new Database('$WORK_DIR/app/.velo/velo.sqlite');
-  const row = db.query('select value from update_smoke where id = 1').get();
-  console.log(row?.value || '');
-  db.close();
-")" = "survived"
+release_smoke_assert_update_result "$WORK_DIR/app" "$VERSION"
+release_smoke_assert_update_files_private "$WORK_DIR/app"
+test "$(release_smoke_package_version "$WORK_DIR/app/package.json")" = "$VERSION"
+release_smoke_assert_table_value "$WORK_DIR/app/.velo/velo.sqlite" update_smoke
 
 echo "update flow smoke passed"


### PR DESCRIPTION
## Summary
- add a packaged update smoke that simulates v2.0.0 -> v2.0.1 from local release tarballs
- extract shared release/update smoke helpers
- wire the packaged update smoke into CI and release checks

## API routes / procedures / contracts
- none

## Tests
- bash -n scripts/*.sh scripts/lib/*.sh
- scripts/test-packaged-update-flow.sh
- scripts/test-update-flow.sh
- scripts/test-release-artifact.sh
- scripts/test-release-upgrade-flow.sh
- git diff --check